### PR TITLE
Update product specs to reflect v2.3 reference documents

### DIFF
--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -24,14 +24,14 @@ Single SPA serving two logical views gated by authenticated role:
 - Staking flow (PLUSD → sPLUSD)
 - Withdrawal flow (sPLUSD → PLUSD → queue)
 - Transaction history
-- Pending deposits (below-minimum accumulation, mint queue status)
+- Live rate-limit status (current window utilisation, per-LP cap remaining)
 - Chainalysis freshness indicator with days remaining
 
 ### Operations Console views (role-gated)
 
 | Role | Views visible |
 |------|--------------|
-| Trustee | Origination queue, repayment reconciliation, weekly yield signing, loan lifecycle, USYC manual override |
+| Trustee | Origination queue, repayment reconciliation, yield attestation approval, loan lifecycle, USYC NAV tracking |
 | Team | Signing queue, compliance review queue, bridge alerts, operator management, operational monitoring |
 | Originator | New origination request, My Requests, My Loans, statistics, notifications |
 
@@ -50,7 +50,7 @@ Desktop-first — LPs and operators are expected to use desktop browsers. Mobile
 
 - **Wallet connection:** WalletConnect v2 + RainbowKit
 - **Contract reads:** ethers.js direct calls for balances, exchange rate, whitelist status
-- **Transactions:** LP signs USDC transfer, sPLUSD.deposit(), sPLUSD.redeem(), WithdrawalQueue.requestWithdrawal() directly from connected wallet
+- **Transactions:** LP signs USDC.approve() + DepositManager.deposit(), sPLUSD.deposit(), sPLUSD.redeem(), WithdrawalQueue.requestWithdrawal(), WithdrawalQueue.claim() directly from connected wallet
 - **No proxy:** contract interactions for LPs go direct from browser wallet to chain — no backend relayer
 
 ## Data fetching

--- a/docs/RELIABILITY.md
+++ b/docs/RELIABILITY.md
@@ -9,7 +9,7 @@ See [`QUALITY_SCORE.md`](./QUALITY_SCORE.md) for latency and availability target
 **MVP (pilot):**
 - Single originator (Open Mineral AG), estimated ≤ 10 active loans
 - LP pool size: accredited investors, regulated by on-chain rate limits
-- Bridge service: single-instance, stateless restart (rebuilds deposit queue from Transfer log delta)
+- Bridge service: single-instance, stateless restart (rebuilds state from finalized on-chain event logs)
 
 **Phase 2 (production):**
 - Multiple originators
@@ -24,7 +24,7 @@ See [`QUALITY_SCORE.md`](./QUALITY_SCORE.md) for latency and availability target
 | USDC ratio out of band | worker | Below 10% or above 20% → on-call Slack |
 | Mint rate limit hit | worker | Any hit → info log; sustained → amber alert |
 | LP payout above $1M | worker | Every occurrence → on-call Slack |
-| Weekly yield distribution missed | worker | If not signed by Thursday 20:00 ET → red alert |
+| Yield attestation custodian co-sign timeout | worker | If custodian does not respond within 30 min → red alert |
 | Price feed polling gap > 2h | worker | On-call Slack |
 | AIS blackout > 12h | worker | Originator + Trustee + Team |
 | Bridge auto-sign failure | worker | Immediate on-call page |
@@ -37,13 +37,13 @@ The append-only audit log is mirrored in near-real-time to a third-party log sin
 
 | Scenario | Recovery path |
 |----------|--------------|
-| Bridge service crash | Restart; rebuilds deposit mint queue from on-chain Transfer log delta |
+| Bridge service crash | Restart; rebuilds state from finalized on-chain event logs (idempotent handlers) |
 | Bridge signing key compromise | Rotate HSM-backed KMS key (2-person operational access); MPC vendor re-keys the Capital Wallet participant |
-| Smart contract pause | Foundation multisig 2-of-5 fast-pause via Risk Council; resume requires same threshold |
+| Smart contract pause | GUARDIAN 2/5 Safe instant pause on all pausable contracts; resume requires same threshold |
 | MPC vendor outage | Trustee + team can co-sign manually via vendor's offline key ceremony path |
 
 ## Known scaling limits
 
-- Deposit mint queue is backend-only (no on-chain state) — single bridge instance is the bottleneck at high deposit volume. Phase 2: distributed queue.
+- Over-rate-limit deposits revert at contract; LPs retry when window headroom opens. No bridge-side queue — single bridge instance is not a deposit bottleneck.
 - LoanRegistry on-chain queries are unbounded in the MVP — a pagination layer is needed at >100 active loans.
 - Price feed polling is single-threaded per commodity — parallel polling required at >20 active loan commodities.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -17,23 +17,25 @@
 
 | Role | Holder | Scope |
 |------|--------|-------|
-| MINTER | Bridge service | Mint PLUSD (bounded by rate limit) |
-| PAUSER | Foundation multisig | Pause/unpause PLUSD, sPLUSD, WithdrawalQueue |
-| WHITELIST_ADMIN | Bridge service | Set/revoke LP whitelist entries |
-| DEFAULT_ADMIN | Foundation multisig | WhitelistRegistry admin, DeFi venue additions |
-| FILLER | Bridge service | Fill WithdrawalQueue requests |
-| loan_manager | Bridge service | Mint and update LoanRegistry entries |
-| risk_council | Risk Council (3-of-5 Safe) | Loan default/close, protocol pause |
+| DEPOSITOR | DepositManager contract | Call `mintForDeposit` on PLUSD (deposit leg only) |
+| YIELD_MINTER | Bridge service | Call `yieldMint` on PLUSD (requires custodian co-sig) |
+| BURNER | WithdrawalQueue | Burn escrowed PLUSD on LP `claim` |
+| WHITELIST_ADMIN | Bridge service | Set/revoke LP whitelist entries, refresh screening |
+| FUNDER | Bridge service | Fund WithdrawalQueue head; skip sanctioned heads |
+| TRUSTEE | Trustee key (Pipeline Trust Company) | Mint and update LoanRegistry NFTs |
+| PAUSER | GUARDIAN 2/5 Safe | Pause/unpause all pausable contracts |
+| RISK_COUNCIL | RISK_COUNCIL 3/5 Safe | Propose loan default; propose shutdown |
+| ADMIN | ADMIN 3/5 Safe | Role management, upgrades, parameter changes (48h timelock) |
 
 ### MPC wallet policies
 
 **Capital Wallet** — three participants: Trustee, Pipeline team, Bridge service.
 
-Bridge service auto-signs only 4 categories:
-1. USDC → USYC swaps within $5M per-tx / $20M daily bounds
-2. LP payouts where destination == original deposit address AND amount within $5M per-tx / $10M 24h bounds
-3. Loan disbursement transaction *preparation* (not signing — requires Trustee + Team co-signature)
-4. Treasury redemption transaction *preparation* (not signing)
+Bridge service auto-signs only 1 category on the Capital Wallet:
+- LP payouts where destination == original deposit address AND amount within $5M per-tx / $10M 24h bounds
+
+Loan disbursements require Trustee + Team co-signature directly; Bridge is not in the disbursement path.
+USDC↔USYC rebalancing is managed by the custodian MPC policy engine and Trustee; Bridge only requests a USYC redemption when Capital Wallet USDC is insufficient at withdrawal funding time.
 
 **Treasury Wallet** — two participants: Trustee, Pipeline team. No bridge auto-signing.
 
@@ -54,7 +56,7 @@ Smart contracts hold no USDC or USYC. A bug or exploit in on-chain code cannot d
 
 ## PLUSD transfer restrictions (MVP)
 
-PLUSD uses a whitelist-only transfer model: every `_update` call reverts if the recipient is not in the WhitelistRegistry (KYCed LPs or foundation-multisig-approved DeFi venues). This prevents a compromised LP wallet from moving funds to an attacker-controlled address that hasn't passed KYC.
+PLUSD uses a non-transferable model: the `_update` hook requires exactly one of (from, to) to be a system address or whitelisted LP. LP↔LP and system↔system transfers both revert. DeFi venues may be added to the allowlist by the ADMIN 3/5 Safe. This prevents a compromised LP wallet from moving funds to an attacker-controlled address that hasn't passed KYC.
 
 sPLUSD has no transfer restriction — the vault is intentionally open for DeFi composability. The KYC chain re-enters on redemption (PLUSD transfer to receiver must pass whitelist check).
 
@@ -75,4 +77,4 @@ sPLUSD has no transfer restriction — the vault is intentionally open for DeFi 
 
 - API endpoints for fund-transfer actions (co-signing, treasury redemption) require active operator session + 2FA confirmation per action
 - Compliance review queue accessible only to team members with the `compliance` sub-role
-- Foundation multisig emergency pause button in team interface sends notification to all Risk Council members — it does not execute the pause itself (they must sign on Safe independently)
+- GUARDIAN 2/5 Safe emergency pause covers all pausable contracts (PLUSD, DepositManager, sPLUSD, WithdrawalQueue, WhitelistRegistry, LoanRegistry) and can be executed immediately without a timelock

--- a/docs/product-specs/bridge-service.md
+++ b/docs/product-specs/bridge-service.md
@@ -2,145 +2,177 @@
 
 ## Overview
 
-The Pipeline Bridge Service is a backend service operated by the Pipeline team. It is the protocol's sole automated actor on the cash rail and the sole holder of the MINTER role on PLUSD. The bridge connects on-chain token-rail events to off-chain cash-rail execution, maintains the on-chain WhitelistRegistry, and runs the price feed and notification subsystem that monitors active loans.
+The Pipeline Bridge Service is a backend operated by the Pipeline team. It watches on-chain
+events, reconciles protocol state, co-signs yield attestations, and submits operational
+transactions. **Bridge is not in the critical path for deposits** — deposits are atomic
+user-driven calls to DepositManager. Bridge also has no role in loan disbursements or
+USDC↔USYC rebalancing; those are managed by the Trustee and custodian MPC policy engine.
 
-The bridge is designed so that its compromise does not enable a drain of investor capital. Its MPC permissions are narrowly scoped, counterparty addresses are pinned, and all automated envelopes are bounded.
+A Bridge compromise cannot produce unbacked PLUSD. Yield minting requires a second independent
+EIP-1271 signature from the custodian; compromising Bridge alone mints zero PLUSD.
 
 ---
 
 ## Behavior
 
-### 1. On-Chain Event Listening
+### 1. Deposit Observation (Bridge not in critical path)
 
-The bridge monitors the following on-chain events continuously:
+Deposits are fully atomic and user-driven via DepositManager. Bridge observes
+`DepositManager.Deposited` events for reconciliation, exposes deposit history via the LP API,
+and cross-checks `sum(Deposited.amount) == PLUSD.cumulativeLPDeposits()`. Bridge is not a
+signer or gate on the deposit flow.
 
-- **USDC Transfer** into the Capital Wallet — triggers deposit eligibility checks and PLUSD mint (or deposit queue entry).
-- **WithdrawalRequested** on the WithdrawalQueue — triggers automated LP payout evaluation.
-- **LoanMinted** on the LoanRegistry — triggers loan disbursement transaction preparation.
-- **RepaymentSettled** (trustee-signed, consumed by the bridge) — triggers yield minting and senior principal USYC sweep.
-- **TreasuryYieldDistributed** (trustee-signed, consumed by the bridge) — triggers weekly yield minting.
+Bridge also exposes live rate-limit state (`maxPerWindow`, `maxPerLPPerWindow`, window
+utilisation, per-LP utilisation) via `GET /v1/protocol/limits` so the deposit UI can display
+cap status before the LP submits.
 
-On restart, the bridge rebuilds all in-memory state by replaying the relevant event logs from chain. No persistent queue state is required to survive a restart; the queue is a derivative of the log delta.
+### 2. Withdrawal Queue Funding
 
-### 2. MPC Auto-Signing (Four Categories)
+When a `WithdrawalRequested` event is observed, Bridge processes the queue head:
 
-The bridge is an MPC participant on the Capital Wallet with auto-signing authority for exactly four transaction categories. All other Capital Wallet transactions require human co-signature from trustee and/or team.
+1. **Whitelist check.** If `WhitelistRegistry.isAllowed(requester)` is false, calls
+   `WQ.skipSanctionedHead()` to unblock the queue.
+2. **Freshness check (Bridge-side).** If stale but not revoked, Bridge calls Chainalysis API.
+   On clean result: `WhitelistRegistry.refreshScreening(lp, newTs)`, then proceeds. On flag:
+   `revokeAccess` then `skipSanctionedHead`. If Chainalysis is unreachable, Bridge halts and
+   alerts ops — head is stuck pending manual `adminRelease`.
+3. **Balance check.** If Capital Wallet USDC is insufficient, Bridge requests a USYC → USDC
+   redemption via the custodian MPC API and retries after settlement.
+4. **Fund.** Calls `WQ.fundRequest(queueId)`. WQ pulls USDC from Capital Wallet via
+   pre-approved allowance. LP's entry moves to `Funded`; LP then calls `WQ.claim()` to burn
+   PLUSD and receive USDC.
 
-| Category | Auto-signing condition | Bounds |
-|---|---|---|
-| USDC → USYC swap | USDC ratio exceeds upper band (20%) | $5M per tx, $20M daily aggregate |
-| USYC → USDC redemption | USDC ratio falls below lower band (10%) | $5M per tx, $20M daily aggregate |
-| LP withdrawal payout | Destination matches pinned original deposit address; LP is whitelisted with fresh screen | $5M per tx, $10M rolling 24h across all LP payouts |
-| Loan disbursement preparation | LoanMinted event observed; transaction prepared for human co-signature (bridge does not auto-sign loan disbursements — it prepares them) | N/A (human signing required) |
+### 3. Yield Minting — Repayment
 
-Swaps above the automated bounds, LP payouts above the automated bounds, and all loan disbursements are routed to the team signing queue for trustee + team co-signature.
+When a loan repayment USDC inflow is detected at the Capital Wallet:
 
-### 3. PLUSD Minting Authority
+1. Bridge presents the detected repayment to the Trustee via `GET /v1/trustee/repayments/pending`.
+2. Trustee submits final split amounts via `POST /v1/trustee/repayments/{id}/approve`.
+3. Bridge builds two `YieldAttestation` structs (vault leg and treasury leg) and signs each
+   with the `bridgeYieldAttestor` key:
+   ```
+   YieldAttestation {
+     bytes32 repaymentRef;  // keccak256(chainId, repaymentTxHash, destinationTag)
+     address destination;   // sPLUSD vault OR Treasury Wallet
+     uint256 amount;
+     uint64  deadline;
+     uint256 salt;
+   }
+   ```
+4. Bridge posts structs + Bridge sigs to the custodian's co-signing API (Fireblocks / BitGo).
+   Custodian independently verifies the USDC inflow and returns EIP-1271 signatures.
+5. Bridge calls `PLUSD.yieldMint(att, bridgeSig, custodianSig)` for each leg via the
+   transaction outbox. PLUSD verifies both signatures on-chain, checks the reserve invariant,
+   and mints to destination.
 
-The bridge holds the sole MINTER role on PLUSD. It distinguishes two minting categories, tracked separately in the audit log:
+Neither Bridge alone nor the custodian alone can mint yield — both sigs plus YIELD_MINTER
+caller role are required.
 
-**Deposit mints** — triggered by a USDC Transfer event into the Capital Wallet from a whitelisted LP address. The bridge runs four checks before minting: (a) lpAddress is whitelisted, (b) Chainalysis screen is within the 90-day freshness window, (c) deposit amount is at or above the $1,000 USDC minimum, (d) the rolling 24h rate limit ($10M) and per-tx cap ($5M) are not breached. On all checks passing, the bridge calls `PLUSD.mint(lpAddress, amount)`.
+### 4. Yield Minting — USYC (Lazy, Stake/Unstake-Triggered)
 
-**Yield mints** — triggered by trustee-signed events:
-- On RepaymentSettled: `PLUSD.mint(sPLUSDvault, senior_coupon_net)` and `PLUSD.mint(TreasuryWallet, management_fee + performance_fee + oet_allocation)`.
-- On TreasuryYieldDistributed: `PLUSD.mint(sPLUSDvault, vault_share)` (70% of accrued T-bill yield) and `PLUSD.mint(TreasuryWallet, treasury_share)` (30%).
+USYC NAV accrues continuously. To keep sPLUSD share price current without a time-based cron,
+yield is minted **lazily** on every sPLUSD `Deposit` or `Withdraw` event:
 
-Both categories are subject to the same on-chain rate limit enforced at the PLUSD contract level.
+1. Bridge reads current USYC NAV from the Hashnote API.
+2. Computes `yield_delta = current_NAV - last_minted_NAV` (applied to Capital Wallet USYC
+   holdings). If `delta <= 0`, skip.
+3. If `delta > 0`: builds two `YieldAttestation` structs (vault + treasury), gets Bridge sig
+   + custodian co-sig (same flow as repayment), submits both `yieldMint` calls.
+4. Advances `last_minted_NAV` baseline only after both legs confirm on-chain.
 
-### 4. Deposit Mint Queue
+Between mints, Bridge polls USYC NAV (e.g., every minute) and exposes
+accrued-but-undistributed yield via `GET /v1/vault/stats` for dashboard display.
 
-When a deposit mint would breach the rolling 24h rate limit or per-tx cap, the bridge does not reject the deposit. The USDC has already arrived in the Capital Wallet and the LP is entitled to PLUSD. The bridge instead enqueues the mint:
+### 5. WhitelistRegistry Maintenance
 
-- Queue entries carry: (lpAddress, amount, deposit_tx_hash, queued_at).
-- Queued mints are processed in FIFO order as headroom opens in the rolling 24h window.
-- A single deposit exceeding the $5M per-tx cap is split into multiple mint transactions across successive windows.
-- The queue has no on-chain state. On bridge restart, the queue is rebuilt by computing the delta between USDC Transfer events into the Capital Wallet and PLUSD mint events for each LP address.
-- LP dashboard shows queued deposits with a "PLUSD mint pending rate limit" status and the expected processing window.
+- **On Sumsub APPROVED + Chainalysis clean result:** `WhitelistRegistry.setAccess(lp, ts)`.
+- **On failed passive re-screen:** `revokeAccess(lp)`, route to compliance review queue.
+- **On manual compliance approval:** `setAccess(lp, approvedAt)`.
+- **Periodic batch re-screen:** `refreshScreening(lp, newTs)` for each LP on a configurable
+  cadence to maintain freshness.
 
-Below-minimum deposits (under $1,000 USDC) are accumulated per LP address as a pending top-up counter. When subsequent deposits from the same address bring the cumulative pending amount to or above $1,000 USDC, the bridge mints PLUSD for the combined total in a single transaction and resets the counter.
+### 6. Price Feed and CCR Monitoring
 
-### 5. USDC → USYC Sweep on Repayment
-
-After a RepaymentSettled event settles and the corresponding USDC inflow to the Capital Wallet is verified, the bridge automatically initiates a USDC → USYC conversion of the `senior_principal_returned` portion. This sweep is executed under the bridge's USDC ↔ USYC auto-signing permission. The senior principal begins earning T-bill yield immediately rather than sitting idle as USDC.
-
-### 6. Weekly Yield Event Pre-Building
-
-The bridge continuously reads the current USYC NAV from the issuer's published feed and maintains a running `accrued_yield` figure between weekly distribution events. This figure is informational and does not affect sPLUSD NAV until the weekly event fires.
-
-At the weekly reference time (Thursday end of day, working assumption: 17:00 America/New_York or issuer NAV publication time, whichever is later), the bridge:
-
-1. Computes `total_accrued_yield = USYC NAV appreciation since previous distribution × USYC holding amount`.
-2. Pre-builds a TreasuryYieldDistributed transaction carrying: total_accrued_yield, vault_share (70%), treasury_share (30%), reference USYC NAV, holding amount, week_ending date.
-3. Presents the pre-built transaction to the trustee tooling for review and signature.
-4. On receipt of the trustee's EIP-712 attestation, executes the two yield mints.
-
-The USYC holding itself is not redeemed during the weekly yield event.
-
-### 7. WhitelistRegistry Maintenance
-
-The bridge writes and revokes entries on the WhitelistRegistry in response to KYC and screening outcomes:
-
-- On Sumsub APPROVED + Chainalysis clean result: calls `WhitelistRegistry.setAccess(lpAddress, currentBlockTimestamp)` immediately, without human review.
-- On failed passive re-screen (Chainalysis freshness window expired and re-screen returns suspicious result): calls `WhitelistRegistry.revokeAccess(lpAddress)` and routes the LP to the compliance review queue.
-- On a compliance officer's manual approval decision: calls `WhitelistRegistry.setAccess(lpAddress, approvedAt)` to write the LP to the whitelist.
-
-### 8. Price Feed and Notification System
-
-The bridge runs a subsystem that monitors every active loan in the LoanRegistry in real time:
-
-- Polls Platts and Argus commodity reference prices on a configurable cadence (working assumption: every 15 minutes during market hours).
-- For each active loan, computes CCR = collateral_value / outstanding_senior_principal in basis points, using current price, quantity from the trustee feed, commodity-specific haircut schedule, and current outstanding senior principal.
-- On threshold crossings, triggers notifications to configured recipients and batches a `loan_manager` update to the LoanRegistry's `lastReportedCCR` field.
+Bridge monitors every active loan in the LoanRegistry, polling Platts/Argus commodity prices
+on a configurable cadence (working assumption: every 15 minutes during market hours). Computes
+CCR = collateral_value / outstanding_senior_principal in basis points. On threshold crossings,
+notifies recipients and queues a `LoanRegistry.updateMutable` call to update `lastReportedCCR`.
 
 | Event | Trigger | Recipients |
 |---|---|---|
-| Watchlist | CCR falls below 130% | Team, Originator, Trustee |
-| Maintenance margin call | CCR falls below 120% | Team, Originator, Borrower (via Originator), Trustee |
-| Margin call | CCR falls below 110% | Team, Originator, Borrower, Trustee |
-| Payment delay (amber) | Scheduled repayment > 7 days late | Team, Originator, Trustee |
-| Payment delay (red) | Scheduled repayment > 21 days late | Team, Originator, Trustee |
-| AIS blackout | Vessel tracking loss > 12 hours | Team, Originator, Trustee |
-| CMA discrepancy | Reported collateral quantity differs from CMA by > 3% | Team, Originator, Trustee |
-| Status transition | Any change to LoanRegistry mutable status field | Team, Originator, Trustee |
+| Watchlist | CCR < 130% | Team, Originator, Trustee |
+| Maintenance margin call | CCR < 120% | Team, Originator, Borrower, Trustee |
+| Margin call | CCR < 110% | Team, Originator, Borrower, Trustee |
+| Payment delay (amber) | Repayment > 7 days late | Team, Originator, Trustee |
+| Payment delay (red) | Repayment > 21 days late | Team, Originator, Trustee |
+| AIS blackout | Vessel tracking loss > 12h | Team, Originator, Trustee |
+| CMA discrepancy | Reported collateral > 3% from CMA | Team, Originator, Trustee |
+| Status transition | Any LoanRegistry mutable status change | Team, Originator, Trustee |
 
-Delivery channels: in-app dashboard alerts, email, and optional Telegram/Slack webhooks configured per recipient. All events are also logged to the protocol dashboard's Panel B event feed.
+### 7. Reserve Reconciliation
 
-### 9. Reconciliation Invariant Publishing
+After every state-changing event, Bridge evaluates and publishes the full backing invariant:
 
-After every state-changing event (deposit, yield distribution, loan disbursement, repayment, LP withdrawal), the bridge evaluates and publishes the protocol's reconciliation invariant:
+```
+PLUSD totalSupply  ==  USDC in Capital Wallet
+                     +  USYC NAV in Capital Wallet
+                     +  USDC out on active loans
+                     +  USDC in transit
+```
 
-`PLUSD totalSupply == USDC in Capital Wallet + USYC NAV in Capital Wallet + USDC out on loans + USDC in transit`
+| Drift | Status | Action |
+|---|---|---|
+| < 0.01% | Green | Normal |
+| 0.01%–1% | Amber | Alert on-call + Trustee |
+| > 1% | Red | Page on-call + Trustee; consider pausing DepositManager |
 
-The result is published to the protocol dashboard with a status indicator: green (drift < 0.01%), amber (0.01%–1%), red (> 1%). Amber and red states trigger an alert to the on-call channel and to the trustee.
+---
+
+## On-Chain Events Monitored
+
+| Contract | Event | Purpose |
+|---|---|---|
+| DepositManager | `Deposited(lp, amount)` | Reconciliation; deposit history for LP API |
+| USDC | `Transfer(*, capitalWallet, amount)` | Repayment inflow classification |
+| PLUSD | `Transfer(0x0, lp, amount)` | Mint cross-check vs DepositManager.Deposited |
+| WithdrawalQueue | `WithdrawalRequested` | Flow 2 trigger |
+| WithdrawalQueue | `WithdrawalFunded / WithdrawalClaimed / WithdrawalSanctionedSkip / WithdrawalAdminReleased` | Status tracking |
+| sPLUSD | `Deposit / Withdraw` | Trigger lazy USYC yield |
+| LoanRegistry | `LoanMinted / LoanUpdated / LoanClosed` | Loan book mirror |
+| PLUSD | `RateLimitsChanged / MaxTotalSupplyChanged` | Update local cache |
+| WhitelistRegistry | `LPApproved / ScreeningRefreshed / LPRevoked` | Whitelist sync |
+| ShutdownController | `ShutdownEntered` | Halt all normal flows |
+| All pausable | `Paused() / Unpaused()` | Halt/resume flows |
 
 ---
 
 ## Role Assignments on Contracts
 
-| Contract | Role | Held by |
-|---|---|---|
-| PLUSD | MINTER | Bridge service |
-| PLUSD | PAUSER | Foundation multisig |
-| sPLUSD | PAUSER | Foundation multisig |
-| WhitelistRegistry | WHITELIST_ADMIN | Bridge service |
-| WhitelistRegistry | DEFAULT_ADMIN | Foundation multisig |
-| WithdrawalQueue | FILLER | Bridge service |
-| WithdrawalQueue | PAUSER | Foundation multisig |
-| LoanRegistry | loan_manager | Bridge service |
-| LoanRegistry | risk_council | Risk Council 3-of-5 multisig |
+Bridge holds: **YIELD_MINTER** (PLUSD), **FUNDER** (WithdrawalQueue), **WHITELIST_ADMIN**
+(WhitelistRegistry).
+
+Bridge has **no role on LoanRegistry** — loan NFT writes are done by the Trustee key directly.
+Bridge **does not sign loan disbursements** — Trustee + Team co-sign on Capital Wallet.
+Bridge **does not manage the USDC↔USYC ratio** — custodian MPC policy engine and Trustee
+manage the band; Bridge only requests a USYC redemption when Capital Wallet USDC is
+insufficient at withdrawal funding time.
 
 ---
 
 ## Security Considerations
 
-**Narrow MPC permissions.** The MPC policy engine, not the bridge's software, enforces the four auto-signing categories. A compromised bridge cannot sign outside the pre-authorised patterns; exceptional transactions require human signatures.
+**Two-party yield attestation.** Yield minting requires Bridge ECDSA sig + custodian EIP-1271
+sig + YIELD_MINTER caller role. Bridge alone cannot mint yield PLUSD.
 
-**Pinned counterparty addresses.** For each auto-signed transaction type, the valid destination is either fixed (USYC issuer for swaps, on-ramp provider for disbursements) or derived from on-chain state (LP payout destination must equal the original deposit address from the bridge's pinned mapping). A compromised bridge cannot redirect funds to an attacker-controlled destination.
+**Narrow on-chain roles.** FUNDER can only trigger WQ pulls for existing queue entries;
+WHITELIST_ADMIN cannot mint; YIELD_MINTER still requires custodian co-sig.
 
-**Bounded automated envelopes.** Every auto-signed transaction type is bounded by per-transaction and rolling-aggregate caps enforced at the MPC policy level. The $10M/$5M caps on LP payouts and the $20M/$5M caps on USDC ↔ USYC swaps bound worst-case exposure within any single detection window.
+**Deposit path is Bridge-free.** A complete Bridge compromise does not stop deposits or allow
+unbacked deposit-leg mints.
 
-**Token-rail bounds.** The MINTER role is bounded by on-chain rate limits at the PLUSD contract level. The FILLER role can only burn PLUSD that is already in queue escrow. The loan_manager role on LoanRegistry mints and mutations both require prior validation of a trustee-verified off-chain signed request.
+**Key storage.** Bridge hot keys (on-chain caller) are in HSM-backed KMS. The
+`bridgeYieldAttestor` key (yield EIP-712 signing) is stored separately in an HSM with no
+internet egress. MPC key shares are managed through the custodian vendor's key ceremony.
 
-**Key storage.** Bridge hot keys for on-chain transactions are stored in an HSM-backed KMS (AWS KMS / GCP KMS) with two-person operational access required for key rotation. The MPC key share is managed through the MPC vendor's key ceremony and is not stored on the bridge's hot infrastructure.
-
-**Audit log.** Every bridge action is recorded in an append-only audit log mirrored in near-real-time to an independent third-party log sink. The bridge service cannot delete or modify historical entries.
+**Audit log.** Every bridge action is recorded in an append-only log mirrored to an
+independent third-party sink. Bridge cannot delete or modify historical entries.

--- a/docs/product-specs/deposits.md
+++ b/docs/product-specs/deposits.md
@@ -2,7 +2,11 @@
 
 ## Overview
 
-An LP deposits USDC directly to the Pipeline Capital Wallet from their whitelisted wallet address. The bridge service detects the on-chain USDC Transfer event, runs four eligibility checks, and mints PLUSD 1:1 to the depositor. Deposits that exceed the rolling rate limit are queued and processed as capacity opens. There is no smart contract deposit function: the LP makes a standard ERC-20 USDC transfer; the mint is a bridge-side response.
+An LP deposits USDC by calling `DepositManager.deposit(amount)` directly. The contract
+atomically pulls USDC from the LP's wallet to the Capital Wallet and mints PLUSD 1:1 to the
+depositor in a single transaction. Bridge is not involved in the deposit flow — the on-chain
+USDC transfer IS the attestation. Deposits that exceed on-chain rate limits revert; the LP
+retries when window headroom opens.
 
 ---
 
@@ -10,134 +14,143 @@ An LP deposits USDC directly to the Pipeline Capital Wallet from their whitelist
 
 ### Deposit Initiation
 
-The LP initiates a deposit through the Pipeline app. Before presenting the deposit UI, the app reads the LP's on-chain WhitelistRegistry entry:
+The LP must first whitelist their wallet via KYC/KYB onboarding (see lp-onboarding spec).
+Before presenting the deposit UI, the app reads the LP's on-chain WhitelistRegistry entry via
+`isAllowedForMint(lp)`:
 
-- If the LP is not whitelisted, the deposit UI is disabled and the LP is directed to complete onboarding.
-- If the LP is whitelisted but the Chainalysis freshness window has expired (i.e., `block.timestamp - approvedAt >= freshnessWindow`), the deposit UI is blocked and the LP is prompted to re-verify. Re-verification triggers a fresh Chainalysis screen via the bridge service; on a clean result, `approvedAt` is refreshed and the deposit UI is unblocked.
+- If not whitelisted, the deposit UI is disabled and the LP is directed to complete onboarding.
+- If whitelisted but the Chainalysis freshness window has expired, the deposit UI is blocked
+  and the LP is prompted to re-verify. Bridge calls `WhitelistRegistry.refreshScreening` on a
+  clean Chainalysis result to update `approvedAt`.
 
-The LP enters a deposit amount and signs a standard USDC `transfer` transaction from their connected wallet to the Capital Wallet address.
+To deposit, the LP first calls `USDC.approve(depositManager, amount)` from their wallet, then
+calls `DepositManager.deposit(amount)`.
 
-### Minimum Deposit and Below-Minimum Accumulation
+### On-Chain Deposit Contract (DepositManager)
 
-The minimum deposit amount is **1,000 USDC**, configurable by the foundation multisig.
+`DepositManager.deposit(uint256 usdcAmount)` enforces all checks in a single atomic
+transaction, in this order:
 
-Deposits below 1,000 USDC are not rejected. The bridge service accumulates the unminted balance per LP address in a **pending top-up counter**. When subsequent deposits from the same address bring the cumulative pending amount to or above 1,000 USDC, the bridge mints PLUSD for the combined total in a single transaction and resets the counter to zero.
+1. **Whitelist + freshness check.** `PLUSD.isAllowedForMint(msg.sender)` must return true.
+   Reverts if the LP is not whitelisted or the Chainalysis screen is stale (> 90-day freshness
+   window).
+2. **Per-LP rolling window cap.** `lpWindowMinted[msg.sender] + amount <= maxPerLPPerWindow`.
+   Reverts if a single LP would exceed their window allocation.
+3. **Global rolling window cap.** `windowMinted + amount <= maxPerWindow`. Reverts if total
+   minted in the current rolling window would exceed the protocol-wide cap.
+4. **Hard total supply cap.** `PLUSD.totalSupply() + amount <= maxTotalSupply`. Reverts if
+   the protocol hard ceiling would be breached.
+5. **USDC pull.** `USDC.transferFrom(msg.sender, capitalWallet, usdcAmount)`. Fails if LP has
+   not approved DepositManager on USDC.
+6. **PLUSD mint.** `PLUSD.mintForDeposit(msg.sender, usdcAmount)`. Checks reserve invariant
+   and increments `cumulativeLPDeposits` in the same transaction. Emits `Deposited(lp, amount)`.
 
-The LP dashboard displays the LP's pending top-up balance as "pending deposits — not yet earning yield", showing how much sits below the threshold and how much additional deposit would unlock the mint.
+If any step reverts, the entire transaction rolls back atomically. The LP's USDC is never
+moved without the corresponding PLUSD mint succeeding in the same transaction.
 
-### Four Eligibility Checks
+### Over-Rate-Limit Deposits
 
-When the bridge service observes a USDC Transfer event into the Capital Wallet, it runs four checks in order:
-
-1. **Whitelist check.** The sending address must be present in the WhitelistRegistry.
-2. **Freshness check.** The sending address must have a Chainalysis screen within the freshness window (`approvedAt` is current).
-3. **Minimum check.** The deposit amount, combined with any pending top-up balance for this address, must reach or exceed 1,000 USDC to trigger a mint.
-4. **Rate limit check.** The mint must not breach the rolling 24h aggregate cap ($10M) or the per-transaction cap ($5M).
-
-If checks 1 or 2 fail, the deposit is quarantined and routed to the compliance review queue for manual resolution by a compliance officer. The LP is not immediately notified of a quarantine; the compliance officer determines the outcome.
-
-If check 3 is not yet met, the amount is added to the LP's pending top-up counter and no mint occurs until the threshold is crossed.
-
-If check 4 fails (rate limit or per-transaction cap would be breached), the deposit enters the mint queue (see Deposit Mint Queue below).
-
-If all four checks pass, the bridge service calls `PLUSD.mint(lpAddress, amount)` immediately.
-
-### Rolling Rate Limit
-
-On-chain rate limits apply to all PLUSD mints (both deposit mints and yield mints):
-
-- **Rolling 24-hour aggregate cap: $10M.** The contract reverts any mint that would cause total minted PLUSD in the preceding 24 hours to exceed this amount.
-- **Per-transaction cap: $5M.** The contract reverts any single mint above this amount.
-
-Both caps are configurable by the foundation multisig. Mints that breach either cap revert at the contract level.
-
-### Deposit Mint Queue
-
-When a deposit would breach the rolling 24h cap or the per-transaction cap, the bridge service does not reject it. The USDC has already arrived in the Capital Wallet and the LP is entitled to PLUSD. Instead:
-
-1. The bridge service records the pending mint as a queue entry: `(lpAddress, amount, deposit_tx_hash, queued_at)`.
-2. As the rolling 24h window advances and headroom becomes available, the bridge processes queued entries in **FIFO order**, calling `PLUSD.mint()` for each as capacity permits.
-3. A single deposit exceeding the $5M per-transaction cap is automatically split by the bridge into multiple mint transactions, each at or below $5M, processed over successive rolling windows. The LP receives incremental PLUSD as each window opens.
-4. The LP dashboard shows queued deposits with status "PLUSD mint pending — rate limit" and the expected processing window.
-
-The queue is a bridge-side backend construct with no on-chain state. If the bridge service restarts, it rebuilds the queue by computing the delta between the USDC Transfer log and the PLUSD mint log for the Capital Wallet address.
+If a deposit would breach `maxPerWindow` or `maxPerLPPerWindow`, the contract reverts. There
+is no queue: the LP must retry when window headroom has reopened. The Bridge API endpoint
+`GET /v1/protocol/limits` exposes current window utilisation and per-LP utilisation so the
+deposit UI can show live cap status before the LP submits.
 
 ### PLUSD Mint
 
-`PLUSD.mint()` is called by the bridge service (the sole holder of the MINTER role). The function enforces on-chain:
+`PLUSD.mintForDeposit(address lp, uint256 amount)` is callable only by the DepositManager
+(DEPOSITOR role). The function:
 
-- The per-transaction cap ($5M).
-- The rolling 24h aggregate cap ($10M).
-- That the recipient address is present on the WhitelistRegistry (the `_update` hook reverts if `!WhitelistRegistry.isAllowed(to)`).
+- Checks the reserve invariant: `totalSupply + amount <= cumulativeLPDeposits + amount +
+  cumulativeYieldMinted - cumulativeLPBurns`. Reverts on invariant failure.
+- Increments `cumulativeLPDeposits` by `amount`.
+- Mints PLUSD 1:1 to `lp`.
+- The `_update` hook enforces: recipient must be a whitelisted address or a system address.
 
 PLUSD is minted 1:1 to USDC received. No fee is deducted at mint time.
-
-The bridge service distinguishes two mint categories in its audit log and alerting, both using the same on-chain function:
-- **Deposit mints**: triggered by USDC Transfer events from whitelisted LP addresses.
-- **Yield mints**: triggered by trustee-signed RepaymentSettled and TreasuryYieldDistributed events.
 
 ---
 
 ## API Contract
 
-### PLUSD.mint
+### DepositManager.deposit
 
 ```solidity
-function mint(address to, uint256 amount) external;
-// Access: MINTER role (bridge service only)
+function deposit(uint256 usdcAmount) external;
+// Access: public (whitelisted LPs only — enforced via isAllowedForMint)
+// Checks (in order):
+//   1. isAllowedForMint(msg.sender) == true
+//   2. lpWindowMinted[msg.sender] + usdcAmount <= maxPerLPPerWindow
+//   3. windowMinted + usdcAmount <= maxPerWindow
+//   4. PLUSD.totalSupply() + usdcAmount <= maxTotalSupply
+//   5. USDC.transferFrom(msg.sender, capitalWallet, usdcAmount)
+//   6. PLUSD.mintForDeposit(msg.sender, usdcAmount)
+// Emits: Deposited(address indexed lp, uint256 amount)
+```
+
+### PLUSD.mintForDeposit
+
+```solidity
+function mintForDeposit(address lp, uint256 amount) external;
+// Access: DEPOSITOR role (DepositManager proxy only)
 // Enforces:
-//   - per-tx cap: amount <= perTxCap (default $5M, 6-decimal USDC units)
-//   - rolling 24h cap: rollingMinted + amount <= rollingCap (default $10M)
-//   - recipient whitelist: WhitelistRegistry.isAllowed(to) == true
-// Reverts if any condition is unmet.
-// Emits: Transfer(address(0), to, amount)
+//   - Reserve invariant: totalSupply + amount <=
+//     cumulativeLPDeposits + amount + cumulativeYieldMinted - cumulativeLPBurns
+//   - _update hook: recipient must be whitelisted or a system address
+// Increments cumulativeLPDeposits by amount.
+// Emits: Transfer(address(0), lp, amount)
 ```
 
-### WhitelistRegistry.isAllowed (called at mint time)
+### WhitelistRegistry.isAllowedForMint
 
 ```solidity
-function isAllowed(address lp) external view returns (bool);
+function isAllowedForMint(address lp) external view returns (bool);
 // Returns true if lp is whitelisted AND (block.timestamp - approvedAt) < freshnessWindow
+// Used by DepositManager at deposit time.
 ```
 
-### On-chain rate limit parameters (configurable by foundation multisig)
+### On-chain rate-limit parameters (configurable by ADMIN 3/5 Safe; tightening instant, loosening 48h)
 
-| Parameter | Default | Description |
-|---|---|---|
-| `perTxCap` | $5,000,000 USDC | Maximum PLUSD minted in a single transaction |
-| `rollingCap` | $10,000,000 USDC | Maximum PLUSD minted across all mint types in any rolling 24-hour window |
-| `minimumDeposit` | $1,000 USDC | Minimum deposit amount to trigger a mint (per-address cumulative threshold) |
+| Parameter | Description |
+|---|---|
+| `maxPerWindow` | Maximum total PLUSD minted across all deposits in the rolling window |
+| `maxPerLPPerWindow` | Maximum PLUSD minted by a single LP in the rolling window |
+| `maxTotalSupply` | Hard ceiling on `PLUSD.totalSupply()` — MakerDAO PSM debt-ceiling analog |
+
+Launch values are a product/risk decision (see references/backend.md decision #13).
 
 ---
 
 ## Data Model
 
-### Deposit Mint Queue Entry (bridge-side, no on-chain state)
+### Reserve Invariant Counters (on PLUSD contract)
 
 | Field | Type | Description |
 |---|---|---|
-| `lpAddress` | `address` | The depositing LP's wallet address |
-| `amount` | `uint256` | USDC amount to mint (6 decimals) |
-| `deposit_tx_hash` | `bytes32` | Transaction hash of the originating USDC Transfer |
-| `queued_at` | `uint256` | Unix timestamp when the entry was added to the queue |
+| `cumulativeLPDeposits` | `uint256` | Cumulative USDC deposited via DepositManager (6 decimals) |
+| `cumulativeYieldMinted` | `uint256` | Cumulative PLUSD minted via yieldMint |
+| `cumulativeLPBurns` | `uint256` | Cumulative PLUSD burned by WithdrawalQueue |
 
-Queue is rebuilt on bridge restart from the delta between the Capital Wallet's USDC Transfer event log and the PLUSD contract's mint event log.
-
-### Pending Top-Up Counter (bridge-side)
-
-| Field | Type | Description |
-|---|---|---|
-| `lpAddress` | `address` | LP wallet address |
-| `pendingAmount` | `uint256` | Cumulative below-minimum USDC received, not yet minted (6 decimals) |
-
-Counter resets to zero when cumulative amount reaches 1,000 USDC and a mint is executed for the total.
+These counters are updated atomically in the same transaction that moves value. The invariant
+`totalSupply <= cumulativeLPDeposits + cumulativeYieldMinted - cumulativeLPBurns` is checked
+on every mint and burn.
 
 ---
 
 ## Security Considerations
 
-- Smart contracts hold no USDC. The Capital Wallet is an MPC wallet; the bridge's auto-signing scope does not include arbitrary USDC outflows. A contract exploit cannot drain deposited USDC.
-- The MINTER role is held exclusively by the bridge service. On-chain rate limits cap the blast radius of a compromised MINTER to $10M in any 24-hour rolling window, enforceable at the contract level independently of the bridge.
-- The `_update` hook on PLUSD ensures minted tokens can only land at whitelisted addresses, preventing accidental or malicious minting to unapproved destinations.
-- Quarantined deposits (whitelist or freshness failure) are not automatically returned. Human compliance review is required, providing a gate against address spoofing or post-approval sanctions events.
-- The foundation multisig can adjust rate limits and the minimum deposit threshold via governance without a contract upgrade.
+- **No off-chain signer to forge.** The on-chain USDC transfer IS the deposit evidence.
+  There is no EIP-712 attestation or Bridge key that could be forged to mint unbacked PLUSD
+  on the deposit leg.
+- **Reserve invariant enforced on-chain.** Three cumulative counters updated in the same
+  transaction prevent the Resolv-class over-minting attack at the contract level, independently
+  of any off-chain service.
+- **Hard supply cap.** `maxTotalSupply` provides a circuit-breaker bounding total PLUSD
+  supply regardless of deposit volume. Tightening is instant (ADMIN); loosening requires a
+  48h AccessManager delay.
+- **Per-LP window cap.** `maxPerLPPerWindow` bounds single-actor minting within any rolling
+  window, replacing the dropped per-transaction cap.
+- **Smart contracts hold no USDC.** The Capital Wallet is an MPC wallet. A contract exploit
+  cannot drain deposited USDC; DepositManager only calls `transferFrom` to move USDC from
+  the LP's wallet directly to the Capital Wallet.
+- **DEPOSITOR role is exclusive.** Only the DepositManager proxy address holds DEPOSITOR on
+  PLUSD. No other caller can invoke `mintForDeposit`.

--- a/docs/product-specs/lp-onboarding.md
+++ b/docs/product-specs/lp-onboarding.md
@@ -32,7 +32,7 @@ LP onboarding is entirely off-chain except for a single on-chain write to the Wh
 - A wallet's Chainalysis screening result is valid for **90 days** from the last clean screen. This parameter is configurable by the foundation multisig via `WhitelistRegistry.freshnessWindow`.
 - When an LP initiates a deposit, the frontend checks the on-chain `approvedAt` timestamp. If the 90-day window has expired, the deposit UI is blocked and the LP is prompted to re-verify.
 - Re-verification triggers a fresh Chainalysis screen via the bridge service. On a clean result, `approvedAt` is refreshed. On a failed or suspicious result, the LP's whitelist entry is flagged for manual compliance review.
-- The frontend freshness gate is a UX convenience; the authoritative check is performed by the bridge service before any PLUSD mint is executed (see deposits spec).
+- The frontend freshness gate is a UX convenience; the authoritative check is enforced on-chain by the DepositManager contract (`isAllowedForMint`) at deposit time (see deposits spec).
 
 ### Passive Re-Screening and Revocation
 

--- a/docs/product-specs/smart-contracts.md
+++ b/docs/product-specs/smart-contracts.md
@@ -2,18 +2,44 @@
 
 ## Overview
 
-The Pipeline protocol deploys six on-chain contracts on Ethereum mainnet. Five are functional token-rail components; one is the governance multisig that holds admin roles across all others. All five functional contracts use OpenZeppelin audited library code as their base, with custom logic confined to small, clearly-scoped extensions totalling approximately 470 lines of custom Solidity across the entire suite.
+The Pipeline protocol deploys eight functional on-chain contracts on Ethereum mainnet, plus a
+shared AccessManager hub and a non-upgradeable EmergencyRevoker. All functional contracts use
+OpenZeppelin v5.x audited library code as their base with custom logic confined to small,
+clearly-scoped extensions. All protocol contracts (except EmergencyRevoker) use UUPS proxies;
+upgrades are gated by the UPGRADER role (ADMIN 3/5 Safe) with a 48h AccessManager delay,
+which GUARDIAN 2/5 Safe may cancel.
+
+---
+
+## Governance
+
+Three Gnosis Safes hold all privileged roles across the protocol, with distinct signer sets:
+
+| Safe | Threshold | Role | Timelock |
+|---|---|---|---|
+| ADMIN | 3/5 | Role management, upgrades, parameter changes | 48h (14d on delay changes) |
+| RISK_COUNCIL | 3/5 | Proposes `setDefault` and `enterShutdown` | 24h |
+| GUARDIAN | 2/5 | Instant pause; cancel pending actions; `revokeAll` on EmergencyRevoker | None |
+
+GUARDIAN is defensive-only — it cannot initiate risk-increasing actions, only halt or cancel
+in-flight ones.
+
+---
 
 ## Contracts
 
-| Contract | Base standard | Purpose | Privileged roles |
+| Contract | Base standard | Purpose | Custom LOC |
 |---|---|---|---|
-| PLUSD | OZ ERC-20Pausable + minimal `_update` override | Receipt token; minted 1:1 to USDC deposits and against trustee-signed yield events | MINTER (bridge), PAUSER (foundation multisig) |
-| sPLUSD | OZ ERC-4626 (standard, unmodified) | Yield-bearing vault on PLUSD with NAV accretion. Open to any PLUSD holder. | PAUSER (foundation multisig) |
-| WhitelistRegistry | Custom (~80 lines) | On-chain allowlist: KYCed LPs + approved DeFi venues. Tracks Chainalysis `approvedAt` timestamp. | WHITELIST_ADMIN (bridge), DEFAULT_ADMIN (foundation multisig) |
-| WithdrawalQueue | Custom (~180 lines) | FIFO queue with partial fill support | FILLER (bridge), PAUSER (foundation multisig) |
-| LoanRegistry | OZ ERC-721 + custom extension (~200 lines) | On-chain registry of loan facilities | loan_manager (bridge), risk_council (Risk Council 3-of-5) |
-| FoundationMultisig | Safe | Holds admin roles on all contracts | Risk Council members (3-of-5 standard, 2-of-5 fast pause) |
+| AccessManager (OZ) | — | Single role-management hub; timelocked scheduled actions | 0 |
+| PLUSD | OZ ERC20Pausable + ERC20Permit + AccessManaged + UUPS | Receipt token; minted via DepositManager (1:1 USDC) or `yieldMint` (two-party attested). Non-transferable except between system addresses and whitelisted LPs. | ~110 |
+| DepositManager | AccessManaged + Pausable + ReentrancyGuard + UUPS | Atomic 1:1 USDC→PLUSD deposit. LP calls `deposit(amount)`; contract pulls USDC to Capital Wallet and calls `mintForDeposit`. | ~60 |
+| sPLUSD | OZ ERC-4626 + ERC20Pausable + AccessManaged + UUPS | Yield-bearing vault on PLUSD; open to any PLUSD holder. | ~35 |
+| WhitelistRegistry | AccessManaged + TimelockPending + UUPS | On-chain allowlist: KYCed LP wallets and approved DeFi venues. Tracks Chainalysis `approvedAt` timestamp. | ~95 |
+| WithdrawalQueue | AccessManaged + Pausable + ReentrancyGuard + UUPS | FIFO withdrawal queue; Pending→Funded→Claimed/AdminReleased lifecycle. Full-amount funding only. | ~140 |
+| LoanRegistry | OZ ERC-721 (soulbound) + AccessManaged + Pausable + UUPS | On-chain registry of loan facilities; immutable origination data + mutable lifecycle state. | ~190 |
+| ShutdownController | AccessManaged + UUPS | Freezes normal flow on distress; fixes `recoveryRateBps`; opens `redeemInShutdown` / `claimAtShutdown` paths. | ~75 |
+| RecoveryPool | AccessManaged + Pausable + ReentrancyGuard + UUPS | Holds USDC for LP recovery payments on shutdown. | ~70 |
+| EmergencyRevoker | standalone, **non-upgradeable** | Single `revokeAll()` call by GUARDIAN atomically strips FUNDER, WHITELIST_ADMIN, YIELD_MINTER from Bridge and TRUSTEE from Trustee key. | ~50 |
 
 ---
 
@@ -23,59 +49,94 @@ The Pipeline protocol deploys six on-chain contracts on Ethereum mainnet. Five a
 
 | Function | Access | Description |
 |---|---|---|
-| `mint(address to, uint256 amount)` | MINTER | Mints PLUSD. Enforces rolling 24h rate limit ($10M) and per-tx cap ($5M), both configurable by foundation multisig. Reverts if recipient not on WhitelistRegistry. |
-| `burn(address from, uint256 amount)` | MINTER | Burns PLUSD from a specified address. Used by WithdrawalQueue.fillRequest. |
-| `transfer(address to, uint256 amount)` | public | Standard ERC-20 transfer. Custom `_update` hook reverts if recipient not on WhitelistRegistry. |
-| `transferFrom(address from, address to, uint256 amount)` | public | Standard ERC-20. Same whitelist check via `_update`. |
-| `pause() / unpause()` | PAUSER | Freezes all mint, burn, and transfer operations. 2-of-5 Risk Council via foundation multisig. |
+| `mintForDeposit(address lp, uint256 amount)` | DEPOSITOR (DepositManager) | Mints PLUSD 1:1 to a USDC deposit. Increments `cumulativeLPDeposits`. Checks reserve invariant and whitelist. |
+| `yieldMint(YieldAttestation att, bytes bridgeSig, bytes custodianSig)` | YIELD_MINTER (Bridge) | Mints yield PLUSD. Verifies two EIP-712 signatures on-chain: Bridge ECDSA (ecrecover on `bridgeYieldAttestor`) and custodian EIP-1271 (on `custodianYieldAttestor`). Destination constrained to sPLUSD vault or Treasury. Checks reserve invariant. |
+| `burn(address from, uint256 amount)` | BURNER (WithdrawalQueue) | Burns escrowed PLUSD when LP calls `claim`. Increments `cumulativeLPBurns`. |
+| `transfer / transferFrom` | public | Standard ERC-20. `_update` hook enforces: exactly one of (from, to) must be a system address or a whitelisted LP. LP↔LP and system↔system both revert. |
+| `pause() / unpause()` | PAUSER (GUARDIAN) | Freezes all mint, burn, and transfer operations. |
+| `reserveHealth()` | public view | Returns `cumulativeLPDeposits + cumulativeYieldMinted - cumulativeLPBurns - totalSupply`. Non-negative = internally consistent. |
 
-The custom surface on PLUSD is approximately 5 lines: a single override of the OpenZeppelin `_update` hook that calls `WhitelistRegistry.isAllowed(to)` before completing any transfer, mint, or burn. All other token logic is inherited unmodified.
+Direct `mint(address, uint256)` is removed. Fresh PLUSD enters supply only through
+`mintForDeposit` (deposit leg) or `yieldMint` (yield leg).
 
-Two minting categories use the same `mint()` function but are tracked separately in the bridge service audit log: deposit mints (triggered by USDC inflow from a whitelisted LP) and yield mints (triggered by trustee-signed RepaymentSettled or TreasuryYieldDistributed events).
+### DepositManager
+
+| Function | Access | Description |
+|---|---|---|
+| `deposit(uint256 usdcAmount)` | public | Atomic deposit: checks `isAllowedForMint`, per-LP cap, rolling cap, supply cap; pulls USDC from LP to Capital Wallet; calls `PLUSD.mintForDeposit`. |
+| `pause() / unpause()` | PAUSER (GUARDIAN) | Freezes all deposits. |
 
 ### sPLUSD (ERC-4626)
 
 | Function | Access | Description |
 |---|---|---|
 | `deposit(uint256 assets, address receiver)` | public | Standard ERC-4626 deposit. Open to any PLUSD holder. |
-| `redeem(uint256 shares, address receiver, address owner)` | public | Standard ERC-4626 redeem. Reverts at the PLUSD level if receiver is not whitelisted. |
-| `totalAssets()` | public view | Returns `PLUSD.balanceOf(address(this))`. Yield accretion happens via fresh PLUSD mints into this address. |
-| `pause() / unpause()` | PAUSER | Freezes deposits and redemptions. 2-of-5 Risk Council via foundation multisig. |
-
-sPLUSD is the OpenZeppelin ERC-4626 implementation deployed without modification. Yield accretion is a natural property of ERC-4626: when the bridge service mints fresh PLUSD directly into the vault address, `totalAssets` increases while `totalSupply` stays constant, raising the share price for all stakers. No custom code is required.
-
-Initial exchange rate is 1 PLUSD = 1 sPLUSD at first deposit. A dead-shares seed at vault deployment mitigates first-deposit inflation attacks. Standard ERC-4626 rounding direction applies.
+| `redeem(uint256 shares, address receiver, address owner)` | public | Standard ERC-4626 redeem. Triggers lazy USYC yield mint if NAV delta > 0. |
+| `totalAssets()` | public view | Returns `PLUSD.balanceOf(address(this))`. Increases when yield mints land in the vault. |
+| `pause() / unpause()` | PAUSER (GUARDIAN) | Freezes deposits and redemptions. |
 
 ### WhitelistRegistry
 
 | Function | Access | Description |
 |---|---|---|
-| `setAccess(address lp, uint256 approvedAt)` | WHITELIST_ADMIN | Bridge sets a wallet as approved with the current Chainalysis screening timestamp. |
-| `revokeAccess(address lp)` | WHITELIST_ADMIN or DEFAULT_ADMIN | Immediate removal from whitelist, e.g., on failed passive re-screen. |
-| `isAllowed(address lp)` | public view | Returns true if lp is currently whitelisted AND `(block.timestamp - approvedAt) < freshnessWindow`. |
-| `freshnessWindow` | public storage | Configurable parameter (default 90 days) set by DEFAULT_ADMIN. |
-| `addDeFiVenue(address venue)` | DEFAULT_ADMIN | Foundation multisig adds approved DeFi pool/vault addresses that can hold PLUSD. |
+| `setAccess(address lp, uint256 approvedAt)` | WHITELIST_ADMIN (Bridge) | Adds or updates a whitelisted LP with the Chainalysis screening timestamp. |
+| `refreshScreening(address lp, uint256 newApprovedAt)` | WHITELIST_ADMIN (Bridge) | Updates `approvedAt` for an existing whitelisted LP after re-screening. |
+| `revokeAccess(address lp)` | WHITELIST_ADMIN (Bridge) or ADMIN | Removes LP from the whitelist immediately. |
+| `isAllowed(address lp)` | public view | Returns true if LP is whitelisted. Does not check freshness. Used by WithdrawalQueue and PLUSD `_update`. |
+| `isAllowedForMint(address lp)` | public view | Returns true if LP is whitelisted AND `(block.timestamp - approvedAt) < freshnessWindow`. Used by DepositManager. |
+| `addDeFiVenue(address venue)` | ADMIN | Adds an approved DeFi pool/vault to the system-address allowlist. |
 
 ### WithdrawalQueue
 
+Lifecycle: `Pending → Funded → Claimed | AdminReleased`
+
 | Function | Access | Description |
 |---|---|---|
-| `requestWithdrawal(uint256 amount)` | public | Pulls PLUSD from caller into escrow, creates a queue entry, returns queue_id. Emits WithdrawalRequested. Reverts if caller not on WhitelistRegistry with a fresh screen. |
-| `cancelWithdrawal(uint256 queueId)` | public | Only callable by original requester. Returns remaining escrowed PLUSD. Cannot reverse already-filled portions. |
-| `fillRequest(uint256 queueId, uint256 amount)` | FILLER | Bridge calls this to fill the first request in the queue, either fully or partially. Burns the filled PLUSD amount. Emits WithdrawalPartiallyFilled or WithdrawalSettled. |
-| `getQueueDepth()` | public view | Returns (totalEscrowed, count, outstandingAtHead). |
-| `pause() / unpause()` | PAUSER | Freezes all fills. 2-of-5 Risk Council via foundation multisig. |
+| `requestWithdrawal(uint256 amount)` | public | Pulls PLUSD from caller into escrow; assigns `queue_id`; emits `WithdrawalRequested`. Reverts if caller not whitelisted with a fresh screen. |
+| `fundRequest(uint256 queueId)` | FUNDER (Bridge) | Funds the queue head in full: pulls USDC from Capital Wallet to WQ via pre-approved allowance. Moves entry to `Funded`. Emits `WithdrawalFunded`. |
+| `skipSanctionedHead()` | FUNDER (Bridge) | Moves a non-`isAllowed` queue head to `AdminReleased`, unblocking the queue. |
+| `claim(uint256 queueId)` | public (original requester only) | Atomically burns escrowed PLUSD and pays out USDC to LP. Only callable after `Funded`. Emits `WithdrawalClaimed`. |
+| `adminRelease(uint256 queueId)` | ADMIN | Manual release of a stuck entry to `AdminReleased`. |
+| `getQueueDepth()` | public view | Returns `(totalEscrowed, pendingCount, fundedCount)`. |
+| `pause() / unpause()` | PAUSER (GUARDIAN) | Freezes `fundRequest` and `claim`. |
+
+Partial fills, `cancelWithdrawal`, and LP-initiated cancellation are not in the MVP.
 
 ### LoanRegistry
 
 | Function | Access | Description |
 |---|---|---|
-| `mintLoan(address originator, ImmutableLoanData data)` | loan_manager | Mints a new loan NFT. Emits LoanMinted, which triggers the bridge service's disbursement preparation. |
-| `updateMutable(uint256 tokenId, LoanStatus status, uint256 newMaturityDate, uint256 newCCR, LocationUpdate newLocation)` | loan_manager | Updates lifecycle fields. Reverts if newStatus == Default. |
-| `setDefault(uint256 tokenId)` | risk_council | Risk Council 3-of-5 multisig transitions a loan to Default status. |
-| `closeLoan(uint256 tokenId, ClosureReason reason)` | loan_manager or risk_council | loan_manager for {ScheduledMaturity, EarlyRepayment}; risk_council for {Default, OtherWriteDown}. |
+| `mintLoan(address originator, ImmutableLoanData data)` | TRUSTEE | Mints a new loan NFT. Emits `LoanMinted`. |
+| `updateMutable(uint256 tokenId, LoanStatus status, uint256 newMaturityDate, uint256 newCCR, LocationUpdate newLocation)` | TRUSTEE | Updates mutable lifecycle fields. Reverts if newStatus == Default. |
+| `setDefault(uint256 tokenId)` | RISK_COUNCIL | Transitions loan to Default (24h timelock). |
+| `closeLoan(uint256 tokenId, ClosureReason reason)` | TRUSTEE or RISK_COUNCIL | TRUSTEE for {ScheduledMaturity, EarlyRepayment}; RISK_COUNCIL for {Default, OtherWriteDown}. |
 | `getImmutable(uint256 tokenId)` | public view | Returns immutable origination data. |
 | `getMutable(uint256 tokenId)` | public view | Returns current mutable lifecycle data. |
+
+Bridge has **no role on LoanRegistry**. All loan NFT writes are done by the Trustee key directly.
+
+### ShutdownController
+
+| Function | Access | Description |
+|---|---|---|
+| `proposeShutdown(uint256 recoveryRateBps)` | RISK_COUNCIL | Proposes shutdown. 24h timelock before ADMIN can execute. |
+| `executeShutdown()` | ADMIN via AccessManager | Freezes normal flow across all contracts; enables `redeemInShutdown` / `claimAtShutdown`. |
+| `adjustRecoveryRateUp(uint256 newRateBps)` | RISK_COUNCIL | Ratchets recovery rate upward only (24h timelock). Rate never decreases after shutdown entry. |
+
+sPLUSD holders exit post-shutdown via normal `sPLUSD.redeem()` (returns PLUSD) then
+`PLUSD.redeemInShutdown` for USDC at the frozen recovery rate.
+
+---
+
+## Role Assignments
+
+Bridge holds: YIELD_MINTER (PLUSD), FUNDER (WithdrawalQueue), WHITELIST_ADMIN (WhitelistRegistry).
+GUARDIAN holds: PAUSER on every pausable contract + EmergencyRevoker trigger.
+ADMIN holds: UPGRADER on every upgradeable contract + ADMIN on WhitelistRegistry + WithdrawalQueue ops.
+RISK_COUNCIL holds: setDefault on LoanRegistry, proposeShutdown on ShutdownController.
+Trustee key holds: TRUSTEE on LoanRegistry (all loan NFT writes — Bridge has no LoanRegistry role).
+DepositManager proxy holds: DEPOSITOR on PLUSD.
+WithdrawalQueue holds: BURNER on PLUSD.
 
 ---
 
@@ -95,9 +156,9 @@ Initial exchange rate is 1 PLUSD = 1 sPLUSD at first deposit. A dead-shares seed
 | originationDate | uint256 | Block timestamp at mint |
 | originalMaturityDate | uint256 | Originally agreed maturity |
 | governingLaw | string | e.g. English law, LCIA London |
-| metadataURI | string | Optional IPFS pointer to descriptive context |
+| metadataURI | string | Optional IPFS pointer |
 
-### MutableLoanData (updated by loan_manager / risk_council)
+### MutableLoanData (updated by TRUSTEE / RISK_COUNCIL)
 
 | Field | Type | Notes |
 |---|---|---|
@@ -108,38 +169,30 @@ Initial exchange rate is 1 PLUSD = 1 sPLUSD at first deposit. A dead-shares seed
 | currentLocation | LocationUpdate | Embedded struct |
 | closureReason | ClosureReason | Set when status = Closed |
 
-### LocationUpdate (embedded in MutableLoanData)
+Enums: `LoanStatus { Performing, Watchlist, Default, Closed }` ·
+`ClosureReason { None, ScheduledMaturity, EarlyRepayment, Default, OtherWriteDown }` ·
+`LocationType { Vessel, Warehouse, TankFarm, Other }`
 
-| Field | Type | Notes |
-|---|---|---|
-| locationType | LocationType | Vessel \| Warehouse \| TankFarm \| Other |
-| locationIdentifier | string | Vessel IMO, warehouse name, tank farm ID |
-| trackingURL | string | Optional external tracking link (MarineTraffic etc.) |
-| updatedAt | uint256 | Timestamp of last location update |
-
-Enums: `LoanStatus { Performing, Watchlist, Default, Closed }` · `ClosureReason { None, ScheduledMaturity, EarlyRepayment, Default, OtherWriteDown }` · `LocationType { Vessel, Warehouse, TankFarm, Other }`.
-
----
-
-## Restricted Interaction Model
-
-PLUSD transfers are gated by the WhitelistRegistry on every movement. The WhitelistRegistry contains two categories of approved address:
-
-- **KYCed LP wallets** approved via the onboarding process, with Chainalysis freshness enforced via the `approvedAt` timestamp and the `freshnessWindow` parameter (default 90 days).
-- **Approved DeFi venues** — specific Curve pools, Uniswap v4 pools, Aave market contracts — explicitly added by the foundation multisig after legal and technical review.
-
-Any PLUSD transfer to an address not in either category reverts. PLUSD cannot be redirected to an attacker-controlled address unless that address has either passed KYC or been added to the DeFi venue allowlist by the foundation multisig.
-
-sPLUSD is not subject to the whitelist check. The vault is open to any PLUSD holder, enabling DeFi composability for the yield-bearing token. The KYC chain re-enters on sPLUSD redemption: the resulting PLUSD transfer to the receiver triggers the PLUSD `_update` hook, which checks the WhitelistRegistry on delivery.
-
-The MVP ships in strict whitelist mode (only approved addresses permitted). The foundation multisig can later shift the WhitelistRegistry to a permissive mode (only sanctioned addresses blocked) via a configuration change, without a contract upgrade.
+`LocationUpdate` (embedded in MutableLoanData): `locationType`, `locationIdentifier` (vessel IMO
+/ warehouse name), `trackingURL` (optional MarineTraffic etc.), `updatedAt`.
 
 ---
 
 ## Security Considerations
 
-- Total custom audit surface is approximately 470 lines across all contracts — a small target for a Tier 1 auditor.
-- Smart contracts hold no USDC or USYC. A contract exploit cannot drain investor capital unilaterally; cash-rail outflows require bridge or human MPC signatures.
-- The FoundationMultisig holds a 2-of-5 Risk Council fast-pause capability over PLUSD, sPLUSD, and the WithdrawalQueue, enabling immediate freeze without the full 3-of-5 quorum.
-- PLUSD on-chain rate limits ($10M rolling 24h / $5M per tx, both configurable by foundation multisig) bound the blast radius of a compromised MINTER key.
-- The FILLER role on WithdrawalQueue can only burn PLUSD that is already in queue escrow; it cannot fabricate fills against non-existent entries.
+- **No single point of mint compromise.** Deposit-leg mints require an atomic contract call
+  through DepositManager (no off-chain signer). Yield-leg mints require Bridge ECDSA signature
+  + custodian EIP-1271 signature + YIELD_MINTER caller role — three independent controls.
+  Compromising any one party alone mints zero PLUSD.
+- **Reserve invariant on every mint path.** On-chain cumulative counters prevent over-minting
+  against the contract's own ledger. Full Proof of Reserve (Chainlink PoR) is deferred to
+  phase 2.
+- **Bounded upgradeability.** 48h ADMIN delay on upgrades with GUARDIAN veto. A 14-day
+  meta-timelock on delay changes closes the "collapse-delay-then-exploit" second-order attack.
+- **Three-Safe governance separation.** ADMIN cannot enter shutdown or declare default;
+  RISK_COUNCIL cannot perform upgrades or manage roles; GUARDIAN cannot initiate risk-increasing
+  actions.
+- **Smart contracts hold no USDC.** Capital Wallet and Treasury Wallet are MPC-controlled.
+  A contract exploit cannot drain investor capital unilaterally.
+- **Non-transferable PLUSD.** The `_update` hook requires exactly one of (from, to) to be a
+  system address or whitelisted LP, closing LP↔LP and system↔system laundering attack classes.

--- a/docs/product-specs/staking.md
+++ b/docs/product-specs/staking.md
@@ -31,19 +31,13 @@ At vault deployment, a small amount of PLUSD ("dead shares") is minted into the 
 
 ### Yield Accretion
 
-Yield is delivered to the vault by the bridge service minting fresh PLUSD directly into the vault contract address:
-
-```
-PLUSD.mint(address(sPLUSDvault), yieldAmount)
-```
-
-This call increases `PLUSD.balanceOf(address(sPLUSDvault))`, which is exactly what `totalAssets()` returns. Because `totalSupply` of sPLUSD shares does not change, the share price (`totalAssets / totalSupply`) increases. All current stakers benefit proportionally without any action on their part.
+Yield is delivered to the vault via `PLUSD.yieldMint(att, bridgeSig, custodianSig)`, which mints fresh PLUSD to the vault address. This increases `PLUSD.balanceOf(address(sPLUSDvault))`, which is exactly what `totalAssets()` returns. Because `totalSupply` of sPLUSD shares does not change, the share price (`totalAssets / totalSupply`) increases. All current stakers benefit proportionally without any action on their part.
 
 Two yield sources feed into the vault this way:
-- **Loan repayment yield**: the `senior_coupon_net` component of each settled repayment, minted in response to a trustee-signed RepaymentSettled event.
-- **T-bill (USYC) yield**: 70% of weekly accrued USYC NAV appreciation, minted in response to a trustee-signed TreasuryYieldDistributed event.
+- **Loan repayment yield**: the `senior_coupon_net` component of each settled repayment, minted after Trustee approves the split amounts via the Bridge API.
+- **USYC NAV yield**: 70% of accrued USYC NAV appreciation, minted lazily on each sPLUSD stake/unstake event when NAV delta > 0.
 
-The bridge service holds the MINTER role on PLUSD and is the only party that can execute these mints. Both categories are subject to the same on-chain rolling rate limit and per-transaction cap as deposit mints.
+Both mints require two independent EIP-712 signatures verified on-chain (Bridge ECDSA + custodian EIP-1271), plus the YIELD_MINTER caller role held by Bridge. Neither Bridge alone nor the custodian alone can mint yield PLUSD.
 
 ### Unstaking (Redemption)
 
@@ -97,7 +91,7 @@ function totalAssets() external view returns (uint256);
 // Increases when the bridge mints fresh PLUSD into the vault address.
 // Decreases when PLUSD is transferred out on redemption.
 
-function pause() external;   // PAUSER role (foundation multisig via 2-of-5 Risk Council)
+function pause() external;   // PAUSER role (GUARDIAN 2/5 Safe)
 function unpause() external;  // PAUSER role
 // Pause freezes all deposits and redemptions.
 ```
@@ -129,7 +123,7 @@ The sPLUSD vault holds no custom on-chain state beyond the standard ERC-4626 / E
 
 - **No custom vault logic.** sPLUSD is the OpenZeppelin ERC-4626 implementation without modification. Yield accretion requires no custom code; it is a natural consequence of minting PLUSD into the vault address. The audit surface is minimal.
 - **Compliance re-entry on redemption.** The whitelist check on PLUSD transfer ensures that sPLUSD holders cannot deliver PLUSD to a non-whitelisted receiver. An attacker who obtains sPLUSD shares through an unrelated exploit cannot extract PLUSD to an unapproved address.
-- **Rate limits on yield mints.** Fresh PLUSD minted into the vault is subject to the same on-chain rolling rate limit ($10M/24h) and per-transaction cap ($5M) as deposit mints, bounding the blast radius of a compromised MINTER.
-- **Pause capability.** The foundation multisig's 2-of-5 Risk Council fast-pause can freeze all sPLUSD deposits and redemptions immediately, independent of the bridge service state.
+- **Two-party yield attestation.** Fresh PLUSD minted into the vault requires Bridge ECDSA + custodian EIP-1271 signatures verified on-chain. A compromised YIELD_MINTER key alone cannot mint yield — the custodian co-sig is an independent control.
+- **Pause capability.** GUARDIAN 2/5 Safe can freeze all sPLUSD deposits and redemptions immediately, independent of the bridge service state.
 - **Dead-shares seed.** Prevents the ERC-4626 inflation attack on the first depositor by ensuring `totalAssets` and `totalSupply` are non-zero at deployment.
 - **Open transfer of sPLUSD.** Because sPLUSD has no whitelist check, it can be transferred freely between any addresses. This is intentional for DeFi composability. The risk is accepted because the compliance boundary is enforced at the PLUSD level on any conversion back to the underlying asset.

--- a/docs/product-specs/withdrawals.md
+++ b/docs/product-specs/withdrawals.md
@@ -2,11 +2,10 @@
 
 ## Overview
 
-LPs exit by redeeming sPLUSD for PLUSD, then queuing PLUSD for USDC payout via the
-WithdrawalQueue contract. The queue is FIFO with partial fill support. The bridge service
-auto-signs routine LP payouts; above-envelope payouts and Treasury redemptions require
-human co-signature. PLUSD is held in escrow until USDC physically leaves the Capital
-Wallet, keeping the PLUSD backing invariant valid throughout the lifecycle.
+LPs exit by redeeming sPLUSD for PLUSD, then queuing PLUSD via the WithdrawalQueue contract
+for USDC payout. The queue is strict FIFO. Bridge funds the queue head in full via
+`fundRequest`; the LP then calls `claim` to atomically burn PLUSD and receive USDC. PLUSD is
+held in escrow until `claim`, preserving the backing invariant throughout the lifecycle.
 
 ---
 
@@ -14,102 +13,89 @@ Wallet, keeping the PLUSD backing invariant valid throughout the lifecycle.
 
 ### Step 1 — sPLUSD to PLUSD
 
-If the LP holds sPLUSD, they first call `sPLUSD.redeem(shares, receiver, owner)`. The vault
-burns the sPLUSD shares and transfers the corresponding PLUSD (at the current exchange rate)
-to the receiver. The receiver must be whitelisted on the WhitelistRegistry; if not, the
-PLUSD transfer reverts at the PLUSD contract level.
+If the LP holds sPLUSD, they call `sPLUSD.redeem(shares, receiver, owner)`. The vault burns
+the sPLUSD shares and transfers PLUSD at the current share price to the receiver. The receiver
+must satisfy `WhitelistRegistry.isAllowed(receiver)` — if not, the PLUSD transfer reverts at
+the PLUSD contract level.
+
+Before processing the redemption, Bridge checks whether a lazy USYC yield mint is due (NAV
+delta > 0) and executes it, keeping the share price current.
 
 ### Step 2 — WithdrawalQueue.requestWithdrawal()
 
-The LP calls `WithdrawalQueue.requestWithdrawal(amount)`. The contract performs two checks
-before accepting the request:
+The LP calls `WithdrawalQueue.requestWithdrawal(amount)`. The contract checks:
 
-- **Whitelist check**: `msg.sender` must be currently whitelisted on the WhitelistRegistry.
-- **Chainalysis freshness check**: the `approvedAt` timestamp on the WhitelistRegistry must
-  be within the active freshness window (default 90 days).
+- **Whitelist check:** `msg.sender` must be currently whitelisted (`isAllowed`).
+- **Freshness check:** `approvedAt` must be within the freshness window (default 90 days).
 
-If either check fails, the call reverts. On success, the contract pulls `amount` PLUSD from
-the caller into queue escrow, assigns a sequential `queue_id`, and emits
-`WithdrawalRequested(lpAddress, amount, queue_id)`.
+On success, the contract pulls `amount` PLUSD from the caller into escrow, assigns a
+sequential `queue_id`, and emits `WithdrawalRequested(lpAddress, amount, queueId)`. Entry
+status is `Pending`.
 
-### FIFO queue with partial fills
+### Queue Funding — Bridge calls fundRequest
 
-The queue processes requests in strict FIFO order by `queue_id`. When USDC arrives in the
-Capital Wallet from any source (deposit, loan repayment, USYC redemption), the bridge
-service attempts to fill the first request in the queue:
+Bridge processes the queue head in strict FIFO order:
 
-- If available USDC covers the full first request, the bridge fills it completely and
-  attempts the next queued request with any remaining USDC.
-- If available USDC is less than the first request, the bridge issues a partial fill. The
-  queue entry's `amount_remaining` is reduced and the entry stays at the head of the queue.
-- `WithdrawalPartiallyFilled(queue_id, amount_filled, amount_remaining)` is emitted on each
-  partial fill.
-- `WithdrawalSettled(queue_id)` is emitted when `amount_remaining` reaches zero and the
-  entry is removed from the queue.
-- The LP dashboard displays progressive fill status for each active request.
+1. **Whitelist check.** If `isAllowed(requester)` is false, calls `WQ.skipSanctionedHead()`.
+   The entry moves to `AdminReleased` and the next entry becomes the head.
+2. **Freshness check (Bridge-side).** If stale: re-screens via Chainalysis. On clean result,
+   calls `WhitelistRegistry.refreshScreening(lp, newTs)`, then proceeds. On flag, calls
+   `revokeAccess` then `skipSanctionedHead`. If Chainalysis is unreachable, Bridge halts and
+   alerts ops — head is stuck until manual `adminRelease`.
+3. **Balance check.** If Capital Wallet USDC is insufficient, Bridge requests a USYC → USDC
+   redemption via the custodian MPC API and retries after settlement.
+4. **Fund.** Calls `WQ.fundRequest(queueId)`. WQ pulls the full `amount` in USDC from the
+   Capital Wallet via pre-approved allowance. Entry moves to `Funded`. Emits
+   `WithdrawalFunded(queueId)`.
 
-USYC is not counted against USDC availability for queue fills. If USDC is insufficient, the
-automated USDC/USYC rebalancing in the yield spec reduces the USYC position and restores
-USDC, which then flows through to pending queue entries.
+Funding is always full-amount. There are no partial fills.
 
-### LP cancelWithdrawal()
+### Step 3 — LP calls claim()
 
-An LP may call `cancelWithdrawal(queue_id)` at any time before the request is fully
-settled. The contract returns only the `amount_remaining` (escrowed but not yet filled).
-Portions already paid out are final and cannot be reversed. A partially-filled request
-returns only the unfilled remainder.
+After their entry is `Funded`, the LP calls `WQ.claim(queueId)`. The contract atomically:
 
-### Automated LP payout authorisation (bridge MPC policy)
+1. Burns the escrowed PLUSD (`amount`) — increments `cumulativeLPBurns` on PLUSD.
+2. Transfers the corresponding USDC from WQ to the LP's address.
+3. Moves entry to `Claimed`. Emits `WithdrawalClaimed(queueId)`.
 
-The bridge service auto-signs Capital Wallet outflows for routine LP payouts. The MPC
-policy engine enforces the following checks before any transaction is executed:
+Only the original requester may call `claim`. PLUSD is not burned until `claim`, preserving
+the backing invariant throughout the funding-to-claim window.
 
-| Check | Rule |
-|---|---|
-| Destination address | Must equal the LP address that originally deposited the USDC corresponding to this PLUSD. Mapping stored in bridge persistent state and verified via policy webhook. |
-| Whitelist status | Destination must be currently whitelisted with a fresh Chainalysis screen. |
-| Amount | Must equal `amount_remaining` in the queue entry, or a valid partial fill up to current Capital Wallet USDC availability. |
-| Per-transaction cap | $5M USDC maximum per single payout transaction. |
-| Rolling 24h aggregate | $10M USDC maximum across all LP payouts in a rolling 24h window. |
-| Out-of-envelope condition | Any request failing destination match, exceeding either cap, or involving a non-whitelisted address is rejected by the MPC engine and routed to the Trustee + team manual signing queue. |
+### Sanctioned Head Handling
 
-LPs who wish to withdraw to a different address from their original deposit address must
-complete a manual review process with the trustee. This flow is not supported through the
-automated path.
+If `isAllowed(requester)` is false at funding time, Bridge calls `skipSanctionedHead()`. The
+WQ contract moves the entry to `AdminReleased`, unblocking the queue. Escrowed PLUSD in the
+skipped entry is held in the contract; ADMIN determines disposition separately.
 
-### Above-envelope payouts
+### Admin Release
 
-Payouts that fail the automated policy check — wrong destination, amount above $5M per-tx
-or $10M rolling 24h, or non-whitelisted address — are surfaced in the trustee tooling's
-signing queue. The trustee and Pipeline team review the request and co-sign via MPC before
-the Capital Wallet transaction is submitted.
+ADMIN (3/5 Safe) may call `adminRelease(queueId)` to manually move a stuck `Pending` entry
+to `AdminReleased` when automated processing is blocked (e.g., Chainalysis unavailable for an
+extended period).
 
-### Treasury Wallet redemption — Stage A (PLUSD to USDC)
+### Above-Envelope Payouts
 
-The Treasury Wallet redeems accumulated PLUSD revenue via the same WithdrawalQueue
-mechanics as a regular LP withdrawal, with a privileged fill path to avoid queue contention
-with LP redemptions. Authorisation requires three parties:
+Bridge's custodian MPC payout policy bounds automated Capital Wallet USDC outflows (per-tx
+cap and rolling 24h aggregate). Payouts exceeding these bounds surface in the Trustee tooling
+signing queue; Trustee and Pipeline team co-sign via MPC.
 
-1. **Team operator A** initiates the redemption request (specifies PLUSD amount).
-2. **Team operator B** independently verifies the request and confirms. Operator B must be
-   a different person from Operator A; the tooling enforces this by binding each step to a
-   distinct authenticated session.
-3. **Trustee** reviews the verified request and provides the final co-signature via MPC.
+### Treasury Wallet Redemption — Stage A (PLUSD to USDC)
 
-On all three signatures, the bridge executes the PLUSD escrow and the USDC payout from the
-Capital Wallet to a protocol-controlled withdrawal endpoint inside the cash rail.
+The Treasury Wallet redeems PLUSD revenue via the same WithdrawalQueue mechanics, with
+three-party authorisation:
 
-### Treasury Wallet redemption — Stage B (USDC to bank account)
+1. **Team operator A** initiates the redemption (specifies PLUSD amount).
+2. **Team operator B** (distinct authenticated session) verifies and confirms.
+3. **Trustee** provides the final co-signature via MPC.
 
-Once USDC is at the withdrawal endpoint, the team initiates the off-ramp leg. The
-destination bank account must be selected from the **pre-approved bank account list**
-maintained by the foundation multisig. Free-text bank account entry is not permitted.
-Adding or removing a destination requires a foundation multisig transaction.
+On all three signatures, Bridge escrows PLUSD and executes the USDC payout from the Capital
+Wallet to a protocol-controlled withdrawal endpoint.
 
-Authorisation chain mirrors Stage A: team operator A initiates, team operator B verifies,
-trustee co-signs via MPC. The bridge then submits the off-ramp instruction to the on/off-ramp
-provider, converting USDC to USD and SWIFT-wiring to the selected Trust Company bank
-account.
+### Treasury Wallet Redemption — Stage B (USDC to bank account)
+
+Once USDC is at the withdrawal endpoint, Team operator A initiates off-ramp. The destination
+bank account must be from the **pre-approved bank account list** maintained by ADMIN Safe.
+Free-text entry is not permitted. Authorisation mirrors Stage A (two operators + Trustee).
 
 ---
 
@@ -117,35 +103,35 @@ account.
 
 ```solidity
 interface IWithdrawalQueue {
-    /// @notice Pulls PLUSD from caller into escrow and creates a queue entry.
-    /// @dev Reverts if caller is not whitelisted with a fresh Chainalysis screen.
-    /// @return queueId Sequential identifier for this request.
+    /// @notice Pulls PLUSD from caller into escrow; creates a Pending entry.
+    /// @dev Reverts if caller is not whitelisted with a fresh screen.
     function requestWithdrawal(uint256 amount) external returns (uint256 queueId);
 
-    /// @notice Returns remaining escrowed PLUSD to the original requester.
-    /// @dev Only callable by the original requester. Cannot reverse filled portions.
-    function cancelWithdrawal(uint256 queueId) external;
+    /// @notice Funds the queue head in full by pulling USDC from Capital Wallet.
+    /// @dev Only callable by FUNDER (Bridge). Moves entry to Funded.
+    function fundRequest(uint256 queueId) external;
 
-    /// @notice Fills the specified queue entry fully or partially.
-    /// @dev Only callable by FILLER role (bridge service). Burns filled PLUSD amount.
-    ///      Emits WithdrawalPartiallyFilled or WithdrawalSettled.
-    function fillRequest(uint256 queueId, uint256 amount) external;
+    /// @notice Skips a sanctioned queue head; moves it to AdminReleased.
+    /// @dev Only callable by FUNDER (Bridge). Requires !isAllowed(head requester).
+    function skipSanctionedHead() external;
+
+    /// @notice Atomically burns escrowed PLUSD and pays USDC to original requester.
+    /// @dev Only callable by the original requester. Entry must be Funded.
+    function claim(uint256 queueId) external;
+
+    /// @notice Manually releases a stuck Pending entry to AdminReleased.
+    /// @dev Only callable by ADMIN (3/5 Safe).
+    function adminRelease(uint256 queueId) external;
 
     /// @notice Returns current queue state.
-    /// @return totalEscrowed  Sum of all outstanding escrowed PLUSD.
-    /// @return count          Number of pending requests.
-    /// @return outstandingAtHead  amount_remaining for the first request in queue.
     function getQueueDepth()
         external view returns (
             uint256 totalEscrowed,
-            uint256 count,
-            uint256 outstandingAtHead
+            uint256 pendingCount,
+            uint256 fundedCount
         );
 
-    /// @notice Freezes all fills. 2-of-5 Risk Council via foundation multisig.
     function pause() external;
-
-    /// @notice Resumes fills after a pause.
     function unpause() external;
 }
 ```
@@ -154,9 +140,10 @@ interface IWithdrawalQueue {
 
 ```solidity
 event WithdrawalRequested(address indexed lp, uint256 amount, uint256 indexed queueId);
-event WithdrawalPartiallyFilled(uint256 indexed queueId, uint256 amountFilled, uint256 amountRemaining);
-event WithdrawalSettled(uint256 indexed queueId);
-event WithdrawalCancelled(uint256 indexed queueId, uint256 amountReturned);
+event WithdrawalFunded(uint256 indexed queueId);
+event WithdrawalClaimed(uint256 indexed queueId, uint256 amountPaid);
+event WithdrawalSanctionedSkip(uint256 indexed queueId);
+event WithdrawalAdminReleased(uint256 indexed queueId);
 ```
 
 ---
@@ -165,34 +152,35 @@ event WithdrawalCancelled(uint256 indexed queueId, uint256 amountReturned);
 
 ```
 WithdrawalEntry {
-  queueId:         uint256   // Sequential, assigned at requestWithdrawal()
-  lp:              address   // Original requester
-  originalAmount:  uint256   // Amount at time of request
-  amountFilled:    uint256   // Cumulative amount paid out so far
-  amountRemaining: uint256   // Outstanding escrowed balance
-  status:          enum { Pending, PartiallyFilled, Settled, Cancelled }
-  createdAt:       uint256   // Block timestamp of requestWithdrawal()
+  queueId:    uint256   // Sequential, assigned at requestWithdrawal()
+  lp:         address   // Original requester
+  amount:     uint256   // Full escrowed PLUSD amount
+  status:     enum { Pending, Funded, Claimed, AdminReleased }
+  createdAt:  uint256   // Block timestamp of requestWithdrawal()
+  fundedAt:   uint256   // Block timestamp of fundRequest() — zero until funded
+  claimedAt:  uint256   // Block timestamp of claim() — zero until claimed
 }
 ```
 
-PLUSD is held in queue escrow and is not burned until `fillRequest()` is called. This keeps
-the PLUSD backing invariant intact: `totalSupply` does not decrease until USDC has
-physically left the Capital Wallet.
+PLUSD is burned only at `claim`, when USDC simultaneously leaves the contract. This preserves
+the PLUSD backing invariant throughout the full withdrawal lifecycle.
 
 ---
 
 ## Security Considerations
 
-- The destination-match check is the central security property of the automated payout
-  path. Only the LP's original deposit address is a valid payout destination; the MPC
-  policy engine enforces this independently of the bridge's software. A compromised bridge
-  cannot redirect withdrawals to an attacker-controlled address.
-- The $5M per-tx and $10M rolling 24h caps bound worst-case automated outflow to a
-  recoverable fraction of the pilot pool within any single detection window.
-- The whitelist and freshness check at `requestWithdrawal()` prevents PLUSD that has
-  drifted to a non-whitelisted address (e.g., via a DeFi venue) from being used to drain
-  protocol liquidity via the queue.
-- PLUSD escrow preserves the backing invariant throughout the withdrawal lifecycle and enables cancellation without economic loss to the LP.
-- The foundation multisig pause capability (2-of-5 Risk Council fast-pause) freezes all fills immediately on incident detection, independent of bridge state.
-- The pre-approved bank account list for Stage B Treasury redemptions prevents operator accounts (including compromised ones) from redirecting protocol revenue to attacker-controlled bank accounts.
-- Every automated payout above $1M triggers an alert to the 24/7 on-call channel.
+- **Two-step settlement.** Funding (USDC to WQ) and claiming (PLUSD burn + USDC to LP) are
+  separate transactions. `totalSupply` does not decrease until USDC has left the Capital
+  Wallet and `claim` burns the PLUSD atomically.
+- **No partial fills.** Funding is all-or-nothing, ensuring no state where PLUSD is partially
+  burned against partial USDC.
+- **Sanctioned head skip.** `skipSanctionedHead` prevents a sanctioned LP from permanently
+  blocking queue progress.
+- **Queue is one-way.** `cancelWithdrawal` is not in MVP. Once PLUSD enters escrow it remains
+  until `claim` or `adminRelease`.
+- **Destination is the original requester.** `claim` always pays to the `lp` address on the
+  queue entry — there is no redirect parameter.
+- **MPC policy caps.** The custodian's policy engine bounds automated Capital Wallet USDC
+  outflows by per-tx and rolling aggregate caps, independent of Bridge software.
+- **GUARDIAN pause.** GUARDIAN 2/5 can freeze all `fundRequest` and `claim` operations
+  immediately on incident detection.

--- a/docs/product-specs/yield.md
+++ b/docs/product-specs/yield.md
@@ -3,10 +3,10 @@
 ## Overview
 
 Protocol yield reaches LP stakers through two distinct paths: loan repayment yield
-(discrete events triggered by borrower wires) and T-bill yield (weekly USYC NAV accrual).
-Both paths deliver fresh PLUSD minted into the sPLUSD vault, accreting NAV for all stakers.
-Fees flow simultaneously to the Treasury Wallet. Senior principal returned on repayment is
-automatically swept into USYC to earn T-bill yield immediately.
+(discrete events triggered by borrower wires) and T-bill yield (USYC NAV accrual distributed
+lazily on each sPLUSD stake/unstake). Both paths deliver fresh PLUSD minted into the sPLUSD
+vault via two-party attestation, accreting NAV for all stakers. Fees flow simultaneously to
+the Treasury Wallet.
 
 ---
 
@@ -56,70 +56,41 @@ OET allocation → originator residual (junior yield). The originator residual i
 directly through the Trust Company's USD bank account and does not appear in any on-chain
 event.
 
-### RepaymentSettled event and on-chain delivery
+### Repayment on-chain delivery
 
-Once the trustee confirms the waterfall breakdown, they sign a `RepaymentSettled` event
-(an EIP-712 off-chain attestation, not an on-chain transaction). This event is the
-trigger for on-chain yield delivery:
+Once the trustee confirms the waterfall breakdown, they submit final split amounts via the
+Bridge API (`POST /v1/trustee/repayments/{id}/approve`). This triggers on-chain yield delivery:
 
 1. The trustee instructs the on-ramp provider to convert the senior portion
    (`senior_principal_returned + senior_coupon_net + protocol fees`) from USD to USDC,
    settling into the Capital Wallet.
-2. The bridge service verifies that the USDC inflow matches the signed event amounts.
-3. The bridge mints PLUSD via the yield-mint path:
-   - `PLUSD.mint(sPLUSDvault, senior_coupon_net)` — increases vault `totalAssets`,
-     accreting NAV for all stakers.
-   - `PLUSD.mint(TreasuryWallet, management_fee + performance_fee + oet_allocation)` —
-     protocol revenue.
-4. The bridge automatically converts `senior_principal_returned` USDC into USYC,
-   sweeping the returned principal back into T-bill yield immediately.
+2. Bridge verifies the USDC inflow matches the Trustee-approved amounts.
+3. Bridge constructs two `YieldAttestation` structs, signs each with `bridgeYieldAttestor`,
+   requests custodian EIP-1271 co-signatures, and calls `PLUSD.yieldMint` for each leg:
+   - Vault leg: mints `senior_coupon_net` PLUSD to the sPLUSD vault — accretes NAV for all
+     stakers.
+   - Treasury leg: mints `management_fee + performance_fee + oet_allocation` PLUSD to the
+     Treasury Wallet.
+   Both signatures (Bridge ECDSA + custodian EIP-1271) are verified on-chain. Neither party
+   alone can mint.
 
-### Weekly USYC NAV yield distribution
+### USYC NAV yield distribution (lazy, stake/unstake-triggered)
 
-USYC in the Capital Wallet accrues NAV continuously. Yield is recognised and distributed
-weekly, on Thursday at the end of day (working reference: 17:00 America/New_York or the
-USYC issuer's published NAV reference time, whichever is later).
+USYC NAV accrues continuously. To keep sPLUSD share price current without a time-based cron,
+yield is minted **lazily** on every sPLUSD `Deposit` or `Withdraw` event:
 
-Between weekly events, the bridge service tracks the running `accrued_yield` figure in
-real time from the USYC issuer's NAV feed. This figure is displayed on the protocol
-dashboard for informational purposes only; it does not affect sPLUSD NAV until the weekly
-distribution fires.
+1. Bridge reads the current USYC NAV from the Hashnote API.
+2. Computes `yield_delta = current_NAV - last_minted_NAV` (applied to Capital Wallet USYC
+   holdings). If `delta <= 0`, no mint occurs.
+3. If `delta > 0`: Bridge constructs two `YieldAttestation` structs (vault 70%, treasury 30%
+   of `yield_delta`), gets Bridge sig + custodian co-sig, submits both `yieldMint` calls.
+4. After both `yieldMint` transactions confirm on-chain, Bridge advances the
+   `last_minted_NAV` baseline. Until both confirm, the baseline is unchanged — idempotent
+   retry is safe.
 
-At the weekly reference time:
-
-1. The bridge computes `total_accrued_yield = USYC NAV appreciation since prior
-   distribution × USYC holding amount`.
-2. The bridge pre-builds a `TreasuryYieldDistributed` transaction and presents it to the
-   trustee tooling, showing: total accrued yield, vault share (70%), treasury share (30%),
-   reference USYC NAV, holding amount, and `week_ending` date.
-3. The trustee reviews and signs (EIP-712 attestation).
-4. On receipt of the trustee signature, the bridge mints:
-   - `PLUSD.mint(sPLUSDvault, 0.70 × total_accrued_yield)` — 70% to stakers.
-   - `PLUSD.mint(TreasuryWallet, 0.30 × total_accrued_yield)` — 30% to Treasury.
-5. USYC is not redeemed during the yield event; it remains in the Capital Wallet and the
-   new NAV becomes the baseline for the following week.
-
-### Automated USDC/USYC rebalancing
-
-After every repayment sweep or withdrawal that shifts the USDC/USYC composition, the bridge
-enforces a target ratio:
-
-| Parameter | Working value | Configurable by |
-|---|---|---|
-| Target USDC ratio | 15% of total reserves | Foundation multisig |
-| Upper band | 20% — triggers USDC → USYC swap | Foundation multisig |
-| Lower band | 10% — triggers USYC → USDC redemption | Foundation multisig |
-| Per-swap cap | $5M | Foundation multisig |
-| Daily aggregate cap | $20M | Foundation multisig |
-
-Swaps above either cap require Trustee + team co-signature via the trustee tooling escape
-path. The trustee retains a manual override UI as a backup path regardless of band state.
-
-### Real-time accrued yield display
-
-The protocol dashboard exposes the running accrued T-bill yield figure as a rolling counter
-that resets to zero after each weekly mint. LPs see T-bill yield accumulating in real time
-even though distribution is weekly.
+USYC is not redeemed during yield distribution; it remains in the Capital Wallet. Between
+mints, Bridge polls USYC NAV continuously and exposes accrued-but-undistributed yield via
+`GET /v1/vault/stats` for dashboard display.
 
 ---
 
@@ -154,16 +125,15 @@ dashboard with a three-state indicator:
 
 ## Security Considerations
 
-- The yield-mint path uses the same `PLUSD.mint()` function as deposit mints but is tracked
-  separately in the bridge audit log. Both paths are subject to the on-chain rolling 24h
-  rate limit ($10M) and per-transaction cap ($5M).
-- The `RepaymentSettled` event is an EIP-712 attestation signed by the trustee; the bridge
-  cannot trigger a yield mint without it. A compromised bridge alone cannot fabricate a
-  yield event.
-- The `TreasuryYieldDistributed` event follows the same pattern: pre-built by the bridge,
-  signed by the trustee, then executed. No yield flows without a trustee signature.
-- USYC is held exclusively in the Capital Wallet; the USYC issuer whitelists only that
-  address as an authorised holder. Automated sweeps to USYC are bounded by the per-swap and
-  daily aggregate caps enforced at the MPC policy engine level.
+- **Two-party yield attestation.** Both repayment and USYC yield mints require Bridge ECDSA
+  signature + custodian EIP-1271 signature + YIELD_MINTER caller role. A compromised Bridge
+  alone cannot mint yield PLUSD.
+- **Reserve invariant enforced on-chain.** Every `yieldMint` call checks the cumulative
+  counter invariant at the PLUSD contract level, bounding yield issuance against the
+  contract's own ledger.
+- **Replay protection.** Each `YieldAttestation` is consumed exactly once via the
+  `usedRepaymentRefs` mapping on PLUSD. Vault and treasury legs use distinct refs per event.
+- USYC is held exclusively in the Capital Wallet. The USDC↔USYC ratio is managed by the
+  custodian MPC policy engine and Trustee — not by Bridge.
 - The reconciliation invariant is continuously re-evaluated; amber and red states produce
-  immediate alerts, enabling prompt detection of any backing discrepancy.
+  immediate alerts enabling prompt detection of any backing discrepancy.

--- a/docs/references/backend.md
+++ b/docs/references/backend.md
@@ -1,0 +1,683 @@
+# Bridge Backend
+
+**Scope:** Bridge service only — off-chain backend, indexer, yield co-signer, on-chain caller. Frontend and Trustee tooling are separate deliverables; Bridge exposes APIs they consume.
+**Reference docs:** [`smart-contracts.md`](./smart-contracts.md) (contract spec v2.3), [`overview.html`](./overview.html) (architecture diagrams), [`security.md`](./security.md) (mint trust model + threat analysis)
+
+---
+
+## Identity
+
+Bridge is the **off-chain backend** for the Pipeline protocol. It watches on-chain events, reconciles state, co-signs yield attestations, and submits operational transactions. It **never custodies USDC** — every dollar moves via the Capital Wallet (MPC) or directly from LP wallets.
+
+**Deposits do not involve Bridge.** LPs deposit by calling the on-chain `DepositManager.deposit(amount)` directly. The contract atomically pulls their USDC to Capital Wallet and mints PLUSD 1:1. Bridge observes the events for reconciliation but is not in the critical path.
+
+On-chain roles held by Bridge's hot key:
+
+| Role | Target contract | What it gates |
+|---|---|---|
+| FUNDER | WithdrawalQueue | `fundRequest(queueId)`, `skipSanctionedHead()` |
+| WHITELIST_ADMIN | WhitelistRegistry | `setAccess(lp, approvedAt)`, `refreshScreening(lp, ts)` |
+| YIELD_MINTER | PLUSD | `yieldMint(att, bridgeSig, custodianSig)` — additionally requires two EIP-712 signatures verified on-chain |
+
+Bridge also operates a **separate yield-signing key** whose address is registered on PLUSD as `bridgeYieldAttestor`. This key signs EIP-712 `YieldAttestation` structs that PLUSD verifies on-chain alongside the custodian's EIP-1271 signature. Neither Bridge alone nor the custodian alone can mint yield — both signatures are required.
+
+Bridge has **no role on LoanRegistry**. All loan NFT writes (mint, amend, close) are done by the Trustee key directly.
+
+Bridge has **no role in the deposit flow**. `MINT_ATTESTOR` is retired (spec v2.3) — deposits are atomic on-chain via DepositManager, which pulls USDC from LP wallets straight to Capital Wallet and mints PLUSD 1:1.
+
+## Scope deviations vs. originator source spec
+
+The v2.3 design deliberately diverges from Pipeline_MVP_Technical_Spec_v0_3_8.docx on a few points, all confirmed with the originator:
+
+| Source-spec item | v2.3 decision | Rationale |
+|---|---|---|
+| Partial fills on WithdrawalQueue | **Dropped.** WQ uses full-amount `fundRequest` only. | Simplification per v2.0 S2. |
+| `cancelWithdrawal(queue_id)` by LP | **Not in MVP.** Queue is one-way once submitted. | Product scope for MVP. |
+| Backend FIFO queue for over-rate-limit deposits | **Dropped.** Over-cap deposit reverts at the contract; LP retries later. | No Bridge-side queue; rate limits enforced on-chain. |
+| Weekly USYC yield cron with Trustee signature | **Replaced with lazy mint on stake/unstake.** | Same two-party attestation model as repayment yield. |
+| Bridge cosigns loan disbursement | **Out of Bridge scope.** Disbursements are Trustee + Team cosigned directly on Capital Wallet (custodian MPC), no Bridge flow. | Separation of duty — Bridge is never in the disbursement signing path. |
+| Bridge manages USDC↔USYC rebalancing | **Out of Bridge scope.** Custodian MPC policy engine + Trustee manage the band. | Custodian abstraction (see 2026-04-16 decisions). |
+
+---
+
+## Part 1 — Service Business Logic
+
+Five core flows, one monitoring concern. Each flow: trigger → validation → action → on-chain effect.
+
+### Flow 1: Deposit Observation (no Bridge action required)
+
+```
+LP calls                       DepositManager pulls USDC        PLUSD.mintForDeposit
+DepositManager.deposit  ─────► LP → Capital Wallet     ──────►  mints 1:1 to LP
+(one atomic tx)                                                  cumulativeLPDeposits++
+                                                                       │
+                                                                       ▼
+                                                       Bridge indexes events
+                                                       (reconciliation only)
+```
+
+Deposits are entirely on-chain and user-driven. Bridge is not a signer, not a gate, not in the critical path. The DepositManager contract enforces whitelist, reserve invariant, hard supply cap, and all rate limits. Any revert rolls the whole tx back atomically.
+
+**Bridge's job on deposits:**
+
+1. Index the events below and persist to the `deposit` table.
+2. Reconcile: the sum of `DepositManager.Deposited.amount` events must equal `PLUSD.cumulativeLPDeposits()`. Any drift is a bug or indexer lag — alert ops.
+3. Maintain per-LP deposit address history for the custodian's withdrawal-destination-matching policy (R2 in the spec).
+4. Expose deposit history + status via the LP-facing API.
+
+**Events to index (deposit-relevant):**
+
+| Contract | Event | Why |
+|---|---|---|
+| DepositManager | `Deposited(lp, amount)` | Primary source of truth for deposits |
+| USDC | `Transfer(lp, capitalWallet, amount)` | Cross-check — custodian reconciliation |
+| PLUSD | `Transfer(0x0, lp, amount)` (mint path) | Cross-check — contract mint confirmation |
+
+**Inflow classification (for Capital Wallet USDC receipts).** Bridge still classifies incoming USDC to Capital Wallet, because not every transfer is a deposit. Used for reconciliation and yield-flow triggers:
+
+| Sender | Classification | Action |
+|---|---|---|
+| DepositManager | Deposit settlement | Already handled by `Deposited` event |
+| On-ramp settlement address | Repayment inflow | Trigger yield flow (Flow 3) |
+| USYC redemption sink | Rebalance inflow | Update balance tracking only |
+| Unknown | Quarantine | Alert ops, do not auto-process |
+
+**Rate-limit surfaces for the frontend.** The deposit UI needs live rate-limit state to show deposit caps before the LP submits. Bridge exposes the on-chain PLUSD state (`maxPerWindow`, `maxPerLPPerWindow`, current window usage, per-LP current usage) via read-only API — it does not gate deposits itself.
+
+**No mint queue, no attestation signing, no reissuance.** Everything that was Bridge's responsibility on deposits in v2.2 is gone in v2.3.
+
+### Flow 2: Withdrawal Queue Funding
+
+```
+WithdrawalRequested event          Bridge checks queue head      Bridge calls on-chain
+(from WQ contract)    ──────────►  whitelist, balance    ──────► WQ.fundRequest(queueId)
+                                                                      │
+                                   LP de-whitelisted?                 ▼
+                                   ──► skipSanctionedHead()    USDC: Capital Wallet → WQ
+                                                               via pre-approved allowance
+```
+
+**Trigger.** `WithdrawalRequested(queueId, requester, amount)` event from WithdrawalQueue contract.
+
+**Decision logic at queue head (`nextToFund`):**
+
+```
+read nextToFund from WQ
+  │
+  ├─ isAllowed(requester)?         ← on-chain check, no freshness
+  │    ├─ YES
+  │    │    ├─ screening fresh?    ← Bridge-side check via Chainalysis
+  │    │    │    ├─ YES → check Capital Wallet USDC balance
+  │    │    │    │          ├─ sufficient → fundRequest(queueId)
+  │    │    │    │          └─ insufficient → request USYC redeem, retry after
+  │    │    │    │
+  │    │    │    └─ STALE → refreshScreening(lp, newTs) first, then fund
+  │    │    │               if Chainalysis returns flagged → revokeAccess, then skip
+  │    │    │
+  │    │    └─ (screening stale AND Chainalysis unreachable)
+  │    │         → alert ops, do NOT fund, do NOT skip
+  │    │           this is a stuck-head state requiring manual intervention
+  │    │
+  │    └─ NO → skipSanctionedHead()
+  │
+  └─ loop: after funding/skip, re-check nextToFund
+```
+
+**Stale-screening-at-head problem.** On-chain `isAllowed` does not check freshness — only `isAllowedForMint` does. `skipSanctionedHead` requires `!isAllowed`, so it reverts on a stale-but-not-revoked LP. Bridge's resolution path: call `refreshScreening(lp, newApprovedAt)` to update the timestamp, then proceed with `fundRequest`. If re-screening returns a sanction flag, Bridge calls `revokeAccess` first, then `skipSanctionedHead`. If Chainalysis is unreachable, the head is stuck — alert ops for manual `adminRelease(Pending)` via the ADMIN Safe.
+
+**USYC liquidity management.** Per spec §15, USYC auto-allocation of idle capital is managed by the **custodian's MPC policy engine**, not by Bridge. Bridge's responsibility is limited to: when funding a withdrawal and Capital Wallet USDC balance is insufficient, Bridge **requests** a USYC → USDC redemption through the MPC custody API. The custodian executes. Bridge does not autonomously manage the USDC/USYC ratio — it only reacts to insufficient balance at funding time.
+
+**Funding mechanics.** Bridge calls `WQ.fundRequest(queueId)`. The WQ contract pulls USDC from Capital Wallet via `usdc.transferFrom(capitalWallet, WQ, amount)` — a pre-existing allowance. Bridge doesn't move USDC itself; it triggers the pull.
+
+### Flow 3: Repayment Yield Distribution
+
+```
+Repayment USDC inflow       Bridge proposes         Custodian co-signs      Bridge submits
+detected on Capital Wallet  YieldAttestation  ────► (EIP-1271)       ────►  yieldMint(att, bSig, cSig)
+(classified from Flow 1)    (EIP-712 sig)                                   PLUSD verifies both
+```
+
+**On-chain reality (v2.3).** `PLUSD.yieldMint(att, bridgeSig, custodianSig)` is `restricted(YIELD_MINTER)` **and** verifies two EIP-712 signatures on-chain: Bridge's ECDSA signature over the `YieldAttestation` struct, and the custodian's EIP-1271 `isValidSignature` return. All three must pass — the role gate on the caller, the Bridge signature, and the custodian signature. The destination is also constrained to `sPLUSD vault` or `Treasury`. Three independent controls mean compromising any single party mints zero PLUSD.
+
+**Attestation struct:**
+
+```
+YieldAttestation {
+  bytes32 repaymentRef;   // keccak256(abi.encode(chainId, repaymentTxHash, destinationTag))
+                          // destinationTag = "vault" or "treasury" (bytes32)
+                          // — deterministic, one PER DESTINATION per repayment
+  address destination;    // vault OR treasury
+  uint256 amount;         // minted amount in PLUSD's 6 decimals
+  uint64  deadline;       // Unix timestamp, attestation expiry
+  uint256 salt;           // random entropy — allows reissuance if sig lost in transit
+}
+```
+
+The encoding must match smart-contracts.md byte-for-byte (`abi.encode` is load-bearing — Bridge signing code must use the same encoding the contract verifies). The EIP-1271 magic value the contract checks from the custodian signer is `0x1626ba7e` — custodian stubs must return exactly this on valid sigs.
+
+**Replay protection.** PLUSD maintains `usedRepaymentRefs` mapping. Each attestation is valid exactly once (first `yieldMint` call consumes the ref). Vault and treasury legs are built with **distinct refs** per destination: `keccak256(chainId, repaymentTxHash, "vault")` and `keccak256(chainId, repaymentTxHash, "treasury")`. Both legs can be submitted independently and retry cleanly.
+
+**Reissuance after a failed submission.** The attestation's `repaymentRef` stays the same (the contract hasn't consumed it yet — the tx reverted). Bridge requests a fresh Bridge sig + custodian co-sig on the same struct with a new `salt` and `deadline`, and resubmits. If the contract already consumed the ref (e.g. Bridge's view of the world was wrong), the whole distribution is over for that destination.
+
+**Workflow:**
+
+1. **Detect.** Bridge indexes USDC inflow to Capital Wallet; classifier (Flow 1 table) identifies it as a repayment.
+2. **Reconcile.** Bridge matches the inflow to a loan via the on-ramp metadata (out-of-band mapping — not on-chain).
+3. **Propose.** Trustee provides final split amounts for vault and treasury via `POST /v1/trustee/repayments/{id}/approve`. (Waterfall computation is not in MVP scope — Trustee computes off-chain; Bridge executes.)
+4. **Bridge signs.** Signer service constructs the two `YieldAttestation` structs (one for vault, one for treasury) and signs each with `bridgeYieldAttestor` key.
+5. **Custodian co-signs.** Bridge posts the structs + Bridge sigs to the custodian's Co-Signer / Policy Engine. Custodian independently verifies:
+   - USDC inflow actually arrived at Capital Wallet (custodian's own ledger)
+   - Amount matches the attestation
+   - Destination is an approved system address (vault / treasury)
+   The custodian's EIP-1271 contract returns a second signature.
+6. **Submit.** Bridge calls `PLUSD.yieldMint(att, bridgeSig, custodianSig)` via the tx outbox. PLUSD verifies both sigs, checks reserve invariant, checks hard supply cap, mints to destination.
+7. **Confirm.** On confirmed receipt, mark the `yield_attestation` record as `confirmed` and advance any dependent state.
+
+**Partial-failure recovery.** Vault and treasury are two separate `yieldMint` calls. If the first succeeds and the second reverts, Bridge retries the failed leg with the same attestation (still valid — not yet replayed). If the attestation's `deadline` has passed, Bridge requests a fresh custodian co-sig with a new `salt` and resubmits.
+
+**Custodian integration surface (implementation detail):**
+
+- API endpoint for co-sign request (Fireblocks Co-Signer Callback Handler, BitGo webhook, or equivalent).
+- Timeout handling: if custodian does not respond within N minutes, alert ops; Bridge cannot submit without both sigs.
+- Retry semantics: idempotent on `repaymentRef`.
+
+**Waterfall data source.** Not in MVP scope. Trustee provides final amounts. Post-MVP the spec will define a `loan_terms` store for on-chain-anchored fee rates.
+
+### Flow 4: USYC Yield Distribution (lazy, stake/unstake-triggered)
+
+```
+Stake or unstake        Bridge reads USYC NAV    Bridge + custodian     Bridge submits
+action detected   ────► from Hashnote API  ────► co-sign YieldAttest ──► yieldMint × 2
+                        computes delta           (same as Flow 3)         advance baseline
+```
+
+USYC grows in price; sPLUSD share price only moves when `yieldMint` runs. To keep the share price current without a cron, yield is minted **lazily** on every stake/unstake action. Same two-party attestation model as Flow 3.
+
+**Trigger.** `sPLUSD.Deposit` or `sPLUSD.Withdraw` event indexed. Before processing the user action downstream, Bridge checks whether a yield mint is due.
+
+**Steps:**
+
+1. Read current USYC NAV from Hashnote API (`https://usyc.hashnote.com/api/price`; historical: `/api/price-reports`).
+2. Compute `yield_delta = current_NAV - last_minted_NAV` (USDC terms, applied to Capital Wallet USYC holdings).
+3. If `delta <= 0`: skip. No mint needed.
+4. If `delta > 0`: apply split ratio (governance-controlled parameter, read from chain or config store). Build two `YieldAttestation` structs (vault + treasury). Refs are `keccak256("usyc-yield", chainId, navTimestamp, "vault")` and `keccak256("usyc-yield", chainId, navTimestamp, "treasury")` — same per-destination scoping pattern as Flow 3.
+5. Get Bridge sig + custodian co-sig (same integration path as Flow 3).
+6. Submit both `yieldMint` calls via tx outbox.
+7. **Only after both txs confirmed:** advance `last_minted_NAV` baseline in the `nav_snapshot` table.
+
+**Partial-failure recovery.** Same as Flow 3. If one leg fails, retry with fresh custodian co-sig. Until both legs confirm, baseline does not advance. Next stake/unstake trigger tries again against the unchanged baseline — idempotent.
+
+**Continuous tracking for UI.** Between mints, Bridge polls USYC NAV (e.g. every minute) and exposes accrued-but-undistributed yield via read API for the dashboard. This is display-only — not an on-chain signal.
+
+### Flow 5: Whitelist Management
+
+**Trigger.** Sumsub webhook (KYC approval) or admin action.
+
+Bridge verifies Chainalysis address screening is clean and current, then calls `WhitelistRegistry.setAccess(lp, approvedAt)` on-chain. LP record stored locally with KYC metadata (approval date, screening expiry, provider ref).
+
+**Ongoing.** Bridge periodically re-checks Chainalysis screening freshness for all whitelisted LPs (batch job, configurable interval). Expired screening (> 90 days) triggers `refreshScreening(lp, newTs)` on-chain if re-screening passes, or `revokeAccess(lp)` if flagged.
+
+### Reserve Reconciliation (the full backing invariant)
+
+PLUSD's on-chain `reserveHealth()` view checks internal consistency — `totalSupply ≤ cumulativeLPDeposits + cumulativeYieldMinted − cumulativeLPBurns`. That is necessary but not sufficient for an LP: it proves the contract's own ledger is balanced, not that custodian reserves actually back the supply.
+
+Bridge publishes a **fuller backing invariant** off-chain, per source spec §5.6:
+
+```
+PLUSD totalSupply  ==  USDC in Capital Wallet
+                    +  USYC NAV in Capital Wallet
+                    +  USDC out on loans (deployed senior principal, not yet repaid)
+                    +  USDC in transit (on-ramp leg, either direction)
+```
+
+**Inputs Bridge assembles:**
+
+| Term | Source |
+|---|---|
+| `USDC in Capital Wallet` | Custodian API (current balance) |
+| `USYC NAV in Capital Wallet` | Hashnote NAV API × Capital Wallet USYC holdings (custodian API) |
+| `USDC out on loans` | Sum of active `loan_mirror` entries where `status ∈ {Active, Watchlist, Default-pending}` at `principal` |
+| `USDC in transit` | On-ramp / off-ramp queue state (off-chain) |
+| `PLUSD totalSupply` | PLUSD `totalSupply()` on-chain |
+
+**Evaluation cadence.** After every: deposit event, withdrawal claim, yield mint, loan disbursement, repayment inflow.
+
+**Publishing.** Result exposed via `GET /v1/protocol/reserve-reconciliation` and on the protocol dashboard with a status indicator:
+
+| Drift | Status | Action |
+|---|---|---|
+| `< 0.01%` | **Green** | Normal — no action |
+| `0.01% – 1%` | **Amber** | Alert on-call channel + Trustee. Investigate before next sensitive operation. |
+| `> 1%` | **Red** | Page on-call + Trustee. Consider pausing `DepositManager` pending investigation. Trip Guardian if sustained. |
+
+The watchdog (security.md Layer 3) consumes this feed. Divergence that cannot be explained within minutes is a Guardian-trip recommendation.
+
+**Intentional gap.** The contract-level invariant (`reserveHealth()`) and this full backing invariant are **different invariants**. Both must hold. The former is self-consistency; the latter is real backing. A contract bug or counter desync shows up in the former; a custodian discrepancy or missing loan tracking shows up in the latter.
+
+### Monitoring (cross-cutting)
+
+| What | Source | Action |
+|---|---|---|
+| All contract events | QuickNode indexer | Persist, reconcile, alert on anomalies |
+| Reserve-invariant headroom | PLUSD `reserveHealth()` view | Alert when headroom < threshold — hard cap approach |
+| Capital Wallet balance | On-chain USDC + USYC | Dashboard data, funding-time balance check |
+| Rate-limit window state | PLUSD on-chain view (`maxPerWindow`, `windowMinted`, `maxPerLPPerWindow`, `lpWindowMinted`) | Read-only surface for deposit UI |
+| Commodity prices | Platts/Argus API | Alert Trustee on CCR threshold crossing |
+| Payout > $1M | Self (pre-fundRequest) | Alert to ops channel |
+| On-chain invariants | WQ `invariantCheck()`, PLUSD `isFullyOperational()`, `reserveHealth()` | Alert on drift |
+| Gas price | Network | Defer non-urgent txs above gas cap (see §Gas Strategy) |
+| DepositManager events vs. PLUSD counters | Reconciliation job | Alert on drift between `Deposited` event sum and `cumulativeLPDeposits()` |
+
+---
+
+## Part 2 — Database & Data Storage Pipeline
+
+### Event Indexer
+
+**Stack.** QuickNode Ethereum node, custom indexer service.
+
+**Finality model.** Use the `finalized` block tag (Ethereum PoS), not a block-depth heuristic. State-changing actions (yield mints, withdrawal funding, whitelist updates) operate on finalized events only. Unfinalized events populate dashboards with a "pending confirmation" label.
+
+**Indexed events (minimum set):**
+
+| Contract | Event | Why |
+|---|---|---|
+| DepositManager | `Deposited(lp, amount)` | Deposit detection (primary source) |
+| USDC | `Transfer(*, capitalWallet, amount)` | Repayment detection, deposit cross-check, inflow classification |
+| USDC | `Transfer(capitalWallet, *, amount)` | Outflow tracking, reconciliation |
+| PLUSD | `Transfer(0x0, lp, amount)` | Mint confirmation (cross-check vs Deposited) |
+| WithdrawalQueue | `WithdrawalRequested` | Flow 2 trigger |
+| WithdrawalQueue | `WithdrawalFunded / WithdrawalClaimed / WithdrawalSanctionedSkip / WithdrawalAdminReleased` | Status tracking |
+| PLUSD | `RateLimitsChanged / MaxTotalSupplyChanged` | Update local cache |
+| PLUSD | `YieldAttestorsChanged` | Audit trail for key rotation |
+| WhitelistRegistry | `LPApproved / ScreeningRefreshed / LPRevoked` | Whitelist sync |
+| LoanRegistry | `LoanMinted / LoanUpdated / LoanClosed` | Local loan book mirror |
+| sPLUSD | `Deposit / Withdraw` | Trigger lazy USYC yield (Flow 4) |
+| ShutdownController | `ShutdownEntered` | Halt all normal flows |
+| All pausable | `Paused() / Unpaused()` | Halt/resume flows |
+
+**Reorg handling.** Indexer tracks `finalized` vs `latest` separately. Handlers only process finalized events for state-changing actions (signing, funding). `latest` events used for real-time dashboard data with a "pending confirmation" label.
+
+### Data Model (logical entities)
+
+```
+┌─────────────────┐     ┌──────────────────┐
+│ lp               │     │ deposit           │
+├─────────────────┤     ├──────────────────┤
+│ address (PK)     │────<│ id (PK)           │  — mirrors DepositManager.Deposited
+│ kyc_status       │     │ lp_address (FK)   │    events. No attestation state —
+│ kyc_provider_ref │     │ tx_hash           │    deposits are atomic on-chain.
+│ screening_expiry │     │ amount            │
+│ whitelisted_at   │     │ block_number      │
+│ created_at       │     │ finalized         │
+│ updated_at       │     │ indexed_at        │
+└─────────────────┘     └──────────────────┘
+
+┌──────────────────────┐     ┌─────────────────────────┐
+│ withdrawal            │     │ yield_attestation        │
+├──────────────────────┤     ├─────────────────────────┤
+│ queue_id (PK)         │     │ id (PK)                  │
+│ lp_address            │     │ repayment_ref (unique)   │
+│ amount                │     │ destination              │
+│ status                │     │  (vault | treasury)      │
+│  (requested |         │     │ amount                   │
+│   funding |           │     │ deadline                 │
+│   funded |            │     │ salt                     │
+│   claimed |           │     │ bridge_sig               │
+│   sanctioned_skipped |│     │ custodian_sig            │
+│   admin_released)     │     │ status                   │
+│ requested_at          │     │  (pending_custodian |    │
+│ funded_at             │     │   co_signed |            │
+│ claimed_at            │     │   submitting |           │
+│ created_at            │     │   confirmed |            │
+└──────────────────────┘     │   failed | expired)      │
+                              │ distribution_id (FK)     │
+                              │ tx_hash (nullable)       │
+                              │ created_at               │
+                              └─────────────────────────┘
+
+┌──────────────────────┐     ┌──────────────────────┐
+│ yield_distribution    │     │ nav_snapshot          │
+├──────────────────────┤     ├──────────────────────┤
+│ id (PK)               │     │ id (PK)               │
+│ type                  │     │ usyc_nav              │
+│  (repayment | usyc)   │     │ usyc_holdings         │
+│ loan_id (nullable)    │     │ yield_delta           │
+│ vault_amount          │     │ captured_at           │
+│ treasury_amount       │     │ distribution_id (FK)  │
+│ status                │     │ is_baseline (bool)    │
+│  (pending_trustee |   │     └──────────────────────┘
+│   co_signing |        │
+│   submitting |        │     ┌──────────────────────┐
+│   partial |           │     │ loan_mirror           │
+│   confirmed |         │     ├──────────────────────┤
+│   failed)             │     │ loan_id (PK)          │
+│ created_at            │     │ originator            │
+└──────────────────────┘     │ borrower              │
+                              │ principal             │
+┌──────────────────────┐     │ commodity             │
+│ loan_terms (post-MVP) │     │ status                │
+├──────────────────────┤     │ ccr_bps               │
+│ loan_id (PK, FK)      │     │ maturity              │
+│ mgmt_fee_rate_bps     │     │ originated_at         │
+│ coupon_rate_bps       │     │ closed_at             │
+│ perf_fee_rate_bps     │     │ closure_reason        │
+│ oet_rate_bps          │     │ last_synced_block     │
+│ doc_hash              │     └──────────────────────┘
+│ entered_by            │
+│ entered_at            │
+└──────────────────────┘
+
+┌──────────────────────┐     ┌──────────────────────┐
+│ indexed_event         │     │ tx_outbox             │
+├──────────────────────┤     ├──────────────────────┤
+│ id (PK)               │     │ intent_id (PK)        │
+│ contract_address       │     │ method                │
+│ event_name             │     │ target_contract       │
+│ tx_hash                │     │ calldata              │
+│ log_index              │     │ nonce (nullable)      │
+│ block_number           │     │ tx_hash (nullable)    │
+│ block_hash             │     │ status                │
+│ finalized              │     │  (pending | submitted │
+│ args (JSONB)           │     │   | confirmed |       │
+│ processed              │     │   | reverted |        │
+│ indexed_at             │     │   | replaced)         │
+└──────────────────────┘     │ gas_price             │
+                              │ retries               │
+                              │ created_at            │
+                              │ confirmed_at          │
+                              └──────────────────────┘
+```
+
+**Removed from v2:** `mint_attestation`, `mint_queue`. Deposits are atomic on-chain; there is nothing to queue or sign on the deposit side.
+
+### Transaction Outbox
+
+The write-side reliability problem: Bridge must not lose transactions between decision and on-chain confirmation. The `tx_outbox` table implements the **outbox pattern**:
+
+1. Business logic writes intent to `tx_outbox` with `status=pending` and a content-derived `intent_id` (idempotent).
+2. Tx Submitter picks up pending intents, assigns nonce, submits to network, updates `status=submitted` + `tx_hash`.
+3. Confirmation watcher matches on-chain receipts to outbox rows, updates `status=confirmed` or `status=reverted`.
+4. On restart: submitter reconciles — checks `eth_getTransactionByHash` for all `submitted` rows, replays `pending` rows.
+
+All outbound transactions (`fundRequest`, `yieldMint`, `setAccess`, `refreshScreening`, `skipSanctionedHead`) go through the outbox. Nonce management is centralized — the submitter is the sole writer to the EOA's nonce space.
+
+Yield mint intents in the outbox carry the full `(YieldAttestation, bridgeSig, custodianSig)` payload in `calldata`. If a yield mint reverts (e.g. reserve-invariant tightening, hard cap breach), the failure is terminal — a new attestation with a fresh `salt` + fresh custodian co-sig is required.
+
+### Data Pipeline
+
+```
+QuickNode node
+      │
+      ├─ latest blocks  ──► real-time dashboard data (unfinalized)
+      │
+      ├─ finalized blocks ──► indexed_event table
+      │                              │
+      │                        Reorg-safe (finalized = no reorgs)
+      │
+      ▼
+ Event Router ────┬──────┬──────┬──────┬──────┬──────►  per event type
+                  │      │      │      │      │
+                  ▼      ▼      ▼      ▼      ▼
+            Deposit   WQ     Yield   sPLUSD  Whitelist
+            Handler  Handler Handler Handler  Handler
+            (observe) (act)  (act)   (trigger)(act)
+               │       │       │        │      │
+               ▼       ▼       ▼        ▼      ▼
+            deposit  withdrawal yield_   ─    lp table
+            table    table      *        │
+                                         ▼
+                                  triggers Flow 4
+                                  (yield mint)
+                                        │
+                                        ▼
+                                   tx_outbox ──► Tx Submitter ──► Ethereum
+```
+
+**Handler responsibilities (v2.3):**
+- **Deposit Handler:** pure observer, no tx output. Reconciles `DepositManager.Deposited` vs `PLUSD.cumulativeLPDeposits()`.
+- **WQ Handler:** funds the queue head, handles stale-screening path, writes `fundRequest` / `skipSanctionedHead` / `refreshScreening` / `revokeAccess` intents to tx_outbox.
+- **Yield Handler:** builds `YieldAttestation`, orchestrates Bridge sig → custodian co-sig → tx_outbox submission. Used by both Flow 3 (repayment) and Flow 4 (USYC).
+- **sPLUSD Handler:** observes stake/unstake events, triggers Yield Handler's USYC flow if NAV delta > 0.
+- **Whitelist Handler:** processes Sumsub webhooks, writes `setAccess` / `refreshScreening` / `revokeAccess` intents.
+
+**Delivery guarantees.** At-least-once processing. Every handler is idempotent (keyed on `tx_hash + log_index`). The indexer persists the last finalized block number and resumes from there on restart.
+
+---
+
+## Part 3 — API Endpoints
+
+### 3A. LP-Facing (consumed by Pipeline App frontend)
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/v1/lp/{address}/status` | LP profile: whitelist status, screening expiry, KYC status |
+| `GET` | `/v1/lp/{address}/deposits` | Deposit history mirrored from `DepositManager.Deposited` events |
+| `GET` | `/v1/lp/{address}/withdrawals` | Withdrawal history with queue position and status |
+| `GET` | `/v1/queue/depth` | WQ stats: pending count, funded count, total escrowed, estimated wait |
+| `GET` | `/v1/vault/stats` | sPLUSD share price, total assets, APY, accrued-undistributed yield |
+| `GET` | `/v1/protocol/status` | Operational: paused contracts, shutdown state, rate-limit window |
+| `GET` | `/v1/protocol/limits` | Current `maxPerWindow`, `maxPerLPPerWindow`, `maxTotalSupply`, window utilization, per-LP utilization — for deposit UI to display caps before the LP submits |
+| `GET` | `/v1/protocol/reserve-health` | `reserveHealth()` view: backing, supply, headroom — for dashboard |
+
+### 3B. Trustee-Facing (consumed by Trustee tooling)
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/v1/trustee/repayments/pending` | Detected repayments awaiting Trustee split decision |
+| `POST` | `/v1/trustee/repayments/{id}/approve` | Submit Trustee's split amounts (vault / treasury) → triggers Bridge to build attestations and request custodian co-sig |
+| `GET` | `/v1/trustee/yield/usyc/status` | Current NAV baseline, current NAV, accrued delta, current split ratio |
+| `GET` | `/v1/trustee/loans` | Loan book mirror (post-MVP: + loan terms) |
+| `GET` | `/v1/trustee/alerts` | Active alerts: CCR crossings, payment delays, screening expirations |
+
+### 3C. Admin / Ops
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/v1/admin/yield-attestations` | Pending yield attestations: status, co-sig state, stuck items |
+| `POST` | `/v1/admin/yield-attestation/{id}/reissue` | Re-request custodian co-sig with fresh `salt` (deadline expired or sig lost) |
+| `GET` | `/v1/admin/reconciliation` | Cross-check: `DepositManager.Deposited` sum vs `PLUSD.cumulativeLPDeposits()`; WQ state vs DB; etc. |
+| `GET` | `/v1/admin/capital-wallet/balance` | USDC + USYC breakdown |
+| `GET` | `/v1/admin/tx-outbox` | Outbox status: pending, submitted, stuck transactions |
+| `POST` | `/v1/admin/tx-outbox/{id}/retry` | Manually retry a failed/stuck transaction |
+| `GET` | `/v1/admin/health` | Service health: indexer lag, last finalized block, queue depths, custodian co-signer reachability |
+
+### 3D. Dashboard Views
+
+Read-only aggregations, exposed as SQL views or dedicated read endpoints.
+
+| View | Content |
+|---|---|
+| `v_daily_deposits` | Per-day: count, total amount, avg amount, rate-limit utilization % |
+| `v_daily_withdrawals` | Per-day: requested/funded/claimed, avg time-to-fund, avg time-to-claim |
+| `v_yield_history` | Per-distribution: type, vault amount, treasury amount, NAV ref, date |
+| `v_lp_positions` | Per-LP: deposited, withdrawn, net position |
+| `v_loan_book` | Active loans, status breakdown, total principal outstanding |
+| `v_yield_attestation_stats` | Time-to-cosign distribution, custodian error rate, expired-sig count |
+| `v_capital_wallet_history` | Daily USDC/USYC balances, inflows, outflows |
+| `v_tx_outbox_stats` | Tx success rate, avg confirmation time, gas spend |
+| `v_reserve_health` | Time series of backing, supply, headroom |
+
+---
+
+## Part 4 — Service Architecture
+
+### Decomposition
+
+Bridge is described as a "single backend" for simplicity, but should be deployed as **separate internal services** sharing a Postgres database, communicating via internal RPC (gRPC or message queue). No service is internet-facing except the API Gateway.
+
+```
+                    ┌──────────────────────────────────────────────┐
+                    │              Bridge Cluster                   │
+                    │                                              │
+ QuickNode ────────►│  ┌─────────────┐    ┌──────────────────┐    │
+                    │  │ Indexer      │───►│ Postgres          │    │
+                    │  │ (no keys)   │    │ (shared state)    │    │
+                    │  └─────────────┘    └──────┬───────────┘    │
+                    │                            │                 │
+                    │  ┌─────────────┐    ┌──────┴───────────┐    │
+                    │  │ Orchestrator│───►│ Tx Outbox         │    │
+                    │  │ (no keys)   │    └──────┬───────────┘    │
+                    │  └─────────────┘           │                 │
+                    │                     ┌──────┴───────────┐    │
+                    │                     │ Tx Submitter      │────►  Ethereum
+                    │                     │ (holds Bridge EOA)│    │
+                    │                     └──────────────────┘    │
+                    │                                              │
+                    │  ┌─────────────┐                            │
+                    │  │ Signer      │  (holds bridgeYieldAttestor│
+                    │  │ (HSM-backed)│   key — yield attestations │
+                    │  └─────────────┘   only; no internet egress)│
+                    │                                              │
+                    │  ┌─────────────┐                            │
+ Frontend ────────►│  │ API Gateway │  (reads DB, proxies to     │
+ Trustee UI ──────►│  │ (no keys)   │   Orchestrator)            │
+ Admin ───────────►│  └─────────────┘                            │
+                    │                                              │
+                    │  ┌────────────────────┐                     │
+                    │  │ Custodian Co-Signer│────────────────────►  Custodian API
+                    │  │ Client             │   (EIP-1271 co-sig) │  (yield only)
+                    │  └────────────────────┘                     │
+                    └──────────────────────────────────────────────┘
+```
+
+**Blast radius per compromise:**
+
+| Service compromised | Can do | Cannot do |
+|---|---|---|
+| Indexer | Poison event data in DB | Sign attestations, submit txs, mint PLUSD |
+| Orchestrator | Queue malicious yield-mint intents | Obtain custodian co-sig (so no yield mint possible) |
+| Tx Submitter | Front-run tx queue, submit arbitrary txs | Forge Bridge yield sig; forge custodian sig; submit anything without EOA roles |
+| Signer | Produce Bridge yield sigs without custodian co-sig | Mint PLUSD alone — still needs custodian EIP-1271 sig + YIELD_MINTER caller role |
+| API Gateway | Leak read data, inject bad Trustee approvals | Sign, submit, or index |
+| Custodian alone (external) | Produce a custodian sig | Mint PLUSD alone — still needs Bridge ECDSA sig + YIELD_MINTER caller role |
+
+### Gas Strategy
+
+| Priority | Transactions | Gas policy |
+|---|---|---|
+| Critical | `fundRequest`, `skipSanctionedHead` | Submit up to 2× market gas. Alert if base fee > configurable cap. |
+| Normal | `yieldMint`, `setAccess`, `refreshScreening` | Submit at market gas. Defer if base fee > cap. Retry next block. |
+| Deferrable | Batch whitelist updates | Wait for gas < threshold. No SLO. |
+
+Gas cap, max retry count, and escalation thresholds are runtime config. Tx Submitter implements EIP-1559 fee estimation with configurable priority fee bounds. Stuck transactions (not mined after N blocks) are replaced with higher gas via the outbox.
+
+### Contract Upgrade Handling
+
+UUPS proxies mean the implementation behind a contract can change. If `PLUSD_Impl_v2` adds a new event or changes ABI, the indexer's parsing breaks. Strategy:
+
+1. Bridge pins ABI per contract address in its config.
+2. On upgrade (detected via `Upgraded(implementation)` event from the proxy), Bridge alerts ops.
+3. Ops deploys updated Bridge with new ABI config. This is a coordinated deploy alongside the 48h upgrade timelock window — there is time to prepare.
+4. The indexer tolerates unknown events (logs them raw, skips handler routing) rather than crashing.
+
+### Key Rotation (yield-attestor keys)
+
+Two yield-attestor addresses are registered on PLUSD: `bridgeYieldAttestor` (Bridge's signing EOA) and `custodianYieldAttestor` (custodian's EIP-1271 contract). Both are rotatable via `PLUSD.proposeYieldAttestors(newBridge, newCustodian)` + 48h timelock.
+
+No scheduled rotation. Rotation is an emergency response to key compromise. During the 48h window both old and new addresses are registered at different times — Bridge's orchestration just continues to use whatever is currently active, and the custodian side operates analogously. Outstanding yield attestations signed by the old Bridge key remain valid until the execute-step lands on-chain; Bridge re-issues any unconfirmed attestation with the new key after rotation.
+
+---
+
+## Part 5 — Operational Concerns
+
+### Observability
+
+Structured JSON logging with correlation IDs spanning: on-chain event → indexer → handler → outbox → tx confirmation. Every flow produces metrics:
+
+| Metric | Type | Granularity |
+|---|---|---|
+| `withdrawal_time_to_fund` | Histogram | Per withdrawal |
+| `yield_attestation_cosign_latency` | Histogram | Per attestation (Bridge-signed → custodian-cosigned) |
+| `yield_distribution_latency` | Histogram | Per distribution (event → confirmed on-chain) |
+| `indexer_lag_blocks` | Gauge | Continuous |
+| `reserve_health_headroom` | Gauge | Continuous (from PLUSD `reserveHealth()` view) |
+| `deposit_counter_drift` | Gauge | Continuous (Deposited sum − cumulativeLPDeposits) |
+| `tx_outbox_pending` | Gauge | Continuous |
+| `tx_submission_errors` | Counter | Per tx type |
+| `gas_spend_wei` | Counter | Per tx type |
+| `custodian_cosign_errors` | Counter | Per error class |
+
+Alerting tiers:
+
+| Tier | Condition | Channel |
+|---|---|---|
+| Page | Indexer lag > 5 min, outbox stuck > 30 min, signer unreachable, custodian co-signer unreachable, shutdown detected, `deposit_counter_drift` ≠ 0, `reserve_health_headroom` below tight threshold | PagerDuty |
+| Ticket | Failed tx after 3 retries, gas above cap for > 1h, Chainalysis API down, custodian co-sign errors > threshold | Slack + ticket |
+| Info | Payout > $1M, attestation expired unsubmitted, screening refresh batch complete | Slack |
+
+### SLOs
+
+| Metric | Target | Measurement |
+|---|---|---|
+| Deposit confirmation → API-visible | p50 < 2 min, p99 < 5 min | From finalized block to `/v1/lp/{addr}/deposits` reflecting it |
+| Withdrawal → funded | p50 < 5 min, p99 < 30 min (excluding USYC redeem) | From event to on-chain confirmation |
+| Yield attestation co-sign round trip | p50 < 30s, p99 < 5 min | Bridge-signed → custodian-cosigned |
+| Indexer lag | < 2 finalized blocks | Continuous |
+| API availability | 99.9% | 30-day rolling |
+| Yield distribution | Confirmed within 24h of Trustee approval | Per distribution |
+
+### Secrets Management
+
+| Secret | Storage | Rotation |
+|---|---|---|
+| `bridgeYieldAttestor` private key | HSM (AWS CloudHSM or custodian's key vault) | Via on-chain `proposeYieldAttestors` + 48h timelock |
+| Bridge EOA private key (FUNDER / WHITELIST_ADMIN / YIELD_MINTER submitter) | HSM | Via role re-grant on AccessManager |
+| Custodian co-signer API credentials | Vault (HashiCorp / AWS Secrets Manager) | Per custodian policy |
+| Sumsub webhook HMAC key | Vault | On provider rotation |
+| Chainalysis API key | Vault | Quarterly |
+| Postgres credentials | Vault, rotated automatically | 90-day |
+| Internal service mTLS certs | Cert manager (auto-provisioned) | 30-day auto-renew |
+
+### Authentication
+
+| Surface | Auth model |
+|---|---|
+| LP-facing (`/v1/lp/*`, `/v1/queue/*`, `/v1/vault/*`, `/v1/protocol/*`) | EIP-4361 (Sign-In-With-Ethereum) session token, proving LP controls the address. Rate-limited. |
+| Trustee-facing (`/v1/trustee/*`) | mTLS + API key. Trustee tooling is a known internal client. |
+| Admin (`/v1/admin/*`) | SSO + WebAuthn (hardware key). IP allowlist. |
+| Internal services (Indexer ↔ Orchestrator ↔ Signer ↔ Submitter) | mTLS with auto-provisioned certs. No internet egress. |
+
+### Disaster Recovery
+
+**RPO/RTO targets.** RPO = 0 (Postgres streaming replication). RTO = 15 min (failover to hot standby).
+
+**Full reconstruction from chain.** The database is fully reconstructible from on-chain events. Procedure: replay all indexed events from contract deployment block through the handlers. This is the "break glass" for catastrophic DB corruption. Estimated time: hours (depends on block range). Deposits, yield mints, withdrawals are all derivable from events. Per-LP deposit address history for custodian-side destination matching is also derivable.
+
+**Indexer checkpoint.** Last finalized block number persisted in DB. On restart, resume from checkpoint. No risk of gap or double-processing (finalized events are stable, handlers are idempotent).
+
+### Test Strategy
+
+| Layer | Scope | Tool |
+|---|---|---|
+| Unit | Business logic (inflow classification, attestation construction, NAV baseline tracking, reconciliation math) | Standard test framework, mocked chain reads |
+| Integration | Full flow: event → handler → outbox → mock tx submission | Anvil fork with deployed contracts |
+| End-to-end | Deposit, withdraw, yield cycle against testnet deployment | Sepolia/Holesky with real contracts |
+| Chaos | Kill indexer mid-flow, kill signer mid-sign, RPC flap, DB failover | Custom harness |
+| Load | 10× expected peak: concurrent deposits, withdrawals, yield distributions | k6 or similar |
+
+### Schema Migrations
+
+Postgres migrations managed by a versioned migration tool (e.g. golang-migrate, Flyway, or framework-native). Breaking schema changes require a blue-green deploy plan. The tx_outbox and indexed_event tables are append-heavy — partition by month if volume warrants it.
+
+---
+
+## Decisions Required Before Implementation
+
+These are not open items — they are **blocking decisions** that affect the implementation architecture.
+
+| # | Decision | Options | Status | Owner |
+|---|---|---|---|---|
+| 1 | Deposit flow | Atomic DepositManager, no off-chain signer | Resolved (v2.3 spec) | — |
+| 2 | Yield approval | Two-party EIP-712 verified on-chain (Bridge + custodian EIP-1271) | Resolved (v2.3 spec) | — |
+| 3 | Waterfall computation / loan_terms store | Post-MVP. Trustee provides split amounts for MVP. | Deferred | Product + Trustee |
+| 4 | USDC/USYC movements | Managed by Trustee at custodian; Bridge only requests at funding time | Resolved | — |
+| 5 | Yield split parameter | On-chain governance parameter | Resolved (v2.3 spec M6) | — |
+| 6 | Custodian provider | Business decision | No architectural impact | Product |
+| 7 | USYC NAV source | Hashnote HTTP API | Resolved — `usyc.hashnote.com/api/price` | Dev |
+| 8 | Service decomposition | Split from day 1 | Resolved | Dev + Security |
+| 9 | Stale-screening resolution | Bridge auto-refreshes via Chainalysis; fallback alert ops | Resolved | Dev |
+| 10 | Yield-attestor key rotation | `proposeYieldAttestors` emergency-only, custodian manages lifecycle | Resolved | — |
+| 11 | `repaymentRef` for vault vs treasury | Resolved — distinct refs per destination: `keccak256(chainId, txHash, "vault")` and `keccak256(chainId, txHash, "treasury")` | Resolved | — |
+| 12 | Custodian co-sign timeout behaviour | Bridge enforces client-side timeout (default 30min) → mark attestation expired, alert ops, require fresh request with new `salt`. Fireblocks also supports server-side TTL via policy engine (belt-and-suspenders); BitGo needs client-side enforcement. Same Bridge policy regardless of custodian. | Resolved | — |
+| 13 | Initial cap parameters | `maxPerWindow`, `maxPerLPPerWindow`, `maxTotalSupply` launch values | **Open** — business decision informed by expected launch TVL and LP profile | Product + Risk |

--- a/docs/references/index.md
+++ b/docs/references/index.md
@@ -4,7 +4,10 @@ External references and source documents for the Pipeline protocol.
 
 ## Source Documents
 
-- [Initial Technical Spec (PRD)](../initial_spec.md) — Pipeline MVP Technical Specification v0.3.8 (source of truth for harness bootstrapping)
+- [Initial Technical Spec (PRD)](../initial_spec.md) — Pipeline MVP Technical Specification v0.3.8 (original source of truth)
+- [Smart Contract Design Spec v2.3](./smart-contracts.md) — Canonical smart contract specification; supersedes v0.3.8 contract descriptions
+- [Bridge Backend Spec](./backend.md) — Bridge service scope, flows, data model, and API surface (v2.3)
+- [Mint Trust Model](./security.md) — Threat analysis, peer-protocol survey, and layered defence rationale for the PLUSD mint path (v2.3)
 
 ## Vendor Documentation
 

--- a/docs/references/overview.html
+++ b/docs/references/overview.html
@@ -1,0 +1,1257 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Pipeline Smart Contracts — Architecture Diagrams</title>
+<style>
+  :root {
+    --bg: #0f1419;
+    --surface: #161b22;
+    --surface2: #1a2030;
+    --border: #2a313c;
+    --text: #e6edf3;
+    --text-muted: #8b949e;
+    /* 5-color semantic palette (Tokyo Night-inspired, desaturated) */
+    --slate: #7aa2f7;    /* titles, section labels, actors */
+    --sage:  #9ece6a;    /* off-chain, money, trustee */
+    --amber: #e0af68;    /* events, loan book, custodian policy */
+    --rose:  #f7768e;    /* bridge, emergency, alerts */
+    --lavender: #bb9af7; /* on-chain contracts, roles, AccessManager */
+    /* legacy aliases (kept so downstream CSS/SVG keep working) */
+    --accent: var(--slate);
+    --green: var(--sage);
+    --orange: var(--amber);
+    --red: var(--rose);
+    --purple: var(--lavender);
+    --pink: var(--lavender);
+    --cyan: var(--sage);
+  }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+    font-size: 14px;
+    line-height: 1.5;
+  }
+  .header {
+    padding: 24px 32px;
+    border-bottom: 1px solid var(--border);
+    background: var(--surface);
+  }
+  .header h1 { font-size: 20px; font-weight: 600; }
+  .header p { color: var(--text-muted); margin-top: 4px; font-size: 13px; }
+  .tabs {
+    display: flex;
+    gap: 0;
+    padding: 0 32px;
+    background: var(--surface);
+    border-bottom: 1px solid var(--border);
+    overflow-x: auto;
+  }
+  .tab {
+    padding: 12px 20px;
+    cursor: pointer;
+    color: var(--text-muted);
+    border-bottom: 2px solid transparent;
+    font-size: 13px;
+    font-weight: 500;
+    transition: all 0.15s;
+    user-select: none;
+    white-space: nowrap;
+  }
+  .tab:hover { color: var(--text); }
+  .tab.active { color: var(--accent); border-bottom-color: var(--accent); }
+  .diagram-container {
+    padding: 32px;
+    overflow-x: auto;
+  }
+  .diagram-container:not(.active) { display: none; }
+  .diagram-title {
+    font-size: 16px;
+    font-weight: 600;
+    margin-bottom: 6px;
+  }
+  .diagram-desc {
+    color: var(--text-muted);
+    font-size: 13px;
+    margin-bottom: 24px;
+    max-width: 1000px;
+  }
+  svg.seq, svg.ctx { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; }
+  .legend { display: flex; gap: 20px; margin-bottom: 20px; flex-wrap: wrap; }
+  .legend-item { display: flex; align-items: center; gap: 6px; font-size: 11px; color: var(--text-muted); }
+  .legend-line { width: 24px; height: 2px; }
+  .legend-line.solid { background: var(--text-muted); }
+  .legend-line.dashed { background: repeating-linear-gradient(90deg, var(--text-muted) 0 5px, transparent 5px 8px); }
+  .legend-line.event-l { background: var(--orange); }
+  .legend-line.mpc-l { background: var(--green); }
+  .legend-line.onchain-l { background: var(--purple); }
+  .legend-line.money-l { background: var(--green); height: 3px; }
+  .legend-line.red-l { background: var(--red); }
+  .legend-line.pink-l { background: var(--pink); }
+  .ctx-summary { max-width: 1100px; }
+  .ctx-table { border-collapse: collapse; width: 100%; font-size: 12px; }
+  .ctx-table th, .ctx-table td {
+    text-align: left;
+    padding: 8px 12px;
+    border-bottom: 1px solid var(--border);
+    color: var(--text-muted);
+  }
+  .ctx-table th { color: var(--text); font-weight: 600; background: var(--surface); }
+  .ctx-table td:first-child { color: var(--text); }
+  .tag { display: inline-block; padding: 1px 8px; border-radius: 10px; font-size: 10px; font-weight: 600; }
+  .tag.oc { background: rgba(187,154,247,0.15); color: var(--purple); }
+  .tag.ev { background: rgba(224,175,104,0.15); color: var(--orange); }
+  .tag.pk { background: rgba(187,154,247,0.15); color: var(--pink); }
+  .tag.rd { background: rgba(247,118,142,0.15); color: var(--red); }
+
+  .role-cards {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 12px;
+    margin-bottom: 24px;
+    max-width: 1100px;
+  }
+  .role-card {
+    background: var(--surface2);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 14px 16px;
+  }
+  .role-card h4 {
+    font-size: 13px;
+    font-weight: 700;
+    margin-bottom: 6px;
+  }
+  .role-card p {
+    font-size: 12px;
+    color: var(--text-muted);
+    line-height: 1.55;
+  }
+  .tbl-h {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text);
+    margin: 20px 0 8px;
+  }
+  .tbl-h .t-code {
+    color: var(--purple);
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 12px;
+    background: rgba(187,154,247,0.08);
+    padding: 2px 8px;
+    border-radius: 4px;
+    margin-left: 4px;
+  }
+  .role-table {
+    border-collapse: collapse;
+    width: 100%;
+    max-width: 1100px;
+    font-size: 12px;
+    margin-bottom: 6px;
+  }
+  .role-table th, .role-table td {
+    text-align: left;
+    padding: 8px 12px;
+    border-bottom: 1px solid var(--border);
+    color: var(--text-muted);
+    vertical-align: top;
+  }
+  .role-table th {
+    color: var(--text);
+    font-weight: 600;
+    background: var(--surface);
+    border-bottom: 1px solid var(--border);
+  }
+  .role-table td code {
+    color: var(--text);
+    font-size: 11px;
+    background: var(--surface);
+    padding: 1px 6px;
+    border-radius: 3px;
+  }
+  .role-pill {
+    display: inline-block;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 10px;
+    font-weight: 700;
+    padding: 2px 8px;
+    border-radius: 10px;
+    background: rgba(187,154,247,0.15);
+    color: var(--pink);
+    white-space: nowrap;
+  }
+  code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 11px;
+    color: var(--text);
+    background: var(--surface);
+    padding: 1px 5px;
+    border-radius: 3px;
+  }
+</style>
+</style>
+</head>
+<body>
+
+<div class="header">
+  <h1>Pipeline Smart Contracts — Architecture Diagrams</h1>
+  <p>System context, governance, and canonical interaction sequences.</p>
+</div>
+
+<div class="tabs" id="tabBar">
+  <div class="tab active" onclick="switchTab('system-context')">System Context</div>
+  <div class="tab" onclick="switchTab('role-topology')">Governance</div>
+  <div class="tab" onclick="switchTab('deposit-mint')">Deposit → Mint</div>
+  <div class="tab" onclick="switchTab('stake-unstake')">Stake / Unstake</div>
+  <div class="tab" onclick="switchTab('withdraw-settle')">Withdraw → Settle</div>
+  <div class="tab" onclick="switchTab('loan-lifecycle')">Loan Lifecycle</div>
+  <div class="tab" onclick="switchTab('yield')">Yield Accretion</div>
+  <div class="tab" onclick="switchTab('shutdown')">Shutdown</div>
+  <div class="tab" onclick="switchTab('incident')">Incident → RevokeAll</div>
+</div>
+
+<!-- SYSTEM CONTEXT -->
+<div class="diagram-container active" id="system-context">
+  <div class="diagram-title">System Context</div>
+  <div class="diagram-desc">All components. Off-chain custody and ops on the left, on-chain contracts on the right, governance Safes below.</div>
+  <svg class="ctx" width="1240" height="860" viewBox="0 0 1240 860">
+
+    <!-- ========== OFF-CHAIN ZONE ========== -->
+    <rect x="20" y="20" width="380" height="580" rx="10" fill="rgba(158,206,106,0.05)" stroke="#9ece6a" stroke-width="1.5"/>
+    <text text-anchor="middle" x="210" y="48" fill="#9ece6a" font-size="13" font-weight="700" letter-spacing="1">OFF-CHAIN</text>
+
+    <!-- Capital Wallet -->
+    <rect x="40" y="70" width="340" height="100" rx="8" fill="#1a2030" stroke="#9ece6a" stroke-width="1.5"/>
+    <text text-anchor="middle" x="210" y="94" fill="#e6edf3" font-size="13" font-weight="600">Capital Wallet</text>
+    <text text-anchor="middle" x="210" y="114" fill="#8b949e" font-size="11">Custodian MPC · Trustee + Team + Bridge cosigners</text>
+    <text text-anchor="middle" x="210" y="132" fill="#8b949e" font-size="11">holds all USDC · deposits · repayments · loan drawdowns</text>
+    <text text-anchor="middle" x="210" y="152" fill="#9ece6a" font-size="11" font-style="italic">no contract ever custodies USDC</text>
+
+    <!-- Bridge -->
+    <rect x="40" y="190" width="340" height="110" rx="8" fill="#1a2030" stroke="#f7768e" stroke-width="1.5"/>
+    <text text-anchor="middle" x="210" y="214" fill="#e6edf3" font-size="13" font-weight="600">Bridge</text>
+    <text text-anchor="middle" x="210" y="232" fill="#8b949e" font-size="11">off-chain backend · indexer + yield co-signer</text>
+    <text text-anchor="middle" x="210" y="250" fill="#8b949e" font-size="11">co-signs yield mints with custodian; funds WQ; whitelist</text>
+    <text text-anchor="middle" x="210" y="268" fill="#8b949e" font-size="11">funds WithdrawalQueue · mints yield · manages whitelist</text>
+    <text text-anchor="middle" x="210" y="286" fill="#f7768e" font-size="11" font-style="italic">on-chain validator only — never custodies USDC</text>
+
+    <!-- Trustee -->
+    <rect x="40" y="320" width="340" height="90" rx="8" fill="#1a2030" stroke="#e0af68" stroke-width="1.5"/>
+    <text text-anchor="middle" x="210" y="344" fill="#e6edf3" font-size="13" font-weight="600">Trustee</text>
+    <text text-anchor="middle" x="210" y="362" fill="#8b949e" font-size="11">Capital Wallet cosigner · independent custodian</text>
+    <text text-anchor="middle" x="210" y="380" fill="#8b949e" font-size="11">holds TRUSTEE role on LoanRegistry (amend loan NFT)</text>
+    <text text-anchor="middle" x="210" y="398" fill="#e0af68" font-size="11" font-style="italic">separation-of-duties cosign on all capital movement</text>
+
+    <!-- Loan Book -->
+    <rect x="40" y="430" width="340" height="80" rx="8" fill="#1a2030" stroke="#8b949e" stroke-width="1.5"/>
+    <text text-anchor="middle" x="210" y="454" fill="#e6edf3" font-size="13" font-weight="600">Loan Book</text>
+    <text text-anchor="middle" x="210" y="472" fill="#8b949e" font-size="11">facility docs · CCR · maturity · commodity · collateral</text>
+    <text text-anchor="middle" x="210" y="492" fill="#8b949e" font-size="11" font-style="italic">anchored on-chain via LoanRegistry</text>
+
+    <!-- Monitoring -->
+    <rect x="40" y="530" width="340" height="60" rx="8" fill="#1a2030" stroke="#8b949e" stroke-width="1.5"/>
+    <text text-anchor="middle" x="210" y="554" fill="#e6edf3" font-size="13" font-weight="600">Monitoring (SOC)</text>
+    <text text-anchor="middle" x="210" y="572" fill="#8b949e" font-size="11">event watchers · rate-limit alerts · reconciliation</text>
+
+    <!-- ========== ON-CHAIN ZONE ========== -->
+    <rect x="440" y="20" width="780" height="580" rx="10" fill="rgba(187,154,247,0.05)" stroke="#bb9af7" stroke-width="1.5"/>
+    <text text-anchor="middle" x="830" y="48" fill="#bb9af7" font-size="13" font-weight="700" letter-spacing="1">ON-CHAIN</text>
+
+    <!-- AccessManager hub (full-width, top) -->
+    <rect x="460" y="70" width="740" height="60" rx="8" fill="#1c2333" stroke="#bb9af7" stroke-width="2.5"/>
+    <text text-anchor="middle" x="830" y="94" fill="#bb9af7" font-size="14" font-weight="700">AccessManager</text>
+    <text text-anchor="middle" x="830" y="114" fill="#8b949e" font-size="11">role hub · (target, selector) → role → grantees · per-target delays</text>
+
+    <!-- Row 1: PLUSD · sPLUSD · WithdrawalQueue -->
+    <rect x="460" y="150" width="240" height="100" rx="8" fill="#1c2333" stroke="#bb9af7" stroke-width="1.5"/>
+    <text text-anchor="middle" x="580" y="174" fill="#e6edf3" font-size="13" font-weight="600">PLUSD</text>
+    <text text-anchor="middle" x="580" y="194" fill="#8b949e" font-size="11">ERC-20 · Pausable receipt token</text>
+    <text text-anchor="middle" x="580" y="212" fill="#8b949e" font-size="11">whitelist gate on transfer</text>
+    <text text-anchor="middle" x="580" y="230" fill="#8b949e" font-size="11">mintForDeposit · yieldMint · burn-on-claim</text>
+
+    <rect x="710" y="150" width="240" height="100" rx="8" fill="#1c2333" stroke="#bb9af7" stroke-width="1.5"/>
+    <text text-anchor="middle" x="830" y="174" fill="#e6edf3" font-size="13" font-weight="600">sPLUSD</text>
+    <text text-anchor="middle" x="830" y="194" fill="#8b949e" font-size="11">ERC-4626 vault · asset = PLUSD</text>
+    <text text-anchor="middle" x="830" y="212" fill="#8b949e" font-size="11">share price rises on repayment</text>
+    <text text-anchor="middle" x="830" y="230" fill="#8b949e" font-size="11">yield-bearing share</text>
+
+    <rect x="960" y="150" width="240" height="100" rx="8" fill="#1c2333" stroke="#bb9af7" stroke-width="1.5"/>
+    <text text-anchor="middle" x="1080" y="174" fill="#e6edf3" font-size="13" font-weight="600">WithdrawalQueue</text>
+    <text text-anchor="middle" x="1080" y="194" fill="#8b949e" font-size="11">strict FIFO · PLUSD escrow</text>
+    <text text-anchor="middle" x="1080" y="212" fill="#8b949e" font-size="11">Pending · Funded · Claimed</text>
+    <text text-anchor="middle" x="1080" y="230" fill="#8b949e" font-size="11">single burn site on claim</text>
+
+    <!-- Row 2: WhitelistRegistry · LoanRegistry · ShutdownController -->
+    <rect x="460" y="265" width="240" height="100" rx="8" fill="#1c2333" stroke="#bb9af7" stroke-width="1.5"/>
+    <text text-anchor="middle" x="580" y="289" fill="#e6edf3" font-size="13" font-weight="600">WhitelistRegistry</text>
+    <text text-anchor="middle" x="580" y="309" fill="#8b949e" font-size="11">LP · venue · system lists</text>
+    <text text-anchor="middle" x="580" y="327" fill="#8b949e" font-size="11">48 h timelock on system adds</text>
+    <text text-anchor="middle" x="580" y="345" fill="#8b949e" font-size="11">staticcalled by PLUSD on transfer</text>
+
+    <rect x="710" y="265" width="240" height="100" rx="8" fill="#1c2333" stroke="#e0af68" stroke-width="1.5"/>
+    <text text-anchor="middle" x="830" y="289" fill="#e6edf3" font-size="13" font-weight="600">LoanRegistry</text>
+    <text text-anchor="middle" x="830" y="309" fill="#8b949e" font-size="11">soulbound ERC-721 per loan</text>
+    <text text-anchor="middle" x="830" y="327" fill="#8b949e" font-size="11">originate · amend · default · close</text>
+    <text text-anchor="middle" x="830" y="345" fill="#8b949e" font-size="11">audit trail · holds no capital</text>
+
+    <rect x="960" y="265" width="240" height="100" rx="8" fill="#1c2333" stroke="#bb9af7" stroke-width="1.5"/>
+    <text text-anchor="middle" x="1080" y="289" fill="#e6edf3" font-size="13" font-weight="600">ShutdownController</text>
+    <text text-anchor="middle" x="1080" y="309" fill="#8b949e" font-size="11">one-way terminal switch</text>
+    <text text-anchor="middle" x="1080" y="327" fill="#8b949e" font-size="11">cascades pause + pull redemption</text>
+    <text text-anchor="middle" x="1080" y="345" fill="#8b949e" font-size="11">sets recovery rate at entry</text>
+
+    <!-- Row 3: RecoveryPool · EmergencyRevoker · AccessManager-emphasis placeholder -->
+    <rect x="460" y="380" width="240" height="100" rx="8" fill="#1c2333" stroke="#bb9af7" stroke-width="1.5"/>
+    <text text-anchor="middle" x="580" y="404" fill="#e6edf3" font-size="13" font-weight="600">RecoveryPool</text>
+    <text text-anchor="middle" x="580" y="424" fill="#8b949e" font-size="11">post-shutdown USDC escrow</text>
+    <text text-anchor="middle" x="580" y="442" fill="#8b949e" font-size="11">pull-based claim at recovery rate</text>
+    <text text-anchor="middle" x="580" y="460" fill="#8b949e" font-size="11">rate ratchets up as pool fills</text>
+
+    <rect x="710" y="380" width="240" height="100" rx="8" fill="#1c2333" stroke="#f7768e" stroke-width="1.5"/>
+    <text text-anchor="middle" x="830" y="404" fill="#e6edf3" font-size="13" font-weight="600">EmergencyRevoker</text>
+    <text text-anchor="middle" x="830" y="424" fill="#8b949e" font-size="11">immutable · no params · holds ADMIN</text>
+    <text text-anchor="middle" x="830" y="442" fill="#8b949e" font-size="11">revokeAll() wipes hot-key roles</text>
+    <text text-anchor="middle" x="830" y="460" fill="#8b949e" font-size="11">one-shot kill switch</text>
+
+    <!-- DepositManager (new in v2.3) -->
+    <rect x="960" y="380" width="240" height="100" rx="8" fill="#1c2333" stroke="#bb9af7" stroke-width="1.5"/>
+    <text text-anchor="middle" x="1080" y="404" fill="#e6edf3" font-size="13" font-weight="600">DepositManager</text>
+    <text text-anchor="middle" x="1080" y="424" fill="#8b949e" font-size="11">atomic 1:1 USDC → PLUSD deposit</text>
+    <text text-anchor="middle" x="1080" y="442" fill="#8b949e" font-size="11">holds DEPOSITOR on PLUSD</text>
+    <text text-anchor="middle" x="1080" y="460" fill="#8b949e" font-size="11">no off-chain signer on deposit leg</text>
+
+    <!-- ========== GOVERNANCE BAND ========== -->
+    <rect x="20" y="620" width="1200" height="220" rx="10" fill="rgba(122,162,247,0.04)" stroke="#7aa2f7" stroke-width="1"/>
+    <text text-anchor="middle" x="620" y="646" fill="#7aa2f7" font-size="13" font-weight="700" letter-spacing="1">GOVERNANCE</text>
+    <text text-anchor="middle" x="620" y="662" fill="#8b949e" font-size="10" font-style="italic">three Safes · all writes flow through AccessManager</text>
+
+    <rect x="50" y="680" width="370" height="140" rx="8" fill="#1a2030" stroke="#e0af68" stroke-width="1.5"/>
+    <text x="70" y="705" fill="#e0af68" font-size="13" font-weight="700">Admin Safe · 3/5</text>
+    <text x="70" y="725" fill="#8b949e" font-size="11">parameters · upgrades · role grants</text>
+    <text x="70" y="743" fill="#8b949e" font-size="11">rate limits · venue lists · selector map</text>
+    <text x="70" y="761" fill="#8b949e" font-size="11">system-whitelist adds</text>
+    <text x="70" y="779" fill="#8b949e" font-size="11">schedules on 48 h delay</text>
+    <text x="70" y="802" fill="#e0af68" font-size="10" font-style="italic">slow path · everything timelocked</text>
+
+    <rect x="435" y="680" width="370" height="140" rx="8" fill="#1a2030" stroke="#bb9af7" stroke-width="1.5"/>
+    <text x="455" y="705" fill="#bb9af7" font-size="13" font-weight="700">Risk Council · 3/5</text>
+    <text x="455" y="725" fill="#8b949e" font-size="11">mark loan default</text>
+    <text x="455" y="743" fill="#8b949e" font-size="11">trigger shutdown</text>
+    <text x="455" y="761" fill="#8b949e" font-size="11">adjust recovery rate (up only)</text>
+    <text x="455" y="779" fill="#8b949e" font-size="11">schedules on 24 h delay</text>
+    <text x="455" y="802" fill="#bb9af7" font-size="10" font-style="italic">credit + wind-down decisions</text>
+
+    <rect x="820" y="680" width="370" height="140" rx="8" fill="#1a2030" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="840" y="705" fill="#f7768e" font-size="13" font-weight="700">Guardian · 2/5</text>
+    <text x="840" y="725" fill="#8b949e" font-size="11">pause any managed contract</text>
+    <text x="840" y="743" fill="#8b949e" font-size="11">cancel any scheduled op</text>
+    <text x="840" y="761" fill="#8b949e" font-size="11">call EmergencyRevoker.revokeAll</text>
+    <text x="840" y="779" fill="#8b949e" font-size="11">instant · no delay</text>
+    <text x="840" y="802" fill="#f7768e" font-size="10" font-style="italic">defensive only · cannot grant roles</text>
+
+  </svg>
+</div>
+
+<!-- GOVERNANCE -->
+<div class="diagram-container" id="role-topology">
+  <div class="diagram-title">Governance</div>
+  <div class="diagram-desc">Three Safes gate the AccessManager: slow writes via Admin, risk actions via Risk Council, instant defensive cancels via Guardian.</div>
+
+  <div class="role-cards" style="grid-template-columns: repeat(3, 1fr);">
+    <div class="role-card">
+      <h4 style="color: var(--amber);">Admin Safe · 3/5</h4>
+      <p style="color:var(--text-muted); font-size:11px; margin-bottom:6px;"><i>48 h delay on all writes</i></p>
+      <ul style="color: var(--text-muted); font-size: 12px; line-height: 1.6; padding-left: 16px;">
+        <li>Role grants and revocations</li>
+        <li>Selector → role mappings</li>
+        <li>Per-target admin delays</li>
+        <li>Rate limits and venue lists</li>
+        <li>System-whitelist adds</li>
+        <li>Contract upgrades</li>
+      </ul>
+    </div>
+
+    <div class="role-card">
+      <h4 style="color: var(--lavender);">Risk Council · 3/5</h4>
+      <p style="color:var(--text-muted); font-size:11px; margin-bottom:6px;"><i>24 h delay on writes</i></p>
+      <ul style="color: var(--text-muted); font-size: 12px; line-height: 1.6; padding-left: 16px;">
+        <li>Mark loan default on LoanRegistry</li>
+        <li>Trigger ShutdownController</li>
+        <li>Adjust recovery rate (up only)</li>
+        <li>Narrow scope — credit and wind-down</li>
+      </ul>
+    </div>
+
+    <div class="role-card">
+      <h4 style="color: var(--rose);">Guardian · 2/5</h4>
+      <p style="color:var(--text-muted); font-size:11px; margin-bottom:6px;"><i>instant · defensive only</i></p>
+      <ul style="color: var(--text-muted); font-size: 12px; line-height: 1.6; padding-left: 16px;">
+        <li>Pause any managed contract</li>
+        <li>Cancel any scheduled op</li>
+        <li>Call EmergencyRevoker.revokeAll</li>
+        <li>Cannot grant roles or move funds</li>
+      </ul>
+    </div>
+  </div>
+
+  <svg width="900" height="280" viewBox="0 0 900 280">
+    <defs>
+      <marker id="gArr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+        <path d="M0,0 L10,5 L0,10 z" fill="#8b949e"/>
+      </marker>
+      <marker id="gArrRose" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+        <path d="M0,0 L10,5 L0,10 z" fill="#f7768e"/>
+      </marker>
+    </defs>
+
+    <!-- Admin -->
+    <rect x="30" y="30" width="160" height="60" rx="8" fill="#1a2030" stroke="#e0af68" stroke-width="1.5"/>
+    <text text-anchor="middle" x="110" y="56" fill="#e0af68" font-size="13" font-weight="700">Admin</text>
+    <text text-anchor="middle" x="110" y="76" fill="#8b949e" font-size="11">schedule</text>
+
+    <!-- Risk Council -->
+    <rect x="30" y="150" width="160" height="60" rx="8" fill="#1a2030" stroke="#bb9af7" stroke-width="1.5"/>
+    <text text-anchor="middle" x="110" y="176" fill="#bb9af7" font-size="13" font-weight="700">Risk Council</text>
+    <text text-anchor="middle" x="110" y="196" fill="#8b949e" font-size="11">schedule</text>
+
+    <!-- Delay -->
+    <rect x="290" y="90" width="160" height="60" rx="8" fill="#1a2030" stroke="#7aa2f7" stroke-width="1.5"/>
+    <text text-anchor="middle" x="370" y="116" fill="#7aa2f7" font-size="13" font-weight="700">Delay</text>
+    <text text-anchor="middle" x="370" y="136" fill="#8b949e" font-size="11">24 h – 48 h</text>
+
+    <!-- Execute -->
+    <rect x="550" y="90" width="160" height="60" rx="8" fill="#1a2030" stroke="#bb9af7" stroke-width="1.5"/>
+    <text text-anchor="middle" x="630" y="116" fill="#bb9af7" font-size="13" font-weight="700">Execute</text>
+    <text text-anchor="middle" x="630" y="136" fill="#8b949e" font-size="11">AccessManager</text>
+
+    <!-- Guardian -->
+    <rect x="290" y="200" width="160" height="60" rx="8" fill="#1a2030" stroke="#f7768e" stroke-width="1.5"/>
+    <text text-anchor="middle" x="370" y="226" fill="#f7768e" font-size="13" font-weight="700">Guardian</text>
+    <text text-anchor="middle" x="370" y="246" fill="#8b949e" font-size="11">cancel · pause</text>
+
+    <!-- Admin → Delay -->
+    <path d="M 190 60 C 240 60, 260 110, 286 115" stroke="#8b949e" stroke-width="1.5" fill="none" marker-end="url(#gArr)"/>
+    <!-- Risk → Delay -->
+    <path d="M 190 180 C 240 180, 260 130, 286 125" stroke="#8b949e" stroke-width="1.5" fill="none" marker-end="url(#gArr)"/>
+    <!-- Delay → Execute -->
+    <path d="M 450 120 L 546 120" stroke="#8b949e" stroke-width="1.5" fill="none" marker-end="url(#gArr)"/>
+    <!-- Guardian → cancel Delay (straight up) -->
+    <path d="M 370 200 L 370 152" stroke="#f7768e" stroke-width="1.5" fill="none" marker-end="url(#gArrRose)" stroke-dasharray="4 3"/>
+    <text x="380" y="180" fill="#f7768e" font-size="10" font-style="italic">cancel</text>
+  </svg>
+</div>
+
+<div class="diagram-container" id="deposit-mint">
+  <div class="diagram-title">Deposit → Mint</div>
+  <div class="diagram-desc">LP deposits USDC via DepositManager; PLUSD is minted 1:1 atomically. No off-chain signer on the deposit leg — the on-chain USDC transfer is the attestation.</div>
+  <svg class="seq" width="1280" height="660" viewBox="0 0 1280 660">
+    <defs>
+      <marker id="dm-a" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="#8b949e"/></marker>
+      <marker id="dm-a-dim" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="#8b949e" opacity="0.5"/></marker>
+      <marker id="dm-a-ev" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="#e0af68"/></marker>
+      <marker id="dm-a-oc" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="#bb9af7"/></marker>
+      <marker id="dm-a-mp" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="#9ece6a"/></marker>
+    </defs>
+
+    <!-- Lanes: LP=100, USDC=320, DepositManager=540, PLUSD=760, WR=980, CapWallet=1180 -->
+    <rect x="40"   y="10" width="120" height="44" rx="6" fill="#161b22" stroke="#7aa2f7" stroke-width="1.5"/>
+    <text text-anchor="middle" x="100"  y="30" fill="#e6edf3" font-size="12" font-weight="600">LP</text>
+    <text text-anchor="middle" x="100"  y="44" fill="#8b949e" font-size="9">whitelisted investor</text>
+
+    <rect x="260"  y="10" width="120" height="44" rx="6" fill="#161b22" stroke="#9ece6a" stroke-width="1.5"/>
+    <text text-anchor="middle" x="320"  y="30" fill="#e6edf3" font-size="12" font-weight="600">USDC</text>
+    <text text-anchor="middle" x="320"  y="44" fill="#8b949e" font-size="9">ERC-20 (external)</text>
+
+    <rect x="480"  y="10" width="120" height="44" rx="6" fill="#161b22" stroke="#bb9af7" stroke-width="1.5"/>
+    <text text-anchor="middle" x="540"  y="30" fill="#e6edf3" font-size="12" font-weight="600">DepositManager</text>
+    <text text-anchor="middle" x="540"  y="44" fill="#8b949e" font-size="9">atomic 1:1 deposit</text>
+
+    <rect x="700"  y="10" width="120" height="44" rx="6" fill="#161b22" stroke="#bb9af7" stroke-width="1.5"/>
+    <text text-anchor="middle" x="760"  y="30" fill="#e6edf3" font-size="12" font-weight="600">PLUSD</text>
+    <text text-anchor="middle" x="760"  y="44" fill="#8b949e" font-size="9">ERC-20 · counters</text>
+
+    <rect x="920"  y="10" width="140" height="44" rx="6" fill="#161b22" stroke="#bb9af7" stroke-width="1.5"/>
+    <text text-anchor="middle" x="990"  y="30" fill="#e6edf3" font-size="12" font-weight="600">WhitelistRegistry</text>
+    <text text-anchor="middle" x="990"  y="44" fill="#8b949e" font-size="9">isAllowedForMint</text>
+
+    <rect x="1120" y="10" width="140" height="44" rx="6" fill="#161b22" stroke="#9ece6a" stroke-width="1.5"/>
+    <text text-anchor="middle" x="1190" y="30" fill="#e6edf3" font-size="12" font-weight="600">Capital Wallet</text>
+    <text text-anchor="middle" x="1190" y="44" fill="#8b949e" font-size="9">MPC custody</text>
+
+    <!-- Lifelines -->
+    <line x1="100"  y1="54" x2="100"  y2="650" stroke="#30363d" stroke-width="1" stroke-dasharray="4 3"/>
+    <line x1="320"  y1="54" x2="320"  y2="650" stroke="#30363d" stroke-width="1" stroke-dasharray="4 3"/>
+    <line x1="540"  y1="54" x2="540"  y2="650" stroke="#30363d" stroke-width="1" stroke-dasharray="4 3"/>
+    <line x1="760"  y1="54" x2="760"  y2="650" stroke="#30363d" stroke-width="1" stroke-dasharray="4 3"/>
+    <line x1="990"  y1="54" x2="990"  y2="650" stroke="#30363d" stroke-width="1" stroke-dasharray="4 3"/>
+    <line x1="1190" y1="54" x2="1190" y2="650" stroke="#30363d" stroke-width="1" stroke-dasharray="4 3"/>
+
+    <!-- PHASE 1: Approval (pre-tx) -->
+    <rect x="10" y="70" width="1260" height="100" rx="4" fill="#161b22" opacity="0.5"/>
+    <text x="20" y="90" fill="#7aa2f7" font-size="11" font-weight="600">1. LP APPROVES DEPOSITMANAGER (one-time, or per-deposit)</text>
+    <line x1="100" y1="135" x2="315" y2="135" stroke="#bb9af7" stroke-width="1.2" marker-end="url(#dm-a-oc)"/>
+    <text x="120" y="127" fill="#e6edf3" font-size="11">USDC.approve(DepositManager, amount)</text>
+
+    <!-- PHASE 2: deposit() — atomic -->
+    <rect x="10" y="185" width="1260" height="340" rx="4" fill="rgba(187,154,247,0.05)" stroke="rgba(187,154,247,0.20)" stroke-width="1"/>
+    <text x="20" y="205" fill="#bb9af7" font-size="11" font-weight="600">2. DEPOSIT — one transaction, atomic</text>
+
+    <line x1="100" y1="245" x2="535" y2="245" stroke="#bb9af7" stroke-width="1.4" marker-end="url(#dm-a-oc)"/>
+    <text x="120" y="237" fill="#e6edf3" font-size="11">DepositManager.deposit(amount)</text>
+
+    <!-- DM checks whitelist -->
+    <line x1="540" y1="285" x2="985" y2="285" stroke="#8b949e" stroke-width="1.2" marker-end="url(#dm-a)"/>
+    <text x="560" y="277" fill="#e6edf3" font-size="11">isAllowedForMint(lp)</text>
+    <line x1="990" y1="310" x2="545" y2="310" stroke="#8b949e" stroke-width="1.2" stroke-dasharray="5 3" opacity="0.7" marker-end="url(#dm-a-dim)"/>
+    <text x="620" y="302" fill="#8b949e" font-size="10">true</text>
+
+    <!-- DM pulls USDC from LP to Capital Wallet (pull pattern) -->
+    <line x1="540" y1="355" x2="315" y2="355" stroke="#bb9af7" stroke-width="1.4" marker-end="url(#dm-a-oc)"/>
+    <text x="340" y="347" fill="#e6edf3" font-size="11">USDC.transferFrom(lp, capitalWallet, amount)</text>
+    <line x1="320" y1="390" x2="1185" y2="390" stroke="#9ece6a" stroke-width="2" marker-end="url(#dm-a-mp)"/>
+    <text x="360" y="382" fill="#9ece6a" font-size="11" font-weight="600">USDC flows LP → Capital Wallet</text>
+
+    <!-- DM calls mintForDeposit -->
+    <line x1="540" y1="440" x2="755" y2="440" stroke="#bb9af7" stroke-width="1.4" marker-end="url(#dm-a-oc)"/>
+    <text x="560" y="432" fill="#e6edf3" font-size="11">PLUSD.mintForDeposit(lp, amount)</text>
+    <text x="560" y="458" fill="#8b949e" font-size="10">restricted(DEPOSITOR) · checks reserve invariant · hard supply cap · rate limits</text>
+
+    <!-- PLUSD mints to LP -->
+    <line x1="755" y1="498" x2="105" y2="498" stroke="#e0af68" stroke-width="1.4" marker-end="url(#dm-a-ev)"/>
+    <text x="300" y="490" fill="#e0af68" font-size="11">Transfer(0x0, lp, amount)  ·  cumulativeLPDeposits += amount</text>
+
+    <!-- PHASE 3: Invariant note -->
+    <rect x="10" y="540" width="1260" height="100" rx="4" fill="rgba(158,206,106,0.04)" stroke="rgba(158,206,106,0.18)" stroke-width="1"/>
+    <text x="20" y="560" fill="#9ece6a" font-size="11" font-weight="600">3. INVARIANT (maintained on every mint path)</text>
+    <text x="20" y="585" fill="#e6edf3" font-size="11" font-family="monospace">totalSupply + amount  ≤  cumulativeLPDeposits + cumulativeYieldMinted − cumulativeLPBurns</text>
+    <text x="20" y="610" fill="#8b949e" font-size="10" font-style="italic">No off-chain signer on the deposit leg. The USDC transfer to Capital Wallet IS the on-chain evidence. Any revert in mintForDeposit rolls back the USDC transfer atomically.</text>
+  </svg>
+</div>
+
+<div class="diagram-container" id="stake-unstake">
+  <div class="diagram-title">Stake / Unstake</div>
+  <div class="diagram-desc">LP deposits PLUSD into the sPLUSD ERC-4626 vault and later redeems back to PLUSD. Stake reverts during shutdown; unstake stays open as the exit path to PLUSD → `redeemInShutdown`.</div>
+  <svg class="seq" width="1100" height="740" viewBox="0 0 1100 740">
+    <defs>
+      <marker id="su-a" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="#8b949e"/></marker>
+      <marker id="su-a-dim" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="#8b949e" opacity="0.5"/></marker>
+      <marker id="su-a-oc" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="#bb9af7"/></marker>
+    </defs>
+
+    <rect x="40"  y="10" width="120" height="44" rx="6" fill="#161b22" stroke="#7aa2f7" stroke-width="1.5"/>
+    <text text-anchor="middle" x="100" y="30" fill="#e6edf3" font-size="12" font-weight="600">LP</text>
+    <text text-anchor="middle" x="100" y="44" fill="#8b949e" font-size="9">whitelisted investor</text>
+
+    <rect x="340" y="10" width="120" height="44" rx="6" fill="#161b22" stroke="#bb9af7" stroke-width="1.5"/>
+    <text text-anchor="middle" x="400" y="30" fill="#e6edf3" font-size="12" font-weight="600">sPLUSD</text>
+    <text text-anchor="middle" x="400" y="44" fill="#8b949e" font-size="9">ERC-4626 vault</text>
+
+    <rect x="640" y="10" width="120" height="44" rx="6" fill="#161b22" stroke="#bb9af7" stroke-width="1.5"/>
+    <text text-anchor="middle" x="700" y="30" fill="#e6edf3" font-size="12" font-weight="600">PLUSD</text>
+    <text text-anchor="middle" x="700" y="44" fill="#8b949e" font-size="9">underlying</text>
+
+    <rect x="880" y="10" width="140" height="44" rx="6" fill="#161b22" stroke="#bb9af7" stroke-width="1.5"/>
+    <text text-anchor="middle" x="950" y="30" fill="#e6edf3" font-size="12" font-weight="600">WhitelistRegistry</text>
+    <text text-anchor="middle" x="950" y="44" fill="#8b949e" font-size="9">isAllowed view</text>
+
+    <line x1="100" y1="54" x2="100" y2="720" stroke="#30363d" stroke-width="1" stroke-dasharray="4 3"/>
+    <line x1="400" y1="54" x2="400" y2="720" stroke="#30363d" stroke-width="1" stroke-dasharray="4 3"/>
+    <line x1="700" y1="54" x2="700" y2="720" stroke="#30363d" stroke-width="1" stroke-dasharray="4 3"/>
+    <line x1="950" y1="54" x2="950" y2="720" stroke="#30363d" stroke-width="1" stroke-dasharray="4 3"/>
+
+    <!-- STAKE -->
+    <rect x="10" y="70" width="1080" height="300" rx="4" fill="rgba(158,206,106,0.04)" stroke="rgba(158,206,106,0.18)" stroke-width="1"/>
+    <text x="20" y="90" fill="#9ece6a" font-size="12" font-weight="600">STAKE  —  PLUSD → sPLUSD shares</text>
+
+    <line x1="100" y1="140" x2="695" y2="140" stroke="#bb9af7" stroke-width="1.4" marker-end="url(#su-a-oc)"/>
+    <text x="120" y="132" fill="#e6edf3" font-size="11">PLUSD.approve(sPLUSD, amount)</text>
+
+    <line x1="100" y1="195" x2="395" y2="195" stroke="#bb9af7" stroke-width="1.4" marker-end="url(#su-a-oc)"/>
+    <text x="120" y="187" fill="#e6edf3" font-size="11">sPLUSD.deposit(amount)</text>
+    <text x="120" y="213" fill="#8b949e" font-size="10">reverts if shutdown</text>
+
+    <line x1="400" y1="260" x2="695" y2="260" stroke="#8b949e" stroke-width="1.4" marker-end="url(#su-a)"/>
+    <text x="420" y="252" fill="#e6edf3" font-size="11">PLUSD.transferFrom(lp, sPLUSD, amount)</text>
+
+    <line x1="400" y1="335" x2="105" y2="335" stroke="#bb9af7" stroke-width="1.4" stroke-dasharray="5 3" opacity="0.75" marker-end="url(#su-a-oc)"/>
+    <text x="120" y="327" fill="#e6edf3" font-size="11">_mint(lp, shares)</text>
+
+    <!-- UNSTAKE -->
+    <rect x="10" y="390" width="1080" height="330" rx="4" fill="rgba(247,118,142,0.04)" stroke="rgba(247,118,142,0.18)" stroke-width="1"/>
+    <text x="20" y="410" fill="#f7768e" font-size="12" font-weight="600">UNSTAKE  —  sPLUSD shares → PLUSD</text>
+
+    <line x1="100" y1="460" x2="395" y2="460" stroke="#bb9af7" stroke-width="1.4" marker-end="url(#su-a-oc)"/>
+    <text x="120" y="452" fill="#e6edf3" font-size="11">sPLUSD.redeem(shares)</text>
+    <text x="120" y="478" fill="#9ece6a" font-size="10">stays OPEN during shutdown — exit path → PLUSD → redeemInShutdown</text>
+
+    <line x1="400" y1="525" x2="105" y2="525" stroke="#bb9af7" stroke-width="1.4" stroke-dasharray="5 3" opacity="0.75" marker-end="url(#su-a-oc)"/>
+    <text x="120" y="517" fill="#e6edf3" font-size="11">_burn(lp, shares)</text>
+
+    <line x1="400" y1="595" x2="695" y2="595" stroke="#bb9af7" stroke-width="1.4" marker-end="url(#su-a-oc)"/>
+    <text x="420" y="587" fill="#e6edf3" font-size="11">PLUSD.transfer(lp, assets)</text>
+
+    <line x1="700" y1="660" x2="945" y2="660" stroke="#8b949e" stroke-width="1.4" marker-end="url(#su-a)"/>
+    <text x="720" y="652" fill="#e6edf3" font-size="11">isAllowed(lp)</text>
+
+    <line x1="950" y1="695" x2="705" y2="695" stroke="#8b949e" stroke-width="1.2" stroke-dasharray="5 3" opacity="0.7" marker-end="url(#su-a-dim)"/>
+    <text x="740" y="687" fill="#8b949e" font-size="10">true</text>
+  </svg>
+</div>
+
+<div class="diagram-container" id="yield">
+  <div class="diagram-title">Yield Accretion</div>
+  <div class="diagram-desc">Borrower repays Capital Wallet; Bridge and custodian co-sign an EIP-712 YieldAttestation; PLUSD.yieldMint verifies both on-chain and mints into sPLUSD vault.</div>
+  <svg class="seq" width="1340" height="900" viewBox="0 0 1340 900">
+    <defs>
+      <marker id="y-a" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="#8b949e"/></marker>
+      <marker id="y-a-dim" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="#8b949e" opacity="0.5"/></marker>
+      <marker id="y-a-ev" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="#e0af68"/></marker>
+      <marker id="y-a-oc" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="#bb9af7"/></marker>
+      <marker id="y-a-mp" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="#9ece6a"/></marker>
+      <marker id="y-a-rd" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="#f7768e"/></marker>
+    </defs>
+
+    <!-- Lanes: Borrower=80, CapWallet=280, Bridge=480, Custodian=700, PLUSD=900, sPLUSD=1100, Treasury=1260 -->
+    <rect x="20"   y="10" width="120" height="44" rx="6" fill="#161b22" stroke="#7aa2f7" stroke-width="1.5"/>
+    <text text-anchor="middle" x="80"   y="30" fill="#e6edf3" font-size="12" font-weight="600">Borrower</text>
+    <text text-anchor="middle" x="80"   y="44" fill="#8b949e" font-size="9">off-chain payer</text>
+
+    <rect x="220"  y="10" width="120" height="44" rx="6" fill="#161b22" stroke="#9ece6a" stroke-width="1.5"/>
+    <text text-anchor="middle" x="280"  y="30" fill="#e6edf3" font-size="12" font-weight="600">Capital Wallet</text>
+    <text text-anchor="middle" x="280"  y="44" fill="#8b949e" font-size="9">MPC custody</text>
+
+    <rect x="420"  y="10" width="120" height="44" rx="6" fill="#161b22" stroke="#f7768e" stroke-width="1.5"/>
+    <text text-anchor="middle" x="480"  y="30" fill="#e6edf3" font-size="12" font-weight="600">Bridge</text>
+    <text text-anchor="middle" x="480"  y="44" fill="#8b949e" font-size="9">YIELD_MINTER + sig</text>
+
+    <rect x="640"  y="10" width="120" height="44" rx="6" fill="#161b22" stroke="#e0af68" stroke-width="1.5"/>
+    <text text-anchor="middle" x="700"  y="30" fill="#e6edf3" font-size="12" font-weight="600">Custodian</text>
+    <text text-anchor="middle" x="700"  y="44" fill="#8b949e" font-size="9">EIP-1271 co-signer</text>
+
+    <rect x="840"  y="10" width="120" height="44" rx="6" fill="#161b22" stroke="#bb9af7" stroke-width="1.5"/>
+    <text text-anchor="middle" x="900"  y="30" fill="#e6edf3" font-size="12" font-weight="600">PLUSD</text>
+    <text text-anchor="middle" x="900"  y="44" fill="#8b949e" font-size="9">ERC-20 · counters</text>
+
+    <rect x="1040" y="10" width="120" height="44" rx="6" fill="#161b22" stroke="#bb9af7" stroke-width="1.5"/>
+    <text text-anchor="middle" x="1100" y="30" fill="#e6edf3" font-size="12" font-weight="600">sPLUSD vault</text>
+    <text text-anchor="middle" x="1100" y="44" fill="#8b949e" font-size="9">ERC-4626</text>
+
+    <rect x="1200" y="10" width="120" height="44" rx="6" fill="#161b22" stroke="#9ece6a" stroke-width="1.5"/>
+    <text text-anchor="middle" x="1260" y="30" fill="#e6edf3" font-size="12" font-weight="600">Treasury</text>
+    <text text-anchor="middle" x="1260" y="44" fill="#8b949e" font-size="9">fee destination</text>
+
+    <line x1="80"   y1="54" x2="80"   y2="880" stroke="#30363d" stroke-width="1" stroke-dasharray="4 3"/>
+    <line x1="280"  y1="54" x2="280"  y2="880" stroke="#30363d" stroke-width="1" stroke-dasharray="4 3"/>
+    <line x1="480"  y1="54" x2="480"  y2="880" stroke="#30363d" stroke-width="1" stroke-dasharray="4 3"/>
+    <line x1="700"  y1="54" x2="700"  y2="880" stroke="#30363d" stroke-width="1" stroke-dasharray="4 3"/>
+    <line x1="900"  y1="54" x2="900"  y2="880" stroke="#30363d" stroke-width="1" stroke-dasharray="4 3"/>
+    <line x1="1100" y1="54" x2="1100" y2="880" stroke="#30363d" stroke-width="1" stroke-dasharray="4 3"/>
+    <line x1="1260" y1="54" x2="1260" y2="880" stroke="#30363d" stroke-width="1" stroke-dasharray="4 3"/>
+
+    <!-- PHASE 1: repay -->
+    <rect x="10" y="70" width="1320" height="120" rx="4" fill="#161b22" opacity="0.5"/>
+    <text x="20" y="90" fill="#7aa2f7" font-size="11" font-weight="600">1. BORROWER REPAYS CAPITAL WALLET  —  plain ERC-20 transfer, no Pipeline contract involved</text>
+    <line x1="80" y1="140" x2="275" y2="140" stroke="#9ece6a" stroke-width="2.2" marker-end="url(#y-a-mp)"/>
+    <text x="95" y="130" fill="#e6edf3" font-size="11">USDC.transfer(capWallet, principal + interest)</text>
+
+    <!-- PHASE 2: Both sides observe + co-sign attestation -->
+    <rect x="10" y="200" width="1320" height="210" rx="4" fill="rgba(247,118,142,0.04)" stroke="rgba(247,118,142,0.18)" stroke-width="1"/>
+    <text x="20" y="220" fill="#f7768e" font-size="11" font-weight="600">2. BRIDGE + CUSTODIAN INDEPENDENTLY VERIFY + CO-SIGN EIP-712 YieldAttestation</text>
+
+    <line x1="280" y1="260" x2="475" y2="260" stroke="#e0af68" stroke-width="1.4" marker-end="url(#y-a-ev)"/>
+    <text x="295" y="252" fill="#e0af68" font-size="11">repayment indexed by Bridge</text>
+
+    <line x1="280" y1="295" x2="695" y2="295" stroke="#e0af68" stroke-width="1.4" marker-end="url(#y-a-ev)"/>
+    <text x="295" y="287" fill="#e0af68" font-size="11">custodian sees inflow via its own ledger</text>
+
+    <rect x="330" y="320" width="520" height="80" rx="6" fill="#1c2333" stroke="#e0af68" stroke-width="1.2"/>
+    <text text-anchor="middle" x="590" y="342" fill="#e6edf3" font-size="11" font-weight="600">co-sign YieldAttestation</text>
+    <text text-anchor="middle" x="590" y="360" fill="#8b949e" font-size="10">{ repaymentRef, destination, amount, deadline, salt }</text>
+    <text text-anchor="middle" x="590" y="378" fill="#8b949e" font-size="10">Bridge → ECDSA sig · Custodian → EIP-1271 sig · one attestation PER DESTINATION</text>
+    <text text-anchor="middle" x="590" y="394" fill="#8b949e" font-size="9" font-style="italic">repaymentRef = keccak256(chainId, txHash, "vault" | "treasury") — distinct per leg, independent replay slots</text>
+
+    <!-- PHASE 3: Bridge submits yieldMint with both sigs -->
+    <rect x="10" y="420" width="1320" height="250" rx="4" fill="rgba(187,154,247,0.05)" stroke="rgba(187,154,247,0.20)" stroke-width="1"/>
+    <text x="20" y="440" fill="#bb9af7" font-size="11" font-weight="600">3. BRIDGE SUBMITS yieldMint — PLUSD VERIFIES BOTH SIGS ON-CHAIN</text>
+
+    <line x1="480" y1="485" x2="895" y2="485" stroke="#bb9af7" stroke-width="1.4" marker-end="url(#y-a-oc)"/>
+    <text x="495" y="477" fill="#e6edf3" font-size="11">PLUSD.yieldMint(att, bridgeSig, custodianSig)</text>
+    <text x="495" y="502" fill="#8b949e" font-size="10">restricted(YIELD_MINTER) + 2-of-2 EIP-712 verification</text>
+
+    <!-- PLUSD verifies -->
+    <rect x="840" y="515" width="200" height="72" rx="6" fill="#1a2030" stroke="#bb9af7" stroke-width="1"/>
+    <text x="850" y="535" fill="#e6edf3" font-size="10" font-weight="600">ecrecover == bridgeYieldAttestor</text>
+    <text x="850" y="552" fill="#e6edf3" font-size="10" font-weight="600">IERC1271(custodian).isValidSignature(…)</text>
+    <text x="850" y="572" fill="#8b949e" font-size="10">check replay on repaymentRef</text>
+    <text x="850" y="586" fill="#8b949e" font-size="10">check reserve invariant + supply cap</text>
+
+    <!-- mint to vault -->
+    <line x1="895" y1="620" x2="1095" y2="620" stroke="#e0af68" stroke-width="1.4" marker-end="url(#y-a-ev)"/>
+    <text x="910" y="612" fill="#e0af68" font-size="11">Transfer(0x0, sPLUSD, coupon_net)  ·  cumulativeYieldMinted += coupon_net</text>
+
+    <!-- or fees to treasury (second call) -->
+    <line x1="895" y1="655" x2="1255" y2="655" stroke="#e0af68" stroke-width="1.4" stroke-dasharray="5 3" marker-end="url(#y-a-ev)"/>
+    <text x="910" y="647" fill="#e0af68" font-size="11">Transfer(0x0, treasury, fees)  — second yieldMint call, independent attestation + co-sig</text>
+
+    <!-- PHASE 4: share price accretes -->
+    <rect x="10" y="685" width="1320" height="100" rx="4" fill="rgba(224,175,104,0.05)" stroke="rgba(224,175,104,0.20)" stroke-width="1"/>
+    <text x="20" y="705" fill="#e0af68" font-size="11" font-weight="600">4. SHARE PRICE ACCRETES</text>
+    <rect x="1010" y="725" width="240" height="48" rx="6" fill="#1c2333" stroke="#bb9af7" stroke-width="1"/>
+    <text x="1020" y="744" fill="#e6edf3" font-size="11" font-weight="600">totalAssets += coupon_net</text>
+    <text x="1020" y="762" fill="#8b949e" font-size="10">totalSupply unchanged</text>
+    <line x1="1010" y1="770" x2="85" y2="770" stroke="#8b949e" stroke-width="1.2" stroke-dasharray="5 3" opacity="0.7" marker-end="url(#y-a-dim)"/>
+
+    <!-- PHASE 5: Safety property -->
+    <rect x="10" y="800" width="1320" height="80" rx="4" fill="rgba(158,206,106,0.04)" stroke="rgba(158,206,106,0.18)" stroke-width="1"/>
+    <text x="20" y="820" fill="#9ece6a" font-size="11" font-weight="600">SAFETY PROPERTY</text>
+    <text x="20" y="843" fill="#e6edf3" font-size="11">Compromising Bridge alone → zero yield mint. Compromising custodian alone → zero yield mint. Three independent controls gate every yield mint.</text>
+    <text x="20" y="864" fill="#8b949e" font-size="10" font-style="italic">cumulativeYieldMinted += amount after successful mint; invariant re-checked</text>
+  </svg>
+</div>
+
+<div class="diagram-container" id="withdraw-settle">
+  <div class="diagram-title">Withdraw → Settle</div>
+  <div class="diagram-desc">LP redeems PLUSD for USDC via FIFO queue. Bridge triggers funding; USDC flows from Capital Wallet to the queue.</div>
+  <svg class="seq" width="1260" height="1120" viewBox="0 0 1260 1120">
+    <defs>
+      <marker id="w-a"    markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="#8b949e"/></marker>
+      <marker id="w-a-oc" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="#bb9af7"/></marker>
+      <marker id="w-a-ev" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="#e0af68"/></marker>
+      <marker id="w-a-mn" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="#9ece6a"/></marker>
+      <marker id="w-a-rd" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="#f7768e"/></marker>
+    </defs>
+
+    <!-- Lanes: LP=100, CapWallet=300, Bridge=500, WQ=720, PLUSD=930, Governance=1140 -->
+    <rect x="40"   y="10" width="120" height="44" rx="6" fill="#161b22" stroke="#7aa2f7" stroke-width="1.5"/>
+    <text text-anchor="middle" x="100"  y="30" fill="#e6edf3" font-size="12" font-weight="600">LP</text>
+    <text text-anchor="middle" x="100"  y="44" fill="#8b949e" font-size="9">requester</text>
+
+    <rect x="240"  y="10" width="120" height="44" rx="6" fill="#161b22" stroke="#9ece6a" stroke-width="1.5"/>
+    <text text-anchor="middle" x="300"  y="30" fill="#e6edf3" font-size="12" font-weight="600">Capital Wallet</text>
+    <text text-anchor="middle" x="300"  y="44" fill="#8b949e" font-size="9">MPC custody</text>
+
+    <rect x="440"  y="10" width="120" height="44" rx="6" fill="#161b22" stroke="#f7768e" stroke-width="1.5"/>
+    <text text-anchor="middle" x="500"  y="30" fill="#e6edf3" font-size="12" font-weight="600">Bridge</text>
+    <text text-anchor="middle" x="500"  y="44" fill="#8b949e" font-size="9">FUNDER · on-chain trigger</text>
+
+    <rect x="650"  y="10" width="140" height="44" rx="6" fill="#161b22" stroke="#bb9af7" stroke-width="1.5"/>
+    <text text-anchor="middle" x="720"  y="30" fill="#e6edf3" font-size="12" font-weight="600">WithdrawalQueue</text>
+    <text text-anchor="middle" x="720"  y="44" fill="#8b949e" font-size="9">FIFO escrow</text>
+
+    <rect x="870"  y="10" width="120" height="44" rx="6" fill="#161b22" stroke="#bb9af7" stroke-width="1.5"/>
+    <text text-anchor="middle" x="930"  y="30" fill="#e6edf3" font-size="12" font-weight="600">PLUSD</text>
+    <text text-anchor="middle" x="930"  y="44" fill="#8b949e" font-size="9">escrow · burn</text>
+
+    <rect x="1070" y="10" width="140" height="44" rx="6" fill="#161b22" stroke="#e0af68" stroke-width="1.5"/>
+    <text text-anchor="middle" x="1140" y="30" fill="#e6edf3" font-size="12" font-weight="600">Governance</text>
+    <text text-anchor="middle" x="1140" y="44" fill="#8b949e" font-size="9">Admin · Guardian</text>
+
+    <!-- Lifelines -->
+    <line x1="100"  y1="54" x2="100"  y2="1080" stroke="#30363d" stroke-width="1" stroke-dasharray="4 3"/>
+    <line x1="300"  y1="54" x2="300"  y2="1080" stroke="#30363d" stroke-width="1" stroke-dasharray="4 3"/>
+    <line x1="500"  y1="54" x2="500"  y2="1080" stroke="#30363d" stroke-width="1" stroke-dasharray="4 3"/>
+    <line x1="720"  y1="54" x2="720"  y2="1080" stroke="#30363d" stroke-width="1" stroke-dasharray="4 3"/>
+    <line x1="930"  y1="54" x2="930"  y2="1080" stroke="#30363d" stroke-width="1" stroke-dasharray="4 3"/>
+    <line x1="1140" y1="54" x2="1140" y2="1080" stroke="#30363d" stroke-width="1" stroke-dasharray="4 3"/>
+
+    <!-- PHASE 1: REQUEST -->
+    <rect x="10" y="70" width="1240" height="170" rx="4" fill="#161b22" opacity="0.5"/>
+    <text x="20" y="90" fill="#7aa2f7" font-size="11" font-weight="600">1. REQUEST</text>
+
+    <line x1="100" y1="130" x2="715" y2="130" stroke="#bb9af7" stroke-width="1.2" marker-end="url(#w-a-oc)"/>
+    <text x="120" y="122" fill="#e6edf3" font-size="11">requestWithdrawal(amount)</text>
+
+    <line x1="720" y1="170" x2="925" y2="170" stroke="#8b949e" stroke-width="1.2" marker-end="url(#w-a)"/>
+    <text x="740" y="162" fill="#e6edf3" font-size="11">PLUSD.transferFrom(lp, WQ, amount)</text>
+
+    <rect x="640" y="195" width="340" height="32" rx="4" fill="#1c2333" stroke="#30363d" stroke-width="1"/>
+    <text x="655" y="214" fill="#e6edf3" font-size="11" font-weight="600">status = Pending · queueId = nextId++</text>
+
+    <!-- PHASE 2: FUND (Model B: Bridge triggers, Capital Wallet is source) -->
+    <rect x="10" y="260" width="1240" height="230" rx="4" fill="rgba(158,206,106,0.04)" stroke="rgba(158,206,106,0.18)" stroke-width="1"/>
+    <text x="20" y="280" fill="#9ece6a" font-size="11" font-weight="600">2. FUND  —  Bridge triggers, Capital Wallet is the USDC source</text>
+
+    <line x1="300" y1="320" x2="715" y2="320" stroke="#9ece6a" stroke-width="1.4" marker-end="url(#w-a-mn)"/>
+    <text x="320" y="312" fill="#9ece6a" font-size="11">USDC.approve(WQ, ceiling)</text>
+    <text x="320" y="336" fill="#8b949e" font-size="10">one-time setup (Trustee + Team cosign); WQ pulls from this allowance</text>
+
+    <line x1="500" y1="380" x2="715" y2="380" stroke="#bb9af7" stroke-width="1.2" marker-end="url(#w-a-oc)"/>
+    <text x="520" y="372" fill="#e6edf3" font-size="11">WQ.fundRequest(queueId)</text>
+
+    <line x1="720" y1="420" x2="305" y2="420" stroke="#9ece6a" stroke-width="1.6" marker-end="url(#w-a-mn)"/>
+    <text x="430" y="412" fill="#9ece6a" font-size="11">USDC.transferFrom(capitalWallet, WQ, amount)</text>
+
+    <rect x="640" y="445" width="340" height="32" rx="4" fill="#1c2333" stroke="#30363d" stroke-width="1"/>
+    <text x="655" y="464" fill="#e6edf3" font-size="11" font-weight="600">status = Funded · fundedAt = now</text>
+
+    <!-- PHASE 3: CLAIM -->
+    <rect x="10" y="510" width="1240" height="180" rx="4" fill="rgba(187,154,247,0.04)" stroke="rgba(187,154,247,0.18)" stroke-width="1"/>
+    <text x="20" y="530" fill="#bb9af7" font-size="11" font-weight="600">3. CLAIM</text>
+
+    <line x1="100" y1="575" x2="715" y2="575" stroke="#bb9af7" stroke-width="1.2" marker-end="url(#w-a-oc)"/>
+    <text x="120" y="567" fill="#e6edf3" font-size="11">claim(queueId)</text>
+
+    <line x1="720" y1="615" x2="925" y2="615" stroke="#8b949e" stroke-width="1.2" marker-end="url(#w-a)"/>
+    <text x="740" y="607" fill="#e6edf3" font-size="11">PLUSD.burn(amount)</text>
+
+    <line x1="720" y1="655" x2="105" y2="655" stroke="#9ece6a" stroke-width="1.6" marker-end="url(#w-a-mn)"/>
+    <text x="140" y="647" fill="#9ece6a" font-size="11">USDC.transfer(lp, amount)</text>
+
+    <rect x="640" y="670" width="180" height="20" rx="4" fill="#1c2333" stroke="#30363d" stroke-width="1"/>
+    <text x="655" y="684" fill="#e6edf3" font-size="11" font-weight="600">status = Claimed</text>
+
+    <!-- PHASE 4: ADMIN RELEASE (side branch) -->
+    <rect x="10" y="710" width="1240" height="190" rx="4" fill="rgba(224,175,104,0.04)" stroke="rgba(224,175,104,0.22)" stroke-width="1"/>
+    <text x="20" y="730" fill="#e0af68" font-size="11" font-weight="600">4. ADMIN RELEASE  —  sanctioned or stale</text>
+    <text x="20" y="748" fill="#8b949e" font-size="10" font-style="italic">Funded request blocked from claim (LP removed from whitelist, or &gt; 180d unclaimed).</text>
+
+    <line x1="1140" y1="790" x2="725" y2="790" stroke="#e0af68" stroke-width="1.2" stroke-dasharray="5 3" marker-end="url(#w-a-ev)"/>
+    <text x="790" y="782" fill="#e0af68" font-size="11">schedule adminRelease(queueId)</text>
+
+    <rect x="640" y="805" width="480" height="24" rx="4" fill="#1a2030" stroke="#e0af68" stroke-width="1"/>
+    <text text-anchor="middle" x="880" y="821" fill="#e0af68" font-size="10" font-weight="600">24h AccessManager delay · Guardian may cancel</text>
+
+    <line x1="1140" y1="855" x2="725" y2="855" stroke="#bb9af7" stroke-width="1.2" marker-end="url(#w-a-oc)"/>
+    <text x="790" y="847" fill="#e6edf3" font-size="11">execute adminRelease(queueId)</text>
+
+    <rect x="640" y="870" width="300" height="20" rx="4" fill="#1c2333" stroke="#30363d" stroke-width="1"/>
+    <text x="655" y="884" fill="#e6edf3" font-size="11" font-weight="600">status = AdminReleased · USDC returned to Capital Wallet</text>
+
+    <!-- PHASE 5: SHUTDOWN CLAIM -->
+    <rect x="10" y="920" width="1240" height="160" rx="4" fill="rgba(247,118,142,0.05)" stroke="rgba(247,118,142,0.18)" stroke-width="1"/>
+    <text x="20" y="940" fill="#f7768e" font-size="11" font-weight="600">5. SHUTDOWN CLAIM</text>
+
+    <line x1="100" y1="980" x2="715" y2="980" stroke="#f7768e" stroke-width="1.2" marker-end="url(#w-a-rd)"/>
+    <text x="120" y="972" fill="#f7768e" font-size="11">claimAtShutdown(queueId)</text>
+
+    <line x1="720" y1="1018" x2="925" y2="1018" stroke="#8b949e" stroke-width="1.2" marker-end="url(#w-a)"/>
+    <text x="740" y="1010" fill="#e6edf3" font-size="11">burn escrow PLUSD</text>
+
+    <line x1="720" y1="1054" x2="105" y2="1054" stroke="#9ece6a" stroke-width="1.6" marker-end="url(#w-a-mn)"/>
+    <text x="140" y="1046" fill="#9ece6a" font-size="11">USDC to LP at recovery rate (from escrow or RecoveryPool)</text>
+  </svg>
+</div>
+
+<div class="diagram-container" id="loan-lifecycle">
+  <div class="diagram-title">Loan Lifecycle</div>
+  <div class="diagram-desc">Soulbound loan NFT: mint, amend, default, close. Registry is audit trail only — holds no capital.</div>
+  <svg class="seq" width="1280" height="1040" viewBox="0 0 1280 1040">
+    <defs>
+      <marker id="l-a"    markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="#8b949e"/></marker>
+      <marker id="l-a-oc" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="#bb9af7"/></marker>
+      <marker id="l-a-ev" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="#e0af68"/></marker>
+      <marker id="l-a-rd" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="#f7768e"/></marker>
+    </defs>
+
+    <!-- Lanes: Originator=100, Borrower=290, Trustee=490, Risk Council=700, LoanRegistry=920 -->
+    <rect x="40"  y="10" width="120" height="44" rx="6" fill="#161b22" stroke="#7aa2f7" stroke-width="1.5"/>
+    <text text-anchor="middle" x="100" y="30" fill="#e6edf3" font-size="12" font-weight="600">Originator</text>
+    <text text-anchor="middle" x="100" y="44" fill="#8b949e" font-size="9">deal lead</text>
+
+    <rect x="220" y="10" width="140" height="44" rx="6" fill="#161b22" stroke="#7aa2f7" stroke-width="1.5"/>
+    <text text-anchor="middle" x="290" y="30" fill="#e6edf3" font-size="12" font-weight="600">Borrower</text>
+    <text text-anchor="middle" x="290" y="44" fill="#8b949e" font-size="9">counterparty</text>
+
+    <rect x="420" y="10" width="140" height="44" rx="6" fill="#161b22" stroke="#e0af68" stroke-width="1.5"/>
+    <text text-anchor="middle" x="490" y="30" fill="#e6edf3" font-size="12" font-weight="600">Trustee</text>
+    <text text-anchor="middle" x="490" y="44" fill="#8b949e" font-size="9">TRUSTEE role</text>
+
+    <rect x="630" y="10" width="140" height="44" rx="6" fill="#161b22" stroke="#f7768e" stroke-width="1.5"/>
+    <text text-anchor="middle" x="700" y="30" fill="#e6edf3" font-size="12" font-weight="600">Risk Council</text>
+    <text text-anchor="middle" x="700" y="44" fill="#8b949e" font-size="9">escalator</text>
+
+    <rect x="830" y="10" width="180" height="44" rx="6" fill="#161b22" stroke="#bb9af7" stroke-width="1.5"/>
+    <text text-anchor="middle" x="920" y="30" fill="#e6edf3" font-size="12" font-weight="600">LoanRegistry</text>
+    <text text-anchor="middle" x="920" y="44" fill="#8b949e" font-size="9">soulbound ERC-721</text>
+
+    <!-- Lifelines -->
+    <line x1="100" y1="54" x2="100" y2="1000" stroke="#30363d" stroke-width="1" stroke-dasharray="4 3"/>
+    <line x1="290" y1="54" x2="290" y2="1000" stroke="#30363d" stroke-width="1" stroke-dasharray="4 3"/>
+    <line x1="490" y1="54" x2="490" y2="1000" stroke="#30363d" stroke-width="1" stroke-dasharray="4 3"/>
+    <line x1="700" y1="54" x2="700" y2="1000" stroke="#30363d" stroke-width="1" stroke-dasharray="4 3"/>
+    <line x1="920" y1="54" x2="920" y2="1000" stroke="#30363d" stroke-width="1" stroke-dasharray="4 3"/>
+
+    <!-- Field-model side box -->
+    <rect x="1040" y="70" width="220" height="270" rx="6" fill="#1c2333" stroke="#e0af68" stroke-width="1"/>
+    <text x="1052" y="90" fill="#e0af68" font-size="10" font-weight="600">Field model</text>
+
+    <text x="1052" y="112" fill="#bb9af7" font-size="9" font-weight="600">Immutable</text>
+    <text x="1052" y="127" fill="#8b949e" font-size="9">docHash</text>
+    <text x="1052" y="141" fill="#8b949e" font-size="9">principal</text>
+    <text x="1052" y="155" fill="#8b949e" font-size="9">originator</text>
+    <text x="1052" y="169" fill="#8b949e" font-size="9">borrower</text>
+    <text x="1052" y="183" fill="#8b949e" font-size="9">commodity</text>
+    <text x="1052" y="197" fill="#8b949e" font-size="9">originatedAt</text>
+
+    <text x="1052" y="224" fill="#9ece6a" font-size="9" font-weight="600">Mutable</text>
+    <text x="1052" y="239" fill="#8b949e" font-size="9">status</text>
+    <text x="1052" y="253" fill="#8b949e" font-size="9">ccrBps</text>
+    <text x="1052" y="267" fill="#8b949e" font-size="9">location</text>
+    <text x="1052" y="281" fill="#8b949e" font-size="9">maturity</text>
+    <text x="1052" y="295" fill="#8b949e" font-size="9">closureReason</text>
+
+    <text x="1052" y="322" fill="#f7768e" font-size="9" font-weight="600">Status</text>
+    <text x="1052" y="335" fill="#8b949e" font-size="9">Performing · Watchlist · Default · Closed</text>
+
+    <!-- PHASE 1: ORIGINATION -->
+    <rect x="10" y="70" width="1020" height="160" rx="4" fill="#161b22" opacity="0.5"/>
+    <text x="20" y="90" fill="#7aa2f7" font-size="11" font-weight="600">1. ORIGINATION</text>
+
+    <line x1="100" y1="125" x2="285" y2="125" stroke="#8b949e" stroke-width="1.2" marker-end="url(#l-a)"/>
+    <text x="115" y="118" fill="#e6edf3" font-size="10">loan doc signed</text>
+
+    <line x1="290" y1="155" x2="485" y2="155" stroke="#8b949e" stroke-width="1.2" marker-end="url(#l-a)"/>
+    <text x="305" y="148" fill="#e6edf3" font-size="10">attestation (docHash)</text>
+
+    <line x1="490" y1="188" x2="915" y2="188" stroke="#bb9af7" stroke-width="1.2" marker-end="url(#l-a-oc)"/>
+    <text x="505" y="181" fill="#e6edf3" font-size="10">mintLoan(immutableData)</text>
+
+    <line x1="920" y1="218" x2="495" y2="218" stroke="#e0af68" stroke-width="1.2" marker-end="url(#l-a-ev)"/>
+    <text x="525" y="211" fill="#e0af68" font-size="10">LoanMinted(loanId)</text>
+
+    <!-- PHASE 2: AMENDMENTS -->
+    <rect x="10" y="250" width="1020" height="230" rx="4" fill="rgba(158,206,106,0.04)" stroke="rgba(158,206,106,0.18)" stroke-width="1"/>
+    <text x="20" y="270" fill="#9ece6a" font-size="11" font-weight="600">2. AMENDMENTS</text>
+
+    <line x1="490" y1="305" x2="915" y2="305" stroke="#bb9af7" stroke-width="1.2" marker-end="url(#l-a-oc)"/>
+    <text x="505" y="298" fill="#e6edf3" font-size="10">updateCCR(loanId, bps)</text>
+
+    <line x1="490" y1="335" x2="915" y2="335" stroke="#bb9af7" stroke-width="1.2" marker-end="url(#l-a-oc)"/>
+    <text x="505" y="328" fill="#e6edf3" font-size="10">updateLocation(loanId, loc)</text>
+
+    <line x1="490" y1="365" x2="915" y2="365" stroke="#bb9af7" stroke-width="1.2" marker-end="url(#l-a-oc)"/>
+    <text x="505" y="358" fill="#e6edf3" font-size="10">updateMaturity(loanId, ts)</text>
+
+    <line x1="490" y1="395" x2="915" y2="395" stroke="#bb9af7" stroke-width="1.2" marker-end="url(#l-a-oc)"/>
+    <text x="505" y="388" fill="#e6edf3" font-size="10">updateStatus(loanId, Watchlist)</text>
+
+    <line x1="920" y1="430" x2="495" y2="430" stroke="#e0af68" stroke-width="1.2" marker-end="url(#l-a-ev)"/>
+    <text x="525" y="423" fill="#e0af68" font-size="10">LoanUpdated(loanId, field, old, new)</text>
+
+    <rect x="440" y="445" width="460" height="22" rx="3" fill="#1c2333" stroke="#30363d" stroke-width="1"/>
+    <text x="450" y="460" fill="#8b949e" font-size="9">immutable fields rejected at function level</text>
+
+    <!-- PHASE 3: DEFAULT -->
+    <rect x="10" y="500" width="1020" height="230" rx="4" fill="rgba(247,118,142,0.05)" stroke="rgba(247,118,142,0.18)" stroke-width="1"/>
+    <text x="20" y="520" fill="#f7768e" font-size="11" font-weight="600">3. DEFAULT ESCALATION</text>
+
+    <line x1="700" y1="555" x2="915" y2="555" stroke="#f7768e" stroke-width="1.2" stroke-dasharray="5 3" marker-end="url(#l-a-rd)"/>
+    <text x="715" y="548" fill="#f7768e" font-size="10">schedule setDefault(loanId)</text>
+
+    <rect x="460" y="585" width="560" height="28" rx="4" fill="#1a2030" stroke="#f7768e" stroke-width="1"/>
+    <text text-anchor="middle" x="740" y="603" fill="#f7768e" font-size="10" font-weight="600">24h delay · Guardian may cancel</text>
+
+    <line x1="700" y1="640" x2="915" y2="640" stroke="#bb9af7" stroke-width="1.2" marker-end="url(#l-a-oc)"/>
+    <text x="715" y="633" fill="#e6edf3" font-size="10">execute setDefault(loanId)</text>
+
+    <rect x="840" y="655" width="180" height="34" rx="4" fill="#1c2333" stroke="#30363d" stroke-width="1"/>
+    <text text-anchor="middle" x="930" y="670" fill="#e6edf3" font-size="10" font-weight="600">status = Default</text>
+    <text text-anchor="middle" x="930" y="683" fill="#8b949e" font-size="9">from Performing | Watchlist</text>
+
+    <line x1="920" y1="710" x2="495" y2="710" stroke="#e0af68" stroke-width="1.2" marker-end="url(#l-a-ev)"/>
+    <text x="525" y="703" fill="#e0af68" font-size="10">LoanUpdated(loanId, status, …, Default)</text>
+
+    <!-- PHASE 4: CLOSURE -->
+    <rect x="10" y="750" width="1020" height="230" rx="4" fill="rgba(187,154,247,0.04)" stroke="rgba(187,154,247,0.18)" stroke-width="1"/>
+    <text x="20" y="770" fill="#bb9af7" font-size="11" font-weight="600">4. CLOSURE</text>
+
+    <line x1="490" y1="805" x2="915" y2="805" stroke="#bb9af7" stroke-width="1.2" marker-end="url(#l-a-oc)"/>
+    <text x="505" y="798" fill="#e6edf3" font-size="10">closeLoan(loanId, reason)</text>
+
+    <rect x="700" y="825" width="320" height="60" rx="4" fill="#1c2333" stroke="#30363d" stroke-width="1"/>
+    <text x="712" y="842" fill="#e6edf3" font-size="10" font-weight="600">reason ∈ ClosureReason</text>
+    <text x="712" y="857" fill="#8b949e" font-size="9">ScheduledMaturity · EarlyRepayment · Default</text>
+    <text x="712" y="873" fill="#8b949e" font-size="9">status = Closed · no further updates</text>
+
+    <line x1="920" y1="915" x2="495" y2="915" stroke="#e0af68" stroke-width="1.2" marker-end="url(#l-a-ev)"/>
+    <text x="525" y="908" fill="#e0af68" font-size="10">LoanClosed(loanId, reason)</text>
+  </svg>
+</div>
+
+<div class="diagram-container" id="shutdown">
+  <div class="diagram-title">Shutdown</div>
+  <div class="diagram-desc">Terminal one-way wind-down. Holders pull USDC from RecoveryPool at a fixed rate; Trustee tops up as capital returns; rate ratchets up only.</div>
+  <svg class="seq" width="1260" height="1150" viewBox="0 0 1260 1150">
+    <defs>
+      <marker id="sh-oc" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="#bb9af7"/></marker>
+      <marker id="sh-rd" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="#f7768e"/></marker>
+      <marker id="sh-sg" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="#9ece6a"/></marker>
+      <marker id="sh-gr" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="#8b949e"/></marker>
+    </defs>
+
+    <!-- Lanes: RC=80, Ctrl=250, Holder=430, sPLUSD=600, PLUSD=770, WQ=940, Pool=1130, Trustee=1130 (share) -->
+    <rect x="20"   y="10" width="120" height="44" rx="6" fill="#161b22" stroke="#bb9af7" stroke-width="1.5"/>
+    <text text-anchor="middle" x="80"   y="30" fill="#e6edf3" font-size="12" font-weight="600">Risk Council</text>
+    <text text-anchor="middle" x="80"   y="44" fill="#8b949e" font-size="9">3-of-5</text>
+
+    <rect x="190"  y="10" width="140" height="44" rx="6" fill="#161b22" stroke="#bb9af7" stroke-width="1.5"/>
+    <text text-anchor="middle" x="260"  y="30" fill="#e6edf3" font-size="12" font-weight="600">ShutdownController</text>
+    <text text-anchor="middle" x="260"  y="44" fill="#8b949e" font-size="9">terminal switch</text>
+
+    <rect x="370"  y="10" width="140" height="44" rx="6" fill="#161b22" stroke="#7aa2f7" stroke-width="1.5"/>
+    <text text-anchor="middle" x="440"  y="30" fill="#e6edf3" font-size="12" font-weight="600">Holder / LP</text>
+    <text text-anchor="middle" x="440"  y="44" fill="#8b949e" font-size="9">sPLUSD · PLUSD · WQ</text>
+
+    <rect x="540"  y="10" width="140" height="44" rx="6" fill="#161b22" stroke="#bb9af7" stroke-width="1.5"/>
+    <text text-anchor="middle" x="610"  y="30" fill="#e6edf3" font-size="12" font-weight="600">sPLUSD</text>
+    <text text-anchor="middle" x="610"  y="44" fill="#8b949e" font-size="9">ERC-4626</text>
+
+    <rect x="710"  y="10" width="140" height="44" rx="6" fill="#161b22" stroke="#bb9af7" stroke-width="1.5"/>
+    <text text-anchor="middle" x="780"  y="30" fill="#e6edf3" font-size="12" font-weight="600">PLUSD</text>
+    <text text-anchor="middle" x="780"  y="44" fill="#8b949e" font-size="9">ERC-20</text>
+
+    <rect x="880"  y="10" width="140" height="44" rx="6" fill="#161b22" stroke="#bb9af7" stroke-width="1.5"/>
+    <text text-anchor="middle" x="950"  y="30" fill="#e6edf3" font-size="12" font-weight="600">WithdrawalQueue</text>
+    <text text-anchor="middle" x="950"  y="44" fill="#8b949e" font-size="9">FIFO</text>
+
+    <rect x="1060" y="10" width="140" height="44" rx="6" fill="#161b22" stroke="#9ece6a" stroke-width="1.5"/>
+    <text text-anchor="middle" x="1130" y="30" fill="#e6edf3" font-size="12" font-weight="600">RecoveryPool</text>
+    <text text-anchor="middle" x="1130" y="44" fill="#8b949e" font-size="9">USDC</text>
+
+    <!-- Lifelines -->
+    <line x1="80"   y1="54" x2="80"   y2="1130" stroke="#30363d" stroke-width="1" stroke-dasharray="4 3"/>
+    <line x1="260"  y1="54" x2="260"  y2="1130" stroke="#30363d" stroke-width="1" stroke-dasharray="4 3"/>
+    <line x1="440"  y1="54" x2="440"  y2="1130" stroke="#30363d" stroke-width="1" stroke-dasharray="4 3"/>
+    <line x1="610"  y1="54" x2="610"  y2="1130" stroke="#30363d" stroke-width="1" stroke-dasharray="4 3"/>
+    <line x1="780"  y1="54" x2="780"  y2="1130" stroke="#30363d" stroke-width="1" stroke-dasharray="4 3"/>
+    <line x1="950"  y1="54" x2="950"  y2="1130" stroke="#30363d" stroke-width="1" stroke-dasharray="4 3"/>
+    <line x1="1130" y1="54" x2="1130" y2="1130" stroke="#30363d" stroke-width="1" stroke-dasharray="4 3"/>
+
+    <!-- PHASE 1: Trigger -->
+    <rect x="10" y="70" width="1240" height="170" rx="4" fill="rgba(122,162,247,0.05)" stroke="rgba(122,162,247,0.20)" stroke-width="1"/>
+    <text x="20" y="90" fill="#7aa2f7" font-size="11" font-weight="600">1. TRIGGER  —  24h timelock</text>
+
+    <line x1="80" y1="125" x2="255" y2="125" stroke="#bb9af7" stroke-width="1.2" marker-end="url(#sh-oc)"/>
+    <text x="95" y="117" fill="#e6edf3" font-size="11">schedule(enterShutdown)</text>
+
+    <rect x="120" y="145" width="900" height="24" rx="4" fill="rgba(122,162,247,0.10)" stroke="#7aa2f7" stroke-width="1" stroke-dasharray="3 2"/>
+    <text text-anchor="middle" x="570" y="162" fill="#7aa2f7" font-size="11">24h AccessManager delay · Guardian may cancel</text>
+
+    <line x1="80" y1="200" x2="255" y2="200" stroke="#bb9af7" stroke-width="1.4" marker-end="url(#sh-oc)"/>
+    <text x="95" y="192" fill="#e6edf3" font-size="11">execute(enterShutdown)</text>
+
+    <!-- PHASE 2: Snapshot + cascade -->
+    <rect x="10" y="260" width="1240" height="200" rx="4" fill="rgba(187,154,247,0.05)" stroke="rgba(187,154,247,0.20)" stroke-width="1"/>
+    <text x="20" y="280" fill="#bb9af7" font-size="11" font-weight="600">2. SNAPSHOT + CASCADE</text>
+
+    <line x1="260" y1="315" x2="605" y2="315" stroke="#bb9af7" stroke-width="1.2" marker-end="url(#sh-oc)"/>
+    <text x="280" y="307" fill="#e6edf3" font-size="11">sPLUSD.pause(deposit/stake)</text>
+
+    <line x1="260" y1="355" x2="775" y2="355" stroke="#bb9af7" stroke-width="1.2" marker-end="url(#sh-oc)"/>
+    <text x="280" y="347" fill="#e6edf3" font-size="11">PLUSD.pause(mintForDeposit, yieldMint, transfers)</text>
+
+    <line x1="260" y1="395" x2="945" y2="395" stroke="#bb9af7" stroke-width="1.2" marker-end="url(#sh-oc)"/>
+    <text x="280" y="387" fill="#e6edf3" font-size="11">WQ.pause(new requests, funding)</text>
+
+    <rect x="200" y="415" width="800" height="30" rx="4" fill="#1c2333" stroke="#bb9af7" stroke-width="1"/>
+    <text text-anchor="middle" x="600" y="435" fill="#bb9af7" font-size="11" font-weight="600">isActive = true · recoveryRateBps set from current pool balance</text>
+
+    <!-- PHASE 3: sPLUSD holders exit via normal redeem -->
+    <rect x="10" y="480" width="1240" height="180" rx="4" fill="rgba(187,154,247,0.04)" stroke="rgba(187,154,247,0.18)" stroke-width="1"/>
+    <text x="20" y="500" fill="#bb9af7" font-size="11" font-weight="600">3. sPLUSD HOLDERS EXIT  —  normal redeem, not a special shutdown path</text>
+
+    <line x1="440" y1="540" x2="605" y2="540" stroke="#bb9af7" stroke-width="1.4" marker-end="url(#sh-oc)"/>
+    <text x="455" y="532" fill="#e6edf3" font-size="11">sPLUSD.redeem(shares)</text>
+    <text x="455" y="558" fill="#8b949e" font-size="10">unstake remains open post-shutdown for exit</text>
+
+    <line x1="610" y1="595" x2="775" y2="595" stroke="#8b949e" stroke-width="1.2" marker-end="url(#sh-gr)"/>
+    <text x="625" y="587" fill="#e6edf3" font-size="11">burn shares</text>
+
+    <line x1="610" y1="630" x2="445" y2="630" stroke="#bb9af7" stroke-width="1.4" stroke-dasharray="5 3" marker-end="url(#sh-oc)"/>
+    <text x="460" y="622" fill="#e6edf3" font-size="11">PLUSD.transfer(lp, assets)</text>
+
+    <!-- PHASE 4: PLUSD holders redeem at rate -->
+    <rect x="10" y="680" width="1240" height="180" rx="4" fill="rgba(187,154,247,0.04)" stroke="rgba(187,154,247,0.18)" stroke-width="1"/>
+    <text x="20" y="700" fill="#bb9af7" font-size="11" font-weight="600">4. PLUSD HOLDERS REDEEM  —  rate × amount from RecoveryPool</text>
+
+    <line x1="440" y1="740" x2="775" y2="740" stroke="#bb9af7" stroke-width="1.4" marker-end="url(#sh-oc)"/>
+    <text x="455" y="732" fill="#e6edf3" font-size="11">redeemInShutdown(amount)</text>
+
+    <line x1="780" y1="780" x2="1125" y2="780" stroke="#bb9af7" stroke-width="1.2" marker-end="url(#sh-oc)"/>
+    <text x="795" y="772" fill="#e6edf3" font-size="11">burn PLUSD · request payout(rate × amount)</text>
+
+    <line x1="1130" y1="820" x2="445" y2="820" stroke="#9ece6a" stroke-width="1.6" marker-end="url(#sh-sg)"/>
+    <text x="700" y="812" fill="#9ece6a" font-size="11">USDC out (rate × amount)</text>
+
+    <!-- PHASE 5: WQ holders -->
+    <rect x="10" y="880" width="1240" height="150" rx="4" fill="rgba(187,154,247,0.04)" stroke="rgba(187,154,247,0.18)" stroke-width="1"/>
+    <text x="20" y="900" fill="#bb9af7" font-size="11" font-weight="600">5. WQ HOLDERS CLAIM</text>
+
+    <line x1="440" y1="935" x2="945" y2="935" stroke="#bb9af7" stroke-width="1.4" marker-end="url(#sh-oc)"/>
+    <text x="455" y="927" fill="#e6edf3" font-size="11">claimAtShutdown(queueId)</text>
+
+    <line x1="950" y1="975" x2="445" y2="975" stroke="#9ece6a" stroke-width="1.6" marker-end="url(#sh-sg)"/>
+    <text x="620" y="967" fill="#9ece6a" font-size="11">USDC at rate · from escrow if Funded, else from pool</text>
+
+    <text x="20" y="1005" fill="#8b949e" font-size="10" font-style="italic">Funded request: residual USDC above haircut returned to RecoveryPool. Pending: full rate × amount from pool.</text>
+
+    <!-- PHASE 6: Top-up + rate ratchet -->
+    <rect x="10" y="1050" width="1240" height="90" rx="4" fill="rgba(158,206,106,0.04)" stroke="rgba(158,206,106,0.20)" stroke-width="1"/>
+    <text x="20" y="1070" fill="#9ece6a" font-size="11" font-weight="600">6. TOP-UP + RATCHET  —  over time as Trustee recovers capital</text>
+
+    <line x1="1125" y1="1100" x2="85" y2="1100" stroke="#9ece6a" stroke-width="1.2" stroke-dasharray="5 3" marker-end="url(#sh-sg)"/>
+    <text x="400" y="1092" fill="#9ece6a" font-size="10">Trustee tops up pool · Risk Council schedules adjustRecoveryRateUp (24h timelock)</text>
+  </svg>
+</div>
+
+<div class="diagram-container" id="incident">
+  <div class="diagram-title">Incident → RevokeAll</div>
+  <div class="diagram-desc">Bridge or Trustee key compromise: pause cascade, atomic role revocation, key rotation.</div>
+  <svg class="seq" width="1260" height="1200" viewBox="0 0 1260 1200">
+    <defs>
+      <marker id="in-oc" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="#bb9af7"/></marker>
+      <marker id="in-rd" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="#f7768e"/></marker>
+      <marker id="in-am" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="#e0af68"/></marker>
+      <marker id="in-dim" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="#8b949e"/></marker>
+    </defs>
+
+    <!-- Lanes: Mon=80, Guardian=260, AM=440, Revoker=620, PLUSD=800, Pausable=980, Admin=1180 -->
+    <rect x="20"   y="10" width="120" height="44" rx="6" fill="#161b22" stroke="#8b949e" stroke-width="1.5"/>
+    <text text-anchor="middle" x="80"   y="30" fill="#e6edf3" font-size="12" font-weight="600">Monitoring</text>
+    <text text-anchor="middle" x="80"   y="44" fill="#8b949e" font-size="9">off-chain alerts</text>
+
+    <rect x="200"  y="10" width="120" height="44" rx="6" fill="#161b22" stroke="#f7768e" stroke-width="1.5"/>
+    <text text-anchor="middle" x="260"  y="30" fill="#e6edf3" font-size="12" font-weight="600">Guardian</text>
+    <text text-anchor="middle" x="260"  y="44" fill="#8b949e" font-size="9">2-of-5 pauser</text>
+
+    <rect x="380"  y="10" width="120" height="44" rx="6" fill="#161b22" stroke="#bb9af7" stroke-width="1.5"/>
+    <text text-anchor="middle" x="440"  y="30" fill="#e6edf3" font-size="12" font-weight="600">AccessManager</text>
+    <text text-anchor="middle" x="440"  y="44" fill="#8b949e" font-size="9">role hub</text>
+
+    <rect x="560"  y="10" width="120" height="44" rx="6" fill="#161b22" stroke="#f7768e" stroke-width="1.5"/>
+    <text text-anchor="middle" x="620"  y="30" fill="#e6edf3" font-size="12" font-weight="600">EmergencyRevoker</text>
+    <text text-anchor="middle" x="620"  y="44" fill="#8b949e" font-size="9">immutable</text>
+
+    <rect x="740"  y="10" width="120" height="44" rx="6" fill="#161b22" stroke="#bb9af7" stroke-width="1.5"/>
+    <text text-anchor="middle" x="800"  y="30" fill="#e6edf3" font-size="12" font-weight="600">PLUSD</text>
+    <text text-anchor="middle" x="800"  y="44" fill="#8b949e" font-size="9">pausable</text>
+
+    <rect x="920"  y="10" width="140" height="44" rx="6" fill="#161b22" stroke="#bb9af7" stroke-width="1.5"/>
+    <text text-anchor="middle" x="990"  y="30" fill="#e6edf3" font-size="12" font-weight="600">Pausable contracts</text>
+    <text text-anchor="middle" x="990"  y="44" fill="#8b949e" font-size="9">DM · sPLUSD · WQ · WL · LR</text>
+
+    <rect x="1120" y="10" width="120" height="44" rx="6" fill="#161b22" stroke="#e0af68" stroke-width="1.5"/>
+    <text text-anchor="middle" x="1180" y="30" fill="#e6edf3" font-size="12" font-weight="600">Admin</text>
+    <text text-anchor="middle" x="1180" y="44" fill="#8b949e" font-size="9">3-of-5</text>
+
+    <!-- Lifelines -->
+    <line x1="80"   y1="54" x2="80"   y2="1190" stroke="#30363d" stroke-width="1" stroke-dasharray="4 3"/>
+    <line x1="260"  y1="54" x2="260"  y2="1190" stroke="#30363d" stroke-width="1" stroke-dasharray="4 3"/>
+    <line x1="440"  y1="54" x2="440"  y2="1190" stroke="#30363d" stroke-width="1" stroke-dasharray="4 3"/>
+    <line x1="620"  y1="54" x2="620"  y2="1190" stroke="#30363d" stroke-width="1" stroke-dasharray="4 3"/>
+    <line x1="800"  y1="54" x2="800"  y2="1190" stroke="#30363d" stroke-width="1" stroke-dasharray="4 3"/>
+    <line x1="990"  y1="54" x2="990"  y2="1190" stroke="#30363d" stroke-width="1" stroke-dasharray="4 3"/>
+    <line x1="1180" y1="54" x2="1180" y2="1190" stroke="#30363d" stroke-width="1" stroke-dasharray="4 3"/>
+
+    <!-- PHASE 1: Detection -->
+    <rect x="10" y="70" width="1240" height="140" rx="4" fill="rgba(247,118,142,0.05)" stroke="rgba(247,118,142,0.18)" stroke-width="1"/>
+    <text x="20" y="90" fill="#f7768e" font-size="11" font-weight="600">1. DETECT</text>
+
+    <line x1="80" y1="130" x2="255" y2="130" stroke="#f7768e" stroke-width="1.2" marker-end="url(#in-rd)"/>
+    <text x="90" y="122" fill="#f7768e" font-size="11">alert(anomaly)</text>
+    <text x="90" y="165" fill="#8b949e" font-size="10" font-style="italic">e.g. mint burst, LoanRepaid without USDC inflow, whitelist churn.</text>
+
+    <!-- PHASE 2: Pause cascade -->
+    <rect x="10" y="220" width="1240" height="160" rx="4" fill="rgba(247,118,142,0.04)" stroke="rgba(247,118,142,0.15)" stroke-width="1"/>
+    <text x="20" y="240" fill="#f7768e" font-size="11" font-weight="600">2. PAUSE CASCADE</text>
+
+    <rect x="300" y="265" width="60" height="90" rx="4" fill="#1c2333" stroke="#f7768e" stroke-width="1.2"/>
+    <text text-anchor="middle" x="330" y="290" fill="#e6edf3" font-size="11" font-weight="600">pause()</text>
+    <text text-anchor="middle" x="330" y="307" fill="#8b949e" font-size="10">fan-out</text>
+
+    <line x1="260" y1="310" x2="295" y2="310" stroke="#f7768e" stroke-width="1.4" marker-end="url(#in-rd)"/>
+
+    <line x1="360" y1="285" x2="795" y2="285" stroke="#bb9af7" stroke-width="1.2" marker-end="url(#in-oc)"/>
+    <text x="370" y="277" fill="#e6edf3" font-size="11">PLUSD.pause()</text>
+
+    <line x1="360" y1="320" x2="985" y2="320" stroke="#bb9af7" stroke-width="1.2" marker-end="url(#in-oc)"/>
+    <text x="370" y="312" fill="#e6edf3" font-size="11">DepositManager · sPLUSD · WQ · WhitelistRegistry · LoanRegistry .pause()</text>
+
+    <!-- PHASE 3: RevokeAll -->
+    <rect x="10" y="390" width="1240" height="220" rx="4" fill="rgba(187,154,247,0.05)" stroke="rgba(187,154,247,0.20)" stroke-width="1"/>
+    <text x="20" y="410" fill="#bb9af7" font-size="11" font-weight="600">3. REVOKE ALL  —  one tx</text>
+
+    <line x1="260" y1="445" x2="615" y2="445" stroke="#f7768e" stroke-width="1.8" marker-end="url(#in-rd)"/>
+    <text x="285" y="437" fill="#f7768e" font-size="11" font-weight="600">revokeAll()</text>
+
+    <line x1="620" y1="475" x2="435" y2="475" stroke="#bb9af7" stroke-width="1.4" marker-end="url(#in-oc)"/>
+    <text x="445" y="467" fill="#bb9af7" font-size="10">revoke(FUNDER, Bridge)</text>
+
+    <line x1="620" y1="500" x2="435" y2="500" stroke="#bb9af7" stroke-width="1.4" marker-end="url(#in-oc)"/>
+    <text x="445" y="492" fill="#bb9af7" font-size="10">revoke(WHITELIST_ADMIN, Bridge)</text>
+
+    <line x1="620" y1="525" x2="435" y2="525" stroke="#bb9af7" stroke-width="1.4" marker-end="url(#in-oc)"/>
+    <text x="445" y="517" fill="#bb9af7" font-size="10">revoke(YIELD_MINTER, Bridge)</text>
+
+    <line x1="620" y1="550" x2="435" y2="550" stroke="#bb9af7" stroke-width="1.4" marker-end="url(#in-oc)"/>
+    <text x="445" y="542" fill="#bb9af7" font-size="10">revoke(TRUSTEE, Trustee)</text>
+
+    <text x="445" y="578" fill="#8b949e" font-size="10" font-style="italic">v2.3: no attestor to clear (MINT_ATTESTOR retired); DepositManager pause in phase 2 blocks deposits structurally</text>
+
+    <!-- PHASE 4: Veto pending -->
+    <rect x="10" y="625" width="1240" height="140" rx="4" fill="rgba(247,118,142,0.04)" stroke="rgba(247,118,142,0.15)" stroke-width="1"/>
+    <text x="20" y="645" fill="#f7768e" font-size="11" font-weight="600">4. VETO PENDING</text>
+
+    <line x1="260" y1="685" x2="435" y2="685" stroke="#f7768e" stroke-width="1.4" marker-end="url(#in-rd)"/>
+    <text x="275" y="677" fill="#f7768e" font-size="11">cancel(scheduledId)</text>
+    <text x="275" y="718" fill="#8b949e" font-size="10" font-style="italic">Any scheduled op by the compromised key is cancelable until it executes. Loop over queued ids.</text>
+
+    <!-- PHASE 5: Investigate -->
+    <rect x="10" y="780" width="1240" height="70" rx="4" fill="#161b22" opacity="0.5"/>
+    <defs>
+      <pattern id="hatch" patternUnits="userSpaceOnUse" width="6" height="6" patternTransform="rotate(45)">
+        <line x1="0" y1="0" x2="0" y2="6" stroke="#8b949e" stroke-width="1" opacity="0.35"/>
+      </pattern>
+    </defs>
+    <rect x="10" y="780" width="1240" height="70" rx="4" fill="url(#hatch)" opacity="0.4"/>
+    <text x="20" y="802" fill="#8b949e" font-size="11" font-weight="600">5. INVESTIGATE  —  off-chain</text>
+    <text x="20" y="822" fill="#8b949e" font-size="10">Audit logs · blast radius · key provisioning · restate off-chain book if needed.</text>
+
+    <!-- PHASE 6: Recovery -->
+    <rect x="10" y="870" width="1240" height="240" rx="4" fill="rgba(158,206,106,0.04)" stroke="rgba(158,206,106,0.18)" stroke-width="1"/>
+    <text x="20" y="890" fill="#9ece6a" font-size="11" font-weight="600">6. RECOVER  —  48h timelock</text>
+
+    <line x1="1180" y1="920" x2="445" y2="920" stroke="#bb9af7" stroke-width="1.2" marker-end="url(#in-oc)"/>
+    <text x="500" y="912" fill="#e6edf3" font-size="11">schedule(grantRole, newBridgeKey)</text>
+
+    <line x1="1180" y1="945" x2="445" y2="945" stroke="#bb9af7" stroke-width="1.2" marker-end="url(#in-oc)"/>
+    <text x="500" y="937" fill="#e6edf3" font-size="11">schedule(grantRole, newTrusteeKey)</text>
+
+    <rect x="440" y="960" width="740" height="22" rx="4" fill="rgba(158,206,106,0.10)" stroke="#9ece6a" stroke-width="1" stroke-dasharray="3 2"/>
+    <text text-anchor="middle" x="810" y="975" fill="#9ece6a" font-size="10">48h Admin delay</text>
+
+    <line x1="1180" y1="1005" x2="445" y2="1005" stroke="#bb9af7" stroke-width="1.4" marker-end="url(#in-oc)"/>
+    <text x="500" y="997" fill="#e6edf3" font-size="11">execute · grant FUNDER · WL_ADMIN · YIELD_MINTER · TRUSTEE</text>
+
+    <line x1="1180" y1="1045" x2="795" y2="1045" stroke="#bb9af7" stroke-width="1.2" marker-end="url(#in-oc)"/>
+    <text x="810" y="1037" fill="#e6edf3" font-size="11">PLUSD.unpause()</text>
+
+    <line x1="1180" y1="1075" x2="985" y2="1075" stroke="#bb9af7" stroke-width="1.2" marker-end="url(#in-oc)"/>
+    <text x="995" y="1067" fill="#e6edf3" font-size="11">DepositManager · sPLUSD · WQ · WL · LR .unpause()</text>
+
+    <!-- PHASE 7: Escalate -->
+    <rect x="10" y="1120" width="1240" height="70" rx="4" fill="rgba(247,118,142,0.03)" stroke="rgba(247,118,142,0.15)" stroke-width="1" stroke-dasharray="4 3"/>
+    <text x="20" y="1140" fill="#f7768e" font-size="11" font-weight="600">7. ESCALATE  —  optional</text>
+
+    <line x1="260" y1="1170" x2="435" y2="1170" stroke="#f7768e" stroke-width="1.2" stroke-dasharray="4 3" marker-end="url(#in-rd)"/>
+    <text x="275" y="1162" fill="#f7768e" font-size="10">schedule(enterShutdown)</text>
+    <text x="500" y="1170" fill="#8b949e" font-size="10" font-style="italic">→ see Shutdown</text>
+  </svg>
+</div>
+
+<script>
+function switchTab(id) {
+  document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
+  document.querySelectorAll('.diagram-container').forEach(d => d.classList.remove('active'));
+  document.getElementById(id).classList.add('active');
+  const tabs = document.querySelectorAll('.tab');
+  const names = ['system-context','role-topology','deposit-mint','stake-unstake','withdraw-settle','loan-lifecycle','yield','shutdown','incident'];
+  const idx = names.indexOf(id);
+  if (idx >= 0) tabs[idx].classList.add('active');
+}
+</script>
+</body>
+</html>

--- a/docs/references/security.md
+++ b/docs/references/security.md
@@ -1,0 +1,175 @@
+# Pipeline Mint Trust Model
+
+**Status:** the defences proposed in this document are implemented in `smart-contracts.md` v2.3 (DepositManager, two-party yield attestation, reserve invariant, three economic caps). This document captures the threat model, peer-protocol analysis, and design rationale. It is the reference for auditors and for engineers asking "why is it built this way?".
+
+This document:
+
+- Analyses the attack surface of PLUSD mint paths.
+- Surveys how peer protocols (Ethena, Ondo, MakerDAO, Chainlink, Lido) mitigate the same risks.
+- Specifies the layered MVP defence stack.
+
+The defence is layered: each layer independently reduces blast radius, and no single compromise — Bridge, custodian, or governance Safe — allows an unbacked mint.
+
+PLUSD mints 1:1 against USDC on deposit — no NAV scaling, no price oracle on the deposit leg. The reserve invariant for MVP is enforced by on-chain cumulative counters in the mint contract itself. A full Chainlink Proof of Reserve integration is deferred to phase 2, to be delivered before TVL crosses a threshold the team will set.
+
+---
+
+## Pre-v2.3 baseline (for context)
+
+Before v2.3, PLUSD was minted by the Bridge backend through EIP-712 signed attestations. The Bridge held four on-chain roles:
+
+1. **MINT_ATTESTOR** — signed deposit attestations
+2. **YIELD_MINTER** — minted yield into the sPLUSD vault
+3. **FUNDER** — funded the Withdrawal Queue
+4. **WHITELIST_ADMIN** — managed the KYC whitelist
+
+Governance is provided by three Safes:
+
+1. **Admin 3/5** — 48h timelock on system changes
+2. **Risk Council 3/5** — 24h timelock on risk parameters
+3. **Guardian 2/5** — instant pause and cancel
+
+The threat-model analysis below was performed against this baseline and drove the v2.3 redesign.
+
+---
+
+## Threat model
+
+Attack vectors by single-role / single-key compromise:
+
+| Compromise | What the attacker does, step by step | Net effect |
+|---|---|---|
+| **Bridge signing key + WHITELIST_ADMIN** (both held by Bridge in the old design) | 1) Add an attacker-controlled address to the whitelist. 2) Sign a fake attestation: "address X deposited 10M USDC, tx hash 0xdead…". 3) Submit to `PLUSD.claimMint()`. Contract verifies the signature (valid — it is the real Bridge key), checks the tx hash is unused (true — it is invented), checks the address is whitelisted (true — step 1), mints 10M PLUSD to the attacker. 4) Attacker requests redemption and waits for Trustee to fund, or dumps on the secondary market. | Unbacked PLUSD minted. Capital Wallet USDC drained when the redemption is funded. Direct theft. **This is the Resolv exploit shape.** |
+| **Bridge signing key ONLY** (WHITELIST_ADMIN split off) | Attacker can forge attestations but only to already-whitelisted LPs. Minted PLUSD goes to those LPs' addresses — not to the attacker. Victims receive unsolicited PLUSD. | No direct theft, but supply inflates, sPLUSD share price collapses on next valuation, LPs rush to redeem, Capital Wallet drained by legitimate redemptions of bogus PLUSD. Still catastrophic even if one step removed. |
+| **YIELD_MINTER** | 1) Pre-attack: attacker quietly buys sPLUSD shares on the secondary market. 2) Attack: calls `PLUSD.yieldMint(sPLUSDVault, huge_amount)`. PLUSD lands in the vault, sPLUSD share price jumps. 3) Redeems inflated sPLUSD for PLUSD, then requests PLUSD redemption for USDC through the Withdrawal Queue. | Dilutes all other sPLUSD holders. Capital Wallet drained by the queue payout. Indirect theft via share-price manipulation. |
+| **FUNDER** (Withdrawal Queue) | FUNDER on its own does NOT enable theft. To extract value, an attacker still needs a queue entry they can claim, which requires burning PLUSD they legitimately hold. FUNDER only lets them accelerate payout of their own legitimate claim. | Not an independent drain path. Dangerous only when paired with a mint compromise (the mint creates attacker-owned PLUSD; FUNDER lets them jump the queue to extract faster). |
+| **WHITELIST_ADMIN alone** | Attacker can add addresses to the whitelist. On its own, adding a whitelisted address does not mint anything. | Not an independent drain path. Dangerous only when paired with MINT_ATTESTOR compromise (it is the "send the loot to me" lever). |
+| **Trustee** (Capital Wallet co-signer) | Cannot mint PLUSD on-chain. Can co-sign Capital Wallet outflows — the off-chain equivalent of the same problem. | Mitigated by the custodian's own policy controls (whitelisted outbound addresses, amount thresholds, second co-signer). Out of scope for on-chain defence design, but in scope for custodian configuration. |
+
+### Additional v2.3 threat rows
+
+| Compromise | Mechanism | Net effect / mitigation |
+|---|---|---|
+| **UPGRADER / ADMIN Safe** (UUPS upgrade) | Schedule `upgradeTo(maliciousImpl)` that removes reserve invariant or mints freely. | 48h AccessManager delay + Guardian cancel + EIP-712 domain pin check in `_authorizeUpgrade` + EmergencyRevoker is non-upgradeable. 14-day meta-timelock on delay changes prevents a "collapse the delay then exploit" sequence. |
+| **Bridge yield-sig + custodian co-signer joint compromise** | Produce a valid `YieldAttestation` with both sigs. PLUSD mints; `cumulativeYieldMinted` self-advances; Layer 1b internal invariant passes because counters and supply move in lockstep. | Defence is **Layer 3 watchdog** (reconcile on-chain mints vs custodian-reported inflows + Bridge's own reserve reconciliation — see §5.6 invariant) and phase-2 Chainlink PoR. Layer 1b alone does NOT catch this. |
+| **Trustee + yield-attestor joint compromise** | Trustee fabricates `LoanClosed(..., EarlyRepayment)` event; yield-attestor pair signs attestation claiming the repayment; mint lands. | Same defence as above (watchdog + PoR). Independent custodian ledger check on Layer 2 co-sig catches it if the custodian verifies actual USDC inflow; if the custodian's own records are forged by the joint compromise, the attack is bounded by Layer 0 caps. |
+| **First-deposit ERC-4626 inflation on sPLUSD** | Attacker is first depositor, donates USDC directly to vault, next LP's shares are rounded to zero. | OZ v5.x `ERC4626Upgradeable` with `_decimalsOffset` mitigation (dead-shares seed). Source spec §4.2 called this out; `smart-contracts.md` §6 confirms implementation. Audit test: first-deposit donation attempt at live config. |
+| **Reentrancy on mint/burn paths** | Re-enter `yieldMint` or `mintForDeposit` inside a callback during `_mint`, before counters are updated. | Not possible: counter increments happen BEFORE `_mint` (spec §5), and all entry points carry `nonReentrant` (`claimMint` removed; new entries `mintForDeposit` and `yieldMint` both nonReentrant). PLUSD is non-transferable and has no external callback in its transfer path. |
+| **Governance capture via overlapping signer sets** | Same people sign Admin + Risk Council + Guardian — turning the three-Safe model into a single-Safe model. | Signer-disjointness is an **operational requirement** enforced off-chain: distinct multisig member sets across Admin (3/5), Risk Council (3/5), and Guardian (2/5). Violation collapses 48h timelock to nominal. Source spec §1.5 confirms disjoint signer requirement. Recommend at least one external signer on Guardian. |
+| **Watchdog compromise or offline** | Watchdog fails to detect mint-vs-inflow divergence; Layer 3 becomes inoperable. | Watchdog should run on infra disjoint from Bridge. Its signal is a Guardian-trip recommendation, not an autonomous on-chain action. Fallback: Trustee and any Guardian member can raise alerts independently. Accepted gap in MVP. |
+| **LP sanctioned post-mint** | LP holds PLUSD and is subsequently added to OFAC / flagged by Chainalysis. | Bridge calls `WhitelistRegistry.revokeAccess(lp)`. Subsequent withdrawal attempts: if LP is at queue head, Bridge calls `skipSanctionedHead` (requires `!isAllowed`). ADMIN can use `adminRelease(Pending)` to remove the entry. PLUSD already held is frozen from further transfers by the non-transferability rule (every transfer requires a system-address leg). Product surface: WQ lifecycle diagram shows admin cancel/delay path. |
+| **Guardian griefing (DoS, not theft)** | Guardian (2/5) repeatedly cancels scheduled Admin operations, blocking every parameter change or role grant. | Not a theft vector but a liveness issue. Admin can rotate Guardian signers (via its own 48h-timelocked grant), but that grant is itself Guardian-cancelable — the failure mode is "stuck at current config" until off-chain resolution. Accepted risk; mitigated by distinct signer sets and contractual obligations on Guardian members. |
+
+**Two observations from the primary threat table drove the highest-leverage defensive moves:** (a) FUNDER is not an independent drain path, (b) MINT_ATTESTOR without WHITELIST_ADMIN causes chaos but not direct self-theft. Splitting MINT_ATTESTOR from WHITELIST_ADMIN was one option; *eliminating MINT_ATTESTOR entirely* was the better one — hence Layer 1 (DepositManager) below.
+
+**Chainalysis 90-day freshness as a second-factor gate.** The WhitelistRegistry enforces `isAllowedForMint` freshness (90-day window) on every mint path via PLUSD's `_update`. Expired screening blocks mints even for whitelisted LPs. This means WHITELIST_ADMIN alone cannot enable a mint: the attacker would need the whitelist flag AND a fresh screening timestamp from Bridge. Source spec §8 requires this behaviour.
+
+---
+
+## What peer protocols do
+
+| Protocol | Relevant mechanism | Takeaway for Pipeline |
+|---|---|---|
+| **Ethena (USDe)** | EIP-712 signed mint orders; 100k USDe per-block hard cap; separate GATEKEEPER role that can disable mint/redeem (pause-only, not unpause); 7/10 cold multisig owns contracts. | Closest analog to Pipeline's old attestation pattern. Caps blast radius to ~$300k per block even with a fully compromised minter key. Pause-only role independent of owner is exactly Pipeline's Guardian. |
+| **Resolv (USR)** — exploited March 2026 | Single AWS KMS signing key. Signature validity was the ONLY check. No collateral ratio check, no supply cap, no rate limit. | Cautionary tale. Pipeline's pre-v2.3 design had the same shape. $25M extracted in 17 minutes. **Must not ship without on-chain economic bounds.** |
+| **Ondo (OUSG)** — OUSGInstantManager | User calls `mint(usdcAmount)`. Contract pulls USDC atomically via `transferFrom`, reads NAV from oracle, mints OUSG, forwards USDC to Coinbase custody. All atomic, no off-chain attestor gates the deposit leg. | Proven open-source pattern that delivers instant UX with no off-chain signer trust on the deposit leg. Directly adopted by Pipeline in v2.3 (DepositManager). |
+| **Chainlink Proof of Reserve** (TUSD, Cache Gold, PoundToken) | Oracle feed carries custodian-attested cumulative reserves. Token's `mint()` reverts if `totalSupply + amount > reserveFeed.latestAnswer()`. Stale feed reverts. | Structural bound that cannot be bypassed even with full mint-key compromise. Pipeline needs a custom variant (tracking LP inflows + interest receipts, not balance-in-wallet) because USDC legitimately leaves Capital Wallet to fund credit lines. Target: phase 2. |
+| **MakerDAO (PSM, DC-IAM)** | Debt Ceiling Instant Access Module: per-module max line (hard ceiling), target available debt (governance-set gap), ceiling-increase cooldown. | Governance sets the envelope; anyone can move within it. Pattern Pipeline copies for its supply cap and rolling-window cap parameters. |
+| **Lido (stETH)** | 1:1 trustless minting: sending ETH to the deposit contract atomically mints stETH. No off-chain signer, no attestor. L2 bridges use native lock-and-mint only. | Principle: do not add an off-chain signer when you can verify on-chain. Pipeline cannot fully replicate (custodied USDC is not equivalent to an ETH deposit contract), but the principle drives the DepositManager design. |
+
+---
+
+## MVP defence stack
+
+Five layers, each independent. All layers ship for MVP. Full Chainlink Proof of Reserve is phase 2. The guiding principle: **no single compromise — Bridge, custodian, or a single governance Safe — should permit an unbacked mint.** (A *joint* compromise of Bridge's yield key AND the custodian signer still mints; that scenario is bounded by Layer 0 caps and detected by Layer 3 watchdog reconciliation — see threat rows above.)
+
+### Layer 0 — Economic bounds on mint
+
+Three numeric caps enforced by the PLUSD contract itself, managed by the Admin Safe 3/5 through the 48h AccessManager timelock:
+
+1. **Rolling 24-hour window cap** (`maxPerWindow`) — aggregate across all LPs.
+2. **Per-LP per-window cap** (`maxPerLPPerWindow`) — prevents single-LP concentration.
+3. **Hard total supply ceiling** (`maxTotalSupply`) — MakerDAO PSM debt-ceiling analog.
+
+Tightening any cap is instant; loosening requires the 48h timelock. Per-transaction caps (`maxPerTx`) were considered and dropped in v2.3 — per-LP-per-window already bounds any one actor, and per-tx caps create UX friction for legitimate large deposits without a security benefit.
+
+### Layer 1 — DepositManager (atomic 1:1 on-chain deposit, no attestor)
+
+A new DepositManager contract using Ondo's OUSGInstantManager pattern, simplified to omit NAV scaling (PLUSD is 1:1 with USDC). Replaces the EIP-712 self-claim attestation flow entirely on the deposit leg. Users call `deposit(usdcAmount)` directly; the contract:
+
+- Atomically pulls USDC from the LP via `transferFrom(lp, capitalWallet, amount)` — one transfer, LP → Capital Wallet directly.
+- Calls `PLUSD.mintForDeposit(lp, amount)` — restricted to DEPOSITOR role held by DepositManager.
+- Enforces whitelist-for-mint inside PLUSD's `_update`.
+
+The on-chain USDC move IS the attestation — there is no off-chain signer to forge, and no way to mint without the USDC actually moving. The MINT_ATTESTOR role is retired. WHITELIST_ADMIN is retained as a KYC gate but is no longer a loot-enabling lever because minting is cryptographically bound to the caller's own USDC transfer. **This single layer eliminates the Resolv attack class entirely for the deposit flow.** Instant 1:1 UX is preserved — and improved, because the mint is one transaction instead of two.
+
+### Layer 1b — Contract-tracked reserve invariant
+
+PLUSD maintains three cumulative counters on-chain, updated in the same transactions that move value:
+
+- `cumulativeLPDeposits` — incremented on every `mintForDeposit`
+- `cumulativeYieldMinted` — incremented on every `yieldMint` call
+- `cumulativeLPBurns` — incremented when PLUSD is burned for redemption via WQ
+
+Every mint path — `mintForDeposit` and `yieldMint` — checks the invariant before executing:
+
+```
+totalSupply(PLUSD) + amount  ≤  cumulativeLPDeposits + cumulativeYieldMinted − cumulativeLPBurns
+```
+
+The invariant reverts any mint that would break the accounting identity. This is **not a true Proof of Reserve** — it verifies consistency inside the contract, not that USDC actually arrived at the custodian — but it structurally prevents the Resolv-shape attack on the yield-mint path (which has no user-provided collateral to gate it) by converting it into a self-check the contract performs against its own ledger. Full custodian-backed Chainlink PoR is phase 2, delivered before TVL crosses the team-defined threshold.
+
+### Layer 2 — Two-party attestation for yield mints
+
+Yield mints are the remaining signer-dependent path because no user-side collateral can gate them — the yield is an abstract off-chain P&L event (loan repayments and USYC accretion). The defence is a two-party EIP-712 signed attestation:
+
+- **Bridge** signs first with its `bridgeYieldAttestor` key (ECDSA).
+- The **custodian-provisioned EIP-1271 signer contract** independently verifies the underlying USDC inflow against the custodian's own ledger and signs second. The backend signing policy is driven by the custodian's platform (Fireblocks API Co-Signer callback handler, BitGo Policy Engine webhook, or equivalent), which routes every signing request through the custodian's operational controls before returning a signature. The on-chain contract does not call the custodian's REST API directly; it validates the resulting signature via `IERC1271.isValidSignature` → `0x1626ba7e`.
+- `PLUSD.yieldMint(att, bridgeSig, custodianSig)` verifies both signatures on-chain.
+
+Compromising Bridge alone mints zero PLUSD. Compromising the custodian alone mints zero PLUSD. Both platforms (Fireblocks Co-Signer Callback Handler and BitGo webhook-based policy) support this automation natively.
+
+### Layer 3 — Guardian pause + off-chain watchdog
+
+The Guardian Safe (2/5) can instantly pause any managed contract and cancel any scheduled operation. For the mint defence, Guardian's scope covers pausing DepositManager (stops all new deposits) and PLUSD (freezes everything). An off-chain watchdog service continuously compares on-chain mint events against custodian-reported inflows and can trip Guardian on divergence, giving sub-minute reaction time against any defence-layer failure.
+
+### Layer 4 — Timelock action table
+
+All role rotations, parameter loosenings, and mint-path reconfigurations are timelocked. A compromised Admin Safe can print new PLUSD only in 48 hours, and the Guardian can cancel it within that window. Tightening actions (lower a cap, revoke a role, pause a contract) are instant. This matches OpenZeppelin TimelockController best practice.
+
+| Action | Caller | Delay | Canceler |
+|---|---|---|---|
+| Pause any managed contract | Guardian 2/5 | instant | — |
+| Cancel any scheduled operation | Guardian 2/5 | instant | — |
+| Revoke any role (EmergencyRevoker) | Guardian 2/5 | instant | — |
+| Lower any cap (tighten) | Admin 3/5 | instant | — |
+| Rotate YIELD_MINTER holder | Admin 3/5 | 48h | Guardian |
+| Rotate FUNDER holder | Admin 3/5 | 48h | Guardian |
+| Rotate WHITELIST_ADMIN holder | Admin 3/5 | 48h | Guardian |
+| Rotate TRUSTEE (LoanRegistry) | Admin 3/5 | 48h | Guardian |
+| Rotate yield-attestor keys (`proposeYieldAttestors`) | Admin 3/5 | 48h | Guardian |
+| Grant any new role to any address | Admin 3/5 | 48h | Guardian |
+| Raise hard supply cap | Admin 3/5 | 48h | Guardian |
+| Raise rolling-window mint cap | Admin 3/5 | 48h | Guardian |
+| Raise per-LP cap | Admin 3/5 | 48h | Guardian |
+| Upgrade ReserveFeed source address (phase 2) | Admin 3/5 | 48h | Guardian |
+| Change ReserveFeed staleness threshold (phase 2) | Admin 3/5 | 48h | Guardian |
+| Change yield-split parameter | Admin 3/5 | 48h | Guardian |
+| Replace DepositManager (deploy new version) | Admin 3/5 | 48h | Guardian |
+| `adminRelease(Pending)` — unstick pending queue entry | Admin 3/5 | instant | — |
+| `adminReleaseFunded` — release a Funded entry blocked by sanctions | Admin 3/5 | 24h | Guardian |
+| `adjustRecoveryRateUp` (shutdown waterfall) | Risk Council 3/5 | 24h | Guardian |
+| Unpause any managed contract | Admin 3/5 | 48h | Guardian |
+
+---
+
+## Internal rug containment
+
+The second half of the original question — *"if we (the team) decide to scam, how is our own ability to mint PLUSD bounded?"* — is answered structurally, not by policy promises:
+
+- **Flat-topology, no proxies:** mint logic cannot be upgraded out from under users. Any change requires deploying a new contract and migrating through a 48h-timelocked Admin Safe action.
+- **Custodian as independent signer (Layer 2):** yield mints require a regulated third-party's EIP-712 signature in addition to Bridge's. The team cannot mint yield without the custodian's co-operation; the custodian has legal liability and independent compliance controls.
+- **Reserve-bounded mint (Layer 1b, with phase-2 Chainlink PoR):** the invariant is computed from on-chain data the team cannot forge. If the team tries to over-mint beyond attested reserves, the mint reverts at the contract level.
+- **Economic caps (Layer 0):** even within attested reserves, rolling-window and per-LP caps limit what can be minted in any 24h period.
+- **Timelocked role rotation (Layer 4):** the team cannot silently swap signing keys to a controlled address — every rotation is visible on-chain for 48 hours and can be cancelled by the Guardian Safe (which can be constituted with external members).
+- **Open-source backend + reproducible builds:** community can verify the Bridge binary matches the published source. Combined with on-chain invariants above, backend behaviour is bounded by what the contracts accept.

--- a/docs/references/smart-contracts.md
+++ b/docs/references/smart-contracts.md
@@ -1,0 +1,1618 @@
+# Pipeline MVP Smart Contract Design Specification
+
+**Version:** 2.3
+**Date:** 2026-04-20
+**Status:** Min-trust-model integration — supersedes v2.2
+**Source spec:** `docs/sources/Pipeline_MVP_Technical_Spec_v0_3_8.docx` + Mint Trust Model (`docs/specs/security.md`)
+**Scope:** Smart contract layer only (8 contracts + shared AccessManager + EmergencyRevoker)
+
+---
+
+## Changelog
+
+**v2.3 (2026-04-20)** — Min-trust mint model. Integrates the Mint Trust Model review (2026-04-20). Structural goal: no single compromise — Bridge, custodian, or a single governance Safe — can produce unbacked PLUSD.
+
+- **M1 — DepositManager (atomic 1:1 deposit, no attestor).** New contract replacing the `claimMint` / EIP-712 mint-attestation flow entirely. LP calls `deposit(usdcAmount)` directly; the contract pulls USDC via `transferFrom(lp, capitalWallet, amount)` in a single on-chain transfer, then calls `PLUSD.mintForDeposit(lp, amount)`. The on-chain USDC move IS the attestation — there is no off-chain signer to forge. Adapted from Ondo's `OUSGInstantManager` pattern, simplified to omit NAV scaling (PLUSD is 1:1 against USDC).
+- **M2 — MINT_ATTESTOR role retired.** All state and functions supporting it are removed from PLUSD: `mintAttestor`, `usedAttestations`, `usedDepositRefs`, `attestationWindow`, `MINT_ATTESTATION_TYPEHASH`, `claimMint`, `setMintAttestor`, `setAttestationWindow`, `invalidateAttestation`, `emergencyClearAttestor`. The Resolv attack class (single-key signature forges unbacked supply) is structurally closed for the deposit leg.
+- **M3 — New `DEPOSITOR` role on PLUSD.** Held by the DepositManager proxy address. Gates the new `mintForDeposit(lp, amount)` entry point — the only path through which deposit-driven mints reach `_update`.
+- **M4 — Reserve invariant on every mint path.** PLUSD maintains three cumulative counters — `cumulativeLPDeposits`, `cumulativeYieldMinted`, `cumulativeLPBurns` — updated in the same transaction that moves value. Every mint (`mintForDeposit`, `yieldMint`) and every burn (`burn` by WQ) checks: `totalSupply + amount ≤ cumulativeLPDeposits + cumulativeYieldMinted − cumulativeLPBurns`. Not a true Proof of Reserve (verifies internal consistency, not custodian balance), but structurally prevents Resolv-shape over-minting against its own ledger. Full Chainlink PoR deferred to phase 2.
+- **M5 — Two-party yield attestation.** `yieldMint(YieldAttestation, bridgeSig, custodianSig)` now verifies *two* EIP-712 signatures on-chain: Bridge (ecrecover on `bridgeYieldAttestor` address) and custodian (EIP-1271 `isValidSignature` on `custodianYieldAttestor` contract — Fireblocks API Co-Signer or BitGo Policy engine). Still `restricted(YIELD_MINTER)` on the caller, so three independent controls gate yield issuance. Compromising Bridge alone mints zero; compromising the custodian alone mints zero. New typehash: `YieldAttestation(bytes32 repaymentRef, address destination, uint256 amount, uint64 deadline, uint256 salt)`. New replay map: `usedRepaymentRefs`.
+- **M6 — Economic caps.** Three numeric caps on the PLUSD mint path: `maxPerWindow` (rolling-window cap on total mint volume, existed in v2.2), `maxPerLPPerWindow` (caps single-LP mint activity per rolling window, new), `maxTotalSupply` (hard ceiling on `PLUSD.totalSupply()` — MakerDAO PSM debt-ceiling analog, new). **Per-tx cap (`maxPerTx`) dropped in v2.3** — redundant given per-LP per-window already bounds any one actor, and it creates UX friction for legitimate large deposits without a security benefit. Tightening any cap is instant (ADMIN); loosening is 48h via AccessManager.
+- **M7 — EmergencyRevoker simplified.** No longer references PLUSD (no attestor to clear). `revokeAll()` now revokes FUNDER, WHITELIST_ADMIN, YIELD_MINTER from Bridge and TRUSTEE from Trustee. Guardian pauses DepositManager and PLUSD directly.
+
+**v2.2 (2026-04-15)** — Merged canonical release. Incorporates the v2.2 delta review (three critic passes — security, spec-consistency, DeFi-design) and the originator's post-delta simplifications.
+
+- **U1 — Bounded upgradeability.** UUPS proxies on every protocol contract except EmergencyRevoker. `upgradeTo` gated by `UPGRADER` role (ADMIN 3/5) with 48h AccessManager delay; GUARDIAN 2/5 can cancel any pending upgrade. Every implementation constructor calls `_disableInitializers()`. EIP-712 `name`/`version` pinned as compile-time constants to prevent silent domain-separator drift across upgrades. 14-day meta-timelock on `setTargetAdminDelay` to prevent a collapse-delay-then-exploit sequence.
+- **U2 — Non-transferable PLUSD.** `_update` requires exactly one of `(from, to)` to be a system address. LP↔LP and system↔system both revert. The previous free-transfer model is closed; yield venue access is still possible because venues are in the `venueAllowlist`, but laundering between two system wallets is prevented structurally.
+- **U3 — WithdrawalQueue claim model.** New lifecycle `Pending → Funded → Claimed | AdminReleased`. Bridge funds the queue head with USDC via `fundRequest`; LP later calls `claim` to atomically burn PLUSD and receive USDC. Strict FIFO on funding with automatic skip of sanctioned heads to prevent queue-DoS.
+- **U4 — Shutdown mode (Option A, symmetric haircut).** `ShutdownController` contract freezes all normal flow, fixes a `recoveryRateBps`, and opens a one-way `redeemInShutdown` path on PLUSD and `claimAtShutdown` on WQ. Funded requests pay the haircut too (Maker-cage style), closing the queue-jump exploit class.
+- **U5 — Three-Safe governance.** ADMIN 3/5 (role management, upgrades, parameter changes), RISK_COUNCIL 3/5 (proposes `setDefault` and `enterShutdown`), GUARDIAN 2/5 (instant pause, cancel any pending scheduled action, `EmergencyRevoker.revokeAll`). Distinct signer sets. *Revised in v2.3: `emergencyClearAttestor` retired with MINT_ATTESTOR; Guardian now pauses DepositManager directly.*
+- **U6 — Mint architecture.** Direct `PLUSD.mint(address,uint256)` is removed. Fresh PLUSD enters supply only via (a) `mintForDeposit(lp, amount)` called by DepositManager during an atomic 1:1 USDC→PLUSD deposit, or (b) `yieldMint(att, bridgeSig, custodianSig)`, a destination-constrained two-party-attested path for yield accrual (restricted to sPLUSD vault or Treasury). *Revised in v2.3 from the original EIP-712 `claimMint` self-claim flow; see M1/M2/M5 above.*
+- **U7 — EmergencyRevoker non-upgradeable.** One call from GUARDIAN atomically revokes FUNDER, WHITELIST_ADMIN, YIELD_MINTER from the Bridge address and TRUSTEE from the Trustee address. Bridge and Trustee target addresses are ADMIN-updatable with 48h timelock to accommodate routine key rotation. *Revised in v2.3: no longer touches PLUSD (no attestor to zero); see M7.*
+- **U8 — Pull-based shutdown unwind.** sPLUSD holders exit post-shutdown through the standard ERC-4626 `redeem` (which returns depegged PLUSD) and then through `PLUSD.redeemInShutdown` for recovery-rate USDC. No special-case shutdown share-conversion function — the race-drain concern is resolved because `redeemInShutdown` pays at a frozen protocol-wide rate, not first-come.
+
+**Post-delta simplifications (originator decision, 2026-04-15) — override the v2.2 delta where they conflict:**
+
+- **`adjustRecoveryRateDown` is dropped.** Recovery rate ratchets **up only** via `adjustRecoveryRateUp` (24h timelock, RISK_COUNCIL). Rationale: lowering the rate after entry transfers value from patient LPs to early exiters, which is strictly anti-LP; rate should only increase as Trustee repatriates capital. All references to the 7d downward delay and the fairness-justification discussion are removed.
+- **`convertSharesAtShutdown` is dropped.** sPLUSD holders exit during shutdown via normal `sPLUSD.redeem()` — which returns (depegged) PLUSD — and then redeem through `RecoveryPool` via the standard PLUSD `redeemInShutdown` path. `sPLUSD.redeem` stays open post-shutdown for exit; there is no special-case shutdown conversion function.
+- **F-8 pool pre-fund invariant is dropped.** The requirement that `RecoveryPool.balance >= totalSupply × recoveryRateBps` at the moment `enterShutdown` executes was non-sensical — a real crisis implies there is no USDC to pre-fund with. `RecoveryPool` starts at whatever balance it has; the recovery rate is set accordingly at entry from the current pool balance; Trustee tops up the pool over time. Ongoing-operation solvency invariants (rate × outstanding ≤ pool + pending inflows) remain.
+- **`setDefault` timelock = 24h** (not 6h). Consistent with the 24h delay already used for shutdown entry.
+
+**v2.1 (2026-04-14)** — Post-alignment reversals after the second Telegram round with the originator. Product-level, not correctness-level.
+
+- **R1 — LoanRegistry reinstated.** Soulbound ERC-721 with immutable + amendable parameter groups. Not in audit scope; no capital touchpoints.
+- **R2 — Custodian-side withdrawal enforcement made explicit.** LP-withdrawal destination matching and cumulative cap enforced by custodian MPC policy engine (Fireblocks/BitGo), not by smart contracts. Documented at §7, §10, §11, §15.
+- **R3 — EmergencyRevoker extended to four revocations.** (Subsequently extended further in v2.2; see U7.)
+
+**v2.0 (2026-04-14)** — Simplification pass after originator alignment.
+
+- **S1 — OZ AccessManager replaces per-contract AccessControl.**
+- **S2 — WithdrawalQueue drops partial fills; strict FIFO.** (Further revised to Pending/Funded/Claimed/AdminReleased model in v2.2; see U3.)
+- **S3 — LoanRegistry removed.** (Later reinstated by R1.)
+
+**v1.1 (2026-04-14)** — Correctness pass after adversarial review.
+
+- **A1–A4** WithdrawalQueue `_advanceHead` fix, cross-rail double-spend guard, `whenNotPaused` on confirm, PLUSD `_update` ordering.
+- **C1–C5** Spec corrections aligning to intended and implemented behaviour.
+
+**v1.0 (2026-04-11)** — Initial design.
+
+---
+
+## 1. Design Principles
+
+1. **Minimise custom code.** Use OpenZeppelin v5.x audited contracts as the base for every contract. Custom logic is isolated to small, clearly-scoped extensions.
+2. **Flat topology.** Each contract is independent; roles are delegated to a single shared `AccessManager` hub (OZ v5.x). No inheritance between protocol contracts (except the shared `TimelockPending` base and the common `AccessManaged` parent). No diamonds.
+3. **Bounded upgradeability.** Protocol contracts use OZ v5.x UUPS proxies. `upgradeTo` is gated by the `UPGRADER` role held by ADMIN (3/5 Safe) and subject to a 48h AccessManager-scheduled delay. GUARDIAN (2/5) may cancel any pending upgrade during the window. EmergencyRevoker is non-upgradeable and immutable. Every implementation constructor calls `_disableInitializers()`; every implementation pins EIP-712 `name`/`version` as compile-time constants to prevent silent domain-separator drift across upgrades. A 14-day meta-timelock on `setTargetAdminDelay` prevents a "collapse the delay then exploit" sequence. Reason for reversal vs. v2.1: originator prefers in-place parameter and bug-fix paths over re-deployment ceremonies once LP capital is in the vault; 48h + GUARDIAN veto bounds concentration of trust.
+4. **On-chain safety invariants.** Rate limits, whitelist checks, non-transferability, and burn restrictions are enforced at the contract level. A compromised Bridge cannot bypass them.
+5. **Two-phase settlement with atomic claim.** Withdrawal escrows both legs (PLUSD and USDC) in WQ before burn; the LP's `claim` burns and pays atomically. Cross-rail atomicity is handled by holding state, not by assuming it.
+
+---
+
+## 2. Stack
+
+| Component | Value |
+|---|---|
+| Solidity | ^0.8.20 |
+| OpenZeppelin | v5.x (pin exact version) — AccessManager / AccessManaged, ERC1967 UUPS, EIP712Upgradeable |
+| Chain | Ethereum mainnet |
+| Governance | **3 Gnosis Safes**: ADMIN (3/5), RISK_COUNCIL (3/5), GUARDIAN (2/5) |
+| Role management | Single OZ `AccessManager` hub |
+| Upgrade | UUPS on all protocol contracts except EmergencyRevoker; 48h ADMIN delay; GUARDIAN cancel; 14d meta-timelock on delay changes |
+
+The three-Safe split:
+
+- **ADMIN 3/5** — role management, upgrades, parameter changes. Slowest, highest threshold.
+- **RISK_COUNCIL 3/5** — proposes `setDefault` (24h timelock) and `enterShutdown` (24h timelock). Distinct signer set from ADMIN so a compromised ADMIN Safe cannot declare default or enter shutdown.
+- **GUARDIAN 2/5** — instant `pause` on every pausable target (PLUSD, DepositManager, sPLUSD, WQ, WhitelistRegistry, LoanRegistry); `AccessManager.cancel(actionId)` on any pending scheduled action; `revokeAll` on EmergencyRevoker. Defensive-only per Morpho sentinel pattern — cannot initiate risk-increasing actions.
+
+---
+
+## 3. Contract Map
+
+| Contract | Base | Custom LOC | Roles (managed by AccessManager) |
+|---|---|---|---|
+| AccessManager (OZ) | — | 0 | ADMIN (3/5) at hub level; per-function target roles below |
+| TimelockPending (abstract) | — | ~25 | — |
+| PLUSD | ERC20Upgradeable + ERC20PausableUpgradeable + ERC20PermitUpgradeable + AccessManagedUpgradeable + UUPSUpgradeable + TimelockPending | ~110 | BURNER (WQ), DEPOSITOR (DepositManager), YIELD_MINTER (Bridge), PAUSER (GUARDIAN), UPGRADER (ADMIN) — **no generic MINTER role; `mint(address,uint256)` is removed; MINT_ATTESTOR retired in v2.3.** |
+| DepositManager (new in v2.3) | AccessManagedUpgradeable + PausableUpgradeable + ReentrancyGuardUpgradeable + UUPSUpgradeable | ~60 | PAUSER (GUARDIAN), UPGRADER (ADMIN). Holds DEPOSITOR on PLUSD. |
+| sPLUSD | ERC4626Upgradeable + ERC20PausableUpgradeable + AccessManagedUpgradeable + UUPSUpgradeable | ~35 | PAUSER (GUARDIAN), UPGRADER (ADMIN) |
+| WithdrawalQueue | AccessManagedUpgradeable + PausableUpgradeable + ReentrancyGuardUpgradeable + UUPSUpgradeable | ~140 | FUNDER (Bridge), PAUSER (GUARDIAN), ADMIN ops (3/5), UPGRADER (ADMIN) |
+| WhitelistRegistry | AccessManagedUpgradeable + TimelockPending + UUPSUpgradeable | ~95 | WHITELIST_ADMIN (Bridge), ADMIN (3/5), PAUSER (GUARDIAN), UPGRADER (ADMIN) |
+| LoanRegistry | ERC721Upgradeable (soulbound) + AccessManagedUpgradeable + PausableUpgradeable + UUPSUpgradeable | ~190 | TRUSTEE (Trustee key), RISK_COUNCIL (setDefault only, 24h delay), PAUSER (GUARDIAN), ADMIN (3/5), UPGRADER (ADMIN) |
+| ShutdownController (new) | AccessManagedUpgradeable + UUPSUpgradeable | ~75 | RISK_COUNCIL (proposeShutdown, adjustRecoveryRateUp), ADMIN (execute via AccessManager), GUARDIAN (cancel via AccessManager) |
+| RecoveryPool (new) | AccessManagedUpgradeable + PausableUpgradeable + ReentrancyGuardUpgradeable + UUPSUpgradeable | ~70 | ADMIN (deposit); `release` / `recordReturned` callable only by PLUSD and WQ (fixed addresses) |
+| EmergencyRevoker | standalone, **non-upgradeable** | ~50 | Holds AccessManager ADMIN; targets `bridge` and `trustee` are ADMIN-updatable with 48h timelock (U7). Parameterless `revokeAll()` callable only by GUARDIAN. |
+
+**Role renames and additions vs. v2.1/v2.2 (swept across all sections):**
+
+- `FILLER` → **FUNDER** (on-chain USDC pusher, held by Bridge).
+- `LOAN_MANAGER` → **TRUSTEE** (grantee: distinct Trustee key, not Bridge).
+- `MINTER` role (on PLUSD) — **removed**; see U6.
+- `MINT_ATTESTOR` (on PLUSD, v2.2) — **retired in v2.3** (M2). Replaced by DepositManager + DEPOSITOR role + two-party yield attestation.
+- **`DEPOSITOR`** (new in v2.3) — on PLUSD, held by DepositManager; gates `mintForDeposit`.
+- `PAUSER` grantee across all contracts: GUARDIAN 2/5 Safe.
+- `RISK_COUNCIL` grantee: 3/5 RISK_COUNCIL Safe (was "3/5 admin Safe" in v2.1). Threshold matches the originator source spec §1.5.
+- `UPGRADER` (new) → ADMIN 3/5 Safe; gates `_authorizeUpgrade` on every upgradeable contract.
+
+**Actor glossary.**
+
+- **Bridge** — the off-chain protocol backend. Single on-chain actor holding FUNDER, WHITELIST_ADMIN, YIELD_MINTER. Co-signs yield-mint EIP-712 attestations (alongside the custodian). **Never custodies USDC.** Does not gate deposits — those are atomic user-driven calls to DepositManager. Every USDC movement on-chain originates from the Capital Wallet (MPC) or from the LP's own wallet (deposits). Bridge's internal key material (HSM, MPC shards, custodian-managed signing keys) is an implementation detail, not an architectural actor.
+- **DepositManager** — on-chain contract through which LPs deposit USDC and receive PLUSD atomically. Holds `DEPOSITOR` on PLUSD. No off-chain signer gates the deposit leg — the USDC transfer to Capital Wallet IS the on-chain evidence of the deposit. Pull pattern: LP approves DepositManager on USDC, DepositManager calls `USDC.transferFrom(lp, capitalWallet, amount)` and `PLUSD.mintForDeposit(lp, amount)` in a single transaction.
+- **Trustee** (Pipeline Trust Company) — holds one MPC key share on the Capital Wallet and Treasury Wallet. Holder of the on-chain `TRUSTEE` role on LoanRegistry. Distinct key set from Bridge and Team.
+- **Pipeline Team** — holds one MPC key share on the Capital Wallet and Treasury Wallet. Co-signs loan disbursement and Treasury Wallet operations per source spec §1.5. Does not hold any on-chain protocol roles.
+- **Capital Wallet** — MPC-controlled on-chain address holding USDC reserves. **Cosigners: Trustee + Team + Bridge (three parties).** Different transaction categories require different cosigner combinations per custodian policy: routine LP withdrawals are auto-signed by Bridge within narrow policy bounds; loan disbursements require Trustee + Team cosign; USYC/USDC swaps within automated bands are Bridge-only. Transfers to/from Capital Wallet are on-chain ERC-20 transfers, not off-chain wires.
+- **Treasury Wallet** — MPC-controlled on-chain address for protocol fees / yield share.
+
+---
+
+## 4. Shared Base: TimelockPending
+
+Minimal timelock pattern extracted to avoid code duplication across PLUSD, WhitelistRegistry, and EmergencyRevoker.
+
+```
+abstract contract TimelockPending
+```
+
+### Constants
+
+- `TIMELOCK_DELAY`: 48 hours (default; per-use overrides where noted).
+
+### State
+
+- `mapping(bytes32 => uint256) public pendingChanges` — maps a change ID to its activation timestamp.
+
+### Internal functions
+
+- `_propose(bytes32 id, uint256 delay)` — records `block.timestamp + delay` for the change ID. Emits `ChangeProposed(id, activationTime)`.
+- `_execute(bytes32 id)` — requires `block.timestamp >= pendingChanges[id]` and `pendingChanges[id] != 0`. Deletes the pending entry. Emits `ChangeExecuted(id)`.
+- `_cancel(bytes32 id)` — deletes the pending entry. Emits `ChangeCancelled(id)`.
+
+### Design notes
+
+- Change IDs are `keccak256` of the operation and parameters (e.g., `keccak256(abi.encode("setWhitelistRegistry", newAddress))`).
+- Used for ad-hoc 48h delays on contract-local operations (system-address changes on WhitelistRegistry, EmergencyRevoker target rotation, `setYieldAttestors` on PLUSD). Role-level scheduling uses AccessManager's built-in `setTargetAdminDelay` / `schedule`.
+- OZ `TimelockController` was considered and rejected — it is a full governance primitive adding ~500 lines of inherited logic. The inline pattern is ~25 lines.
+
+---
+
+## 5. PLUSD
+
+```
+contract PLUSD is ERC20Upgradeable, ERC20PausableUpgradeable, ERC20PermitUpgradeable, AccessManagedUpgradeable, UUPSUpgradeable, TimelockPending
+```
+
+### Purpose
+
+Receipt token. Minted 1:1 against USDC deposits (via `DepositManager.deposit` → `mintForDeposit`) and against Trustee-confirmed yield events (via two-party-attested `yieldMint`). Non-transferable between LPs — every transfer has exactly one system-address leg. Backed by USD-equivalent reserves held at the custodian's Capital Wallet, verified against on-chain cumulative counters on every mint path.
+
+### Roles (via AccessManager)
+
+| Role | Holder | Can do |
+|---|---|---|
+| BURNER | WithdrawalQueue | `burn()` (WQ invokes on claim / claimAtShutdown) |
+| DEPOSITOR | DepositManager | `mintForDeposit(lp, amount)` — atomic 1:1 deposit mint |
+| YIELD_MINTER | Bridge | `yieldMint(att, bridgeSig, custodianSig)` — destination ∈ {sPLUSD vault, Treasury}; also requires both EIP-712 sigs |
+| PAUSER | GUARDIAN 2/5 | `pause()`, `unpause()` |
+| UPGRADER | ADMIN 3/5 | `upgradeTo` (48h AccessManager delay) |
+| ADMIN (hub) | ADMIN 3/5 | Parameter changes, timelocked state changes via TimelockPending |
+
+**No generic MINTER role.** `mint(address,uint256)` is removed from the ABI (U6). Fresh PLUSD enters supply only via:
+
+1. **`mintForDeposit(lp, amount)`** — restricted to DEPOSITOR (DepositManager). Used by the atomic 1:1 deposit flow (see §5b). There is no off-chain attestor on this path: the USDC transfer to Capital Wallet and the PLUSD mint happen in the same DepositManager transaction.
+2. **`yieldMint(att, bridgeSig, custodianSig)`** — restricted to YIELD_MINTER (Bridge) *and* requires two EIP-712 signatures (Bridge + custodian) verified on-chain. Destination constrained to `sPLUSD vault` or `Treasury` inside the function body. Compromising any single key on this path mints zero PLUSD.
+
+Why two-party on yield: yield mints are the only remaining signer-dependent path — no user-provided collateral can gate them, because the yield is an abstract off-chain P&L event (loan repayments, USYC accretion). The custodian independently verifies the underlying USDC inflow against its own ledger before signing. Compromising Bridge alone → zero mint. Compromising custodian alone → zero mint.
+
+### Custom state
+
+```solidity
+IWhitelistRegistry public whitelistRegistry;
+IShutdownController public shutdownController;
+
+// Rate limiting (rolling window)
+uint256 public maxPerWindow;          // default 10_000_000e6 ($10M)
+uint256 public maxPerLPPerWindow;     // default 5_000_000e6 ($5M)  — new in v2.3
+uint256 public maxTotalSupply;        // hard ceiling on totalSupply() — new in v2.3
+uint256 public windowDuration;        // default 24 hours
+uint256 public windowStart;
+uint256 public windowMinted;
+mapping(address => uint256) public lpWindowMinted;  // per-LP, cleared on window roll
+
+// Operational gate
+bool public operational;              // admin toggle, blocks non-admin ops when false
+
+// Reserve invariant (new in v2.3 — M4)
+uint256 public cumulativeLPDeposits;  // incremented in mintForDeposit
+uint256 public cumulativeYieldMinted; // incremented in yieldMint
+uint256 public cumulativeLPBurns;     // incremented in burn (from WQ)
+
+// Two-party yield attestation (new in v2.3 — M5)
+address public bridgeYieldAttestor;   // EOA — Bridge's yield-signing key
+address public custodianYieldAttestor; // EIP-1271 smart-contract signer (custodian's co-signer)
+mapping(bytes32 => bool) public usedRepaymentRefs;
+
+bytes32 public constant YIELD_ATTESTATION_TYPEHASH = keccak256(
+    "YieldAttestation(bytes32 repaymentRef,address destination,uint256 amount,uint64 deadline,uint256 salt)"
+);
+```
+
+The `repaymentRef` is deterministic and **scoped per destination**: `keccak256(abi.encode(chainId, repaymentTxHash, destinationTag))` where `destinationTag` is the string `"vault"` or `"treasury"`. One on-chain repayment produces two independent attestations (one for sPLUSD vault coupon_net, one for Treasury fees), each with its own `repaymentRef`. This lets both legs be submitted independently — each consumes its own replay slot. `salt` allows reissuance if a signature is lost in transit. `deadline` bounds attestation validity.
+
+**Removed from v2.2:** `mintAttestor`, `usedAttestations`, `usedDepositRefs`, `attestationWindow`, `attestorRotatedAt`, `MINT_ATTESTATION_TYPEHASH` (M2). The entire single-party deposit-attestation surface is gone.
+
+### Constants
+
+```solidity
+uint256 public constant MIN_WINDOW_DURATION    = 1 hours;
+uint256 public constant MAX_PER_WINDOW_CEILING = 100_000_000e6;
+uint256 public constant MAX_TOTAL_SUPPLY_FLOOR = 10_000_000e6;   // hard cap can't be set below this
+```
+
+### Functions
+
+**`decimals()`** — Returns 6. Matches USDC.
+
+**`mintForDeposit(address lp, uint256 amount)`** — `restricted` (DEPOSITOR). Called by DepositManager inside an atomic 1:1 deposit.
+
+```solidity
+function mintForDeposit(address lp, uint256 amount) external restricted nonReentrant {
+    require(!shutdownController.isActive(), "PLUSD: shutdown");
+    _requireReserveInvariant(amount);
+    cumulativeLPDeposits += amount;
+    _mint(lp, amount);  // runs _update mint-path gates: operational, isAllowedForMint, rate limits
+}
+```
+
+**`yieldMint(YieldAttestation att, bytes bridgeSig, bytes custodianSig)`** — `restricted` (YIELD_MINTER) + dual EIP-712 signature verification.
+
+```solidity
+function yieldMint(
+    YieldAttestation calldata att,
+    bytes calldata bridgeSig,
+    bytes calldata custodianSig
+) external restricted nonReentrant {
+    require(!shutdownController.isActive(), "PLUSD: shutdown");
+    require(block.timestamp <= att.deadline, "PLUSD: expired");
+    require(att.destination == address(vault) || att.destination == address(treasury), "PLUSD: bad dest");
+    require(!usedRepaymentRefs[att.repaymentRef], "PLUSD: replay");
+
+    bytes32 digest = _hashTypedDataV4(keccak256(abi.encode(
+        YIELD_ATTESTATION_TYPEHASH,
+        att.repaymentRef, att.destination, att.amount, att.deadline, att.salt
+    )));
+
+    // Bridge sig (ECDSA)
+    require(ECDSA.recover(digest, bridgeSig) == bridgeYieldAttestor, "PLUSD: bad bridge sig");
+
+    // Custodian sig (EIP-1271 smart-contract verification)
+    require(
+        IERC1271(custodianYieldAttestor).isValidSignature(digest, custodianSig) == 0x1626ba7e,
+        "PLUSD: bad custodian sig"
+    );
+
+    usedRepaymentRefs[att.repaymentRef] = true;
+    _requireReserveInvariant(att.amount);
+    cumulativeYieldMinted += att.amount;
+    _mint(att.destination, att.amount);
+}
+```
+
+Three independent controls gate every yield mint: (1) YIELD_MINTER role on the caller, (2) Bridge signature on the attestation, (3) custodian EIP-1271 signature on the same attestation. Plus: destination constraint, replay guard on `repaymentRef`, deadline bound, reserve invariant, hard supply cap via `_update`, and shutdown guard.
+
+**`burn(uint256 amount)`** — `restricted` (BURNER role). Calls `_burn(msg.sender, amount)` and increments `cumulativeLPBurns`. Caller can only burn its own balance. Only WithdrawalQueue holds BURNER.
+
+```solidity
+function burn(uint256 amount) external restricted {
+    cumulativeLPBurns += amount;
+    _burn(msg.sender, amount);
+}
+```
+
+**Internal: `_requireReserveInvariant(uint256 amount)`**
+
+```solidity
+function _requireReserveInvariant(uint256 amount) internal view {
+    require(totalSupply() + amount <= maxTotalSupply, "PLUSD: supply cap");
+    // Invariant holds after the add:
+    // totalSupply + amount <= cumulativeLPDeposits + cumulativeYieldMinted - cumulativeLPBurns
+    uint256 backing = cumulativeLPDeposits + cumulativeYieldMinted - cumulativeLPBurns;
+    // The mint being processed adds to one counter and to totalSupply in lockstep.
+    // The check that matters is the conservative view *before* adding: existing totalSupply
+    // must already be <= backing (no silent accounting drift), and the new amount must
+    // not exceed the headroom projection. In practice the post-add equality is maintained
+    // by the call path; this require catches any drift from storage corruption or a
+    // malformed external interaction.
+    require(totalSupply() <= backing, "PLUSD: reserve drift");
+}
+```
+
+The counters move in lockstep with `totalSupply` under normal operation. The `require` catches two failure modes: (a) a bug that lets totalSupply and counters drift, (b) a contract upgrade that changes accounting semantics and leaves inconsistent state.
+
+**`_update(address from, address to, uint256 amount)`** — Override of `ERC20PausableUpgradeable._update` with non-transferability enforcement (U2) and rate-limit charging.
+
+```solidity
+function _update(address from, address to, uint256 amount)
+    internal override(ERC20Upgradeable, ERC20PausableUpgradeable)
+{
+    // Shutdown blocks everything except burn-from-shutdown-redeem path.
+    require(!shutdownController.isActive() || _isShutdownRedeemPath(), "PLUSD: shutdown");
+
+    if (from == address(0)) {
+        // Mint path: operational gate, whitelist-for-mint, rate limits.
+        // Note: mint path is entered only via mintForDeposit (DEPOSITOR) or
+        // yieldMint (YIELD_MINTER + two-party sigs). Reserve invariant and
+        // hard supply cap are checked in those entry points before _update.
+        _requireOperational();
+        require(whitelistRegistry.isAllowedForMint(to), "PLUSD: not allowed for mint");
+        _chargeRateLimit(to, amount);
+    } else if (to == address(0)) {
+        // Burn path: no checks. Pause still applies.
+    } else {
+        // Transfer path: exactly one side must be system.
+        _requireOperational();
+        bool fromSys = whitelistRegistry.isSystemAddress(from);
+        bool toSys   = whitelistRegistry.isSystemAddress(to);
+        require(fromSys != toSys, "PLUSD: LP-to-LP or sys-to-sys blocked");
+        require(whitelistRegistry.isAllowed(to), "PLUSD: recipient not allowed");
+    }
+
+    super._update(from, to, amount);
+}
+
+function _chargeRateLimit(address to, uint256 amount) internal {
+    // Roll aggregate window if elapsed
+    if (block.timestamp >= windowStart + windowDuration) {
+        windowStart = block.timestamp;
+        windowMinted = 0;
+    }
+    require(windowMinted + amount <= maxPerWindow, "PLUSD: window cap");
+    windowMinted += amount;
+
+    // Per-LP cap: applies only to LP deposit mints, NOT to yield mints into
+    // system addresses (sPLUSD vault, Treasury). Yield mints are already
+    // bounded by maxPerWindow + maxTotalSupply; adding a per-recipient cap
+    // would bottleneck all yield into a single system address.
+    if (whitelistRegistry.isSystemAddress(to)) {
+        return;
+    }
+    uint256 lpUsed = _lpWindowUsed(to);
+    require(lpUsed + amount <= maxPerLPPerWindow, "PLUSD: per-LP cap");
+    _recordLPMint(to, amount);
+}
+```
+
+- `fromSys != toSys` enforces "exactly one side is system" — closes the system↔system laundering bypass.
+- `_isShutdownRedeemPath()` returns true only when called inside `redeemInShutdown` (re-entrancy-style flag set/unset within that function) — lets shutdown redemptions burn while blocking all other transfers.
+- Per-LP window tracking: `lpWindowMinted[lp]` paired with `lpWindowStart[lp]` lazily reset on next mint for the same LP. Gas cost is a single SSTORE per deposit under normal operation. Skipped entirely when `to` is a system address (yield-mint destinations).
+
+**`redeemInShutdown(uint256 plusdAmount)`** — Shutdown-only one-way redemption.
+
+```solidity
+function redeemInShutdown(uint256 plusdAmount) external nonReentrant {
+    require(shutdownController.isActive(), "PLUSD: no shutdown");
+    require(whitelistRegistry.isAllowed(msg.sender), "PLUSD: not whitelisted");
+
+    uint16 bps = shutdownController.recoveryRateBps();
+    uint256 usdcOut = plusdAmount * bps / 10_000;
+
+    _setShutdownRedeemPath(true);
+    cumulativeLPBurns += plusdAmount;   // keep reserve invariant in lockstep
+    _burn(msg.sender, plusdAmount);
+    _setShutdownRedeemPath(false);
+
+    recoveryPool.release(msg.sender, usdcOut);
+    emit ShutdownRedemption(msg.sender, plusdAmount, usdcOut);
+}
+```
+
+Pause is overridden only for this function (via the transient flag pattern). Non-redemption transfers remain blocked. `cumulativeLPBurns` is updated here (not via the external `burn` BURNER path) because shutdown redemptions bypass WithdrawalQueue; the counter must still advance to keep the reserve invariant consistent.
+
+**`setRateLimits(uint256 newMaxPerWindow, uint256 newMaxPerLP, uint256 newWindowDuration)`** — `restricted` (ADMIN). Validates against floor/ceiling constants. **Tightening** (any new value ≤ current) is immediate. **Loosening** (any new value > current) is timelocked 48h via AccessManager. Emits `RateLimitsChanged(old, new)`.
+
+**`setMaxTotalSupply(uint256 newMax)`** — `restricted` (ADMIN). Same tighten-instant / loosen-48h pattern. Floor: `MAX_TOTAL_SUPPLY_FLOOR`. Emits `MaxTotalSupplyChanged(old, new)`.
+
+**`proposeWhitelistRegistry(address newRegistry)`** / **`executeWhitelistRegistryChange(address newRegistry)`** / **`cancelWhitelistRegistryChange()`** — ADMIN, 48h timelock via `TimelockPending`.
+
+**`setOperational(bool status)`** — `restricted` (ADMIN). Toggles the operational gate. Emits `OperationalStatusChanged(status)`.
+
+**`pause()` / `unpause()`** — `restricted` (PAUSER, GUARDIAN).
+
+**`proposeYieldAttestors(address newBridge, address newCustodian)`** / **`executeYieldAttestorsChange(...)`** / **`cancelYieldAttestorsChange()`** — ADMIN, 48h timelock via `TimelockPending`. Emits `YieldAttestorsChanged(oldBridge, newBridge, oldCustodian, newCustodian)`. Rotation is emergency-only (key compromise) — the custodian normally manages these keys as part of its HSM/MPC lifecycle.
+
+**`isFullyOperational() → bool`** — View. Returns `operational && !paused() && !shutdownController.isActive()`. Convenience for monitoring.
+
+**`reserveHealth() → (uint256 backing, uint256 supply, uint256 headroom)`** — View. Returns the three numbers driving the invariant so monitors can alert on tight headroom before a mint reverts.
+
+### Burn exemption
+
+Burns are exempt from both the `operational` gate and the whitelist check. This is intentional. The WithdrawalQueue must be able to complete in-flight `claim` burns during a maintenance window where `operational = false`, and cannot be blocked by a whitelist check against `address(0)`. Pause (`whenNotPaused` via `ERC20PausableUpgradeable`) still applies to burns — that is the emergency brake that overrides both operational and the settlement pipeline.
+
+### EIP-712 domain pinning
+
+```solidity
+// in implementation initializer:
+__EIP712_init("Pipeline PLUSD", "1");   // name, version pinned at impl-deploy time
+
+function _authorizeUpgrade(address newImpl) internal override restricted {
+    // UPGRADER role + 48h AccessManager delay handle authorization.
+    // Verify the new impl preserves domain fields:
+    (,,string memory newName, string memory newVersion,,,) = IERC5267(newImpl).eip712Domain();
+    require(
+        keccak256(bytes(newName))    == keccak256(bytes("Pipeline PLUSD")) &&
+        keccak256(bytes(newVersion)) == keccak256(bytes("1")),
+        "PLUSD: EIP-712 domain drift"
+    );
+}
+```
+
+Defends against a bad UUPS upgrade silently changing the domain separator and orphaning pre-signed yield attestations.
+
+### Known properties (document in audit brief)
+
+- **Rolling-window boundary.** Worst-case 2 × `maxPerWindow` ($20M) over the window boundary. Acceptable — bounded by `maxTotalSupply` and per-LP cap; custodian MPC policy engine provides independent cap on Bridge-originated USDC releases.
+- **`windowMinted` does not decrease on burn.** Net supply may be lower than window usage suggests. Acceptable — mints and burns have different purposes.
+- **Reserve invariant measures internal consistency, not external backing.** The three counters track what the contract has observed on-chain. A custodian holding less USDC than claimed will not be detected by this invariant — full Chainlink PoR (phase 2) closes that gap. MVP relies on counters + Watchdog service + custodian legal/compliance independence.
+- **ERC20Permit linearization.** The `permit()` → `transferFrom()` path must hit `_update` and enforce non-transferability. Confirmed via linearization with the inheritance chain `ERC20 → ERC20Pausable → ERC20Permit → PLUSD`. Dedicated test: `permit` + `transferFrom` to non-whitelisted or LP-to-LP address must revert.
+
+---
+
+## 5b. DepositManager (new in v2.3)
+
+```
+contract DepositManager is AccessManagedUpgradeable, PausableUpgradeable, ReentrancyGuardUpgradeable, UUPSUpgradeable
+```
+
+### Purpose
+
+Atomic 1:1 USDC→PLUSD deposit path. Replaces the v2.2 EIP-712 self-claim mint flow entirely (M1). The on-chain USDC transfer to Capital Wallet IS the deposit attestation — there is no off-chain signer on this path. Pattern reference: Ondo `OUSGInstantManager`, simplified to omit NAV scaling (PLUSD is 1:1 with USDC).
+
+### Roles (via AccessManager)
+
+| Role | Holder | Can do |
+|---|---|---|
+| PAUSER | GUARDIAN 2/5 | `pause()`, `unpause()` |
+| UPGRADER | ADMIN 3/5 | `upgradeTo` (48h delay) |
+
+DepositManager **holds** DEPOSITOR on PLUSD — it is the only account authorised to call `PLUSD.mintForDeposit`.
+
+### State
+
+```solidity
+IERC20           public immutable usdc;
+IPLUSD           public immutable plusd;
+IWhitelistRegistry public whitelistRegistry;   // same registry as PLUSD
+address          public capitalWallet;         // MPC-controlled destination; ADMIN-updatable 48h
+
+uint256 public minDeposit;                     // default 1_000e6 ($1K); anti-dust
+```
+
+### Functions
+
+**`deposit(uint256 amount)`** — public, pausable, reentrancy-guarded. The entire deposit flow in one transaction.
+
+```solidity
+function deposit(uint256 amount) external whenNotPaused nonReentrant {
+    require(amount >= minDeposit, "DM: below min");
+    require(whitelistRegistry.isAllowedForMint(msg.sender), "DM: not allowed for mint");
+
+    // Pull USDC directly from LP to Capital Wallet (LP must have pre-approved DM on USDC)
+    usdc.safeTransferFrom(msg.sender, capitalWallet, amount);
+
+    // Mint PLUSD 1:1 to LP — PLUSD.mintForDeposit checks reserve invariant,
+    // hard supply cap, rate limits, and whitelist-for-mint inside _update.
+    plusd.mintForDeposit(msg.sender, amount);
+
+    emit Deposited(msg.sender, amount);
+}
+```
+
+**Why pull, not push.** A single `USDC.transferFrom(lp, capitalWallet, amount)` moves USDC from the LP directly to the Capital Wallet. DepositManager never holds USDC, eliminating one escrow vector. LP's USDC allowance is granted to DepositManager; USDC's `transferFrom` supports an arbitrary `to` so the one approval covers the full flow.
+
+**`proposeCapitalWallet(address)`** / **`executeCapitalWalletChange(address)`** / **`cancelCapitalWalletChange()`** — ADMIN, 48h timelock via PLUSD-style TimelockPending (or equivalent). Changing the capital wallet is a high-sensitivity operation (effectively changes where deposit USDC lands).
+
+**`setMinDeposit(uint256 newMin)`** — `restricted` (ADMIN). Operational parameter.
+
+**`pause()` / `unpause()`** — `restricted` (PAUSER, GUARDIAN). Under pause, all new deposits revert. PLUSD itself is unaffected unless separately paused.
+
+### Shutdown behaviour
+
+`deposit` reverts when `PLUSD.shutdownController.isActive()` because `PLUSD.mintForDeposit` reverts in that state. No explicit shutdown check needed in DepositManager — PLUSD is the authority.
+
+### Design notes
+
+- **No attestor, no replay map, no signature verification.** The LP's own `transferFrom` is the authenticator — nobody else can cause an LP's USDC to move. Replay-protection is unnecessary because each `transferFrom` moves a distinct chunk of balance.
+- **MinDeposit.** Dust-limit floor keeps the contract from becoming a spam vector and preserves a floor on per-deposit gas economics.
+- **No fee.** MVP charges no deposit fee. Adding one would be a separate timelocked parameter change.
+- **Capital Wallet as `to` in `transferFrom`.** USDC semantics allow this. The LP's one approval is consumed by DepositManager's single `safeTransferFrom` call; USDC itself moves from LP to Capital Wallet atomically.
+- **No off-chain reliance for deposit.** The Bridge backend is not in the critical path for deposits. Bridge only observes the resulting `Transfer(lp, capitalWallet, amount)` and `Mint(0x0, lp, amount)` events for reconciliation, accounting, and dashboard data.
+
+### Known properties (document in audit brief)
+
+- **Capital Wallet compromise does not enable deposit fraud.** An attacker controlling the Capital Wallet cannot cause fake LP deposits — `transferFrom` must be authorised by the LP on USDC's ledger.
+- **Front-running resistance.** Deposits are self-serve and not MEV-profitable (1:1 exchange, no price impact).
+- **Reserve invariant per-call.** Each `deposit` atomically adds to `cumulativeLPDeposits`, `totalSupply`, and (off-chain) USDC in Capital Wallet. Any failure aborts all three.
+
+---
+
+## 6. sPLUSD
+
+```
+contract SPLUSD is ERC4626Upgradeable, ERC20PausableUpgradeable, AccessManagedUpgradeable, UUPSUpgradeable
+```
+
+### Purpose
+
+Yield-bearing vault on PLUSD. Open to any PLUSD holder (no whitelist check at the vault layer). Yield accretion is a natural property of ERC-4626: the Bridge mints PLUSD to the vault address via `PLUSD.yieldMint`, increasing `totalAssets` and the share price.
+
+### Roles (via AccessManager)
+
+| Role | Holder | Can do |
+|---|---|---|
+| PAUSER | GUARDIAN 2/5 | `pause()`, `unpause()` |
+| UPGRADER | ADMIN 3/5 | `upgradeTo` (48h delay) |
+| ADMIN (hub) | ADMIN 3/5 | — (no local admin ops; role management at hub) |
+
+### State (shutdown additions)
+
+```solidity
+IShutdownController public shutdownController;
+```
+
+(Snapshot state for the dropped `convertSharesAtShutdown` is removed; sPLUSD holders exit post-shutdown via the standard `redeem` path — see below.)
+
+### Custom logic
+
+**`_decimalsOffset()`** — Returns 6. First-deposit inflation attack protection for 6-decimal underlying. With 6-decimal offset, manipulating share price by $1 requires donating ~$1M PLUSD.
+
+**`_update(address from, address to, uint256 amount)`** — `override(ERC20Upgradeable, ERC20PausableUpgradeable)`. Calls `super._update()` to enforce pause. No whitelist check — sPLUSD is intentionally open.
+
+**`maxDeposit` / `maxMint` / `maxWithdraw` / `maxRedeem`** — Override to return 0 when paused. Integrators calling these view functions before transacting get accurate information.
+
+**`pause()` / `unpause()`** — `restricted` (PAUSER).
+
+### Shutdown behaviour
+
+- `deposit` / `mint` revert while shutdown is active. (Enforced by the underlying `PLUSD._update` shutdown check; no local check needed.)
+- `redeem` / `withdraw` remain open post-shutdown for exit. They return depegged PLUSD (no share-price recovery is attempted here); the holder then calls `PLUSD.redeemInShutdown` for recovery-rate USDC. This is the pull-based unwind (U8, simplified).
+- Race-drain concern is resolved structurally: `PLUSD.redeemInShutdown` pays at a frozen protocol-wide `recoveryRateBps`, not first-come, so the order in which sPLUSD holders unwrap does not affect per-unit payout.
+
+### Post-shutdown yield
+
+Any post-shutdown recoveries flow via `RecoveryPool.deposit` by ADMIN, which enables `RISK_COUNCIL.adjustRecoveryRateUp`. `yieldMint` is blocked during shutdown by the PLUSD `_update` guard.
+
+### Design notes
+
+- No MINTER role. Yield accretion happens externally via `PLUSD.yieldMint(address(this), amount)`.
+- KYC chain re-enters on redeem: `sPLUSD.redeem()` → `PLUSD.transfer(vault → receiver)` → `PLUSD._update` → `whitelistRegistry.isAllowed(receiver)` and non-transferability check (vault is system; receiver must be non-system and whitelisted). If receiver is not whitelisted, redeem reverts at the PLUSD level.
+- Pause freezes deposits, redeems, AND transfers. Conservative choice for an emergency mechanism.
+- OZ version pinned. `ERC4626Upgradeable` does not override `_update` in OZ v5.x. Pin and verify on upgrade.
+- sPLUSD remains transferable. The PLUSD redeem-whitelist gate neuters secondary-market value for non-KYC buyers; no attack paths identified by reviewers.
+
+### Audit brief items
+
+- Donation attack math: confirm $1M donation threshold holds at $50M TVL.
+- Vault concentration risk (single LP holding dominant share position) is a monitoring/dashboard concern.
+- LP agreement must include: "Emergency pause may freeze all positions; shutdown pays a protocol-set recovery rate."
+
+---
+
+## 7. WithdrawalQueue
+
+```
+contract WithdrawalQueue is AccessManagedUpgradeable, PausableUpgradeable, ReentrancyGuardUpgradeable, UUPSUpgradeable
+```
+
+### Purpose
+
+Holds both PLUSD (LP-deposited on request) and USDC (Bridge-funded on head) during a withdrawal. On `claim`, burns PLUSD and transfers USDC atomically. No cancellation — queue is one-way. Strict FIFO on funding, with auto-skip of sanctioned heads to prevent queue-DoS.
+
+**USDC custody model (Model B Bridge).** Bridge never holds USDC. The `fundRequest(queueId)` call is made by Bridge but the USDC itself moves via `usdc.transferFrom(capitalWallet, address(this), amount)` — a pre-existing allowance from Capital Wallet (granted during deployment and cosigned Trustee + Bridge) lets the WQ pull USDC directly from Capital Wallet when Bridge calls `fundRequest`. The funds path is `Capital Wallet → WithdrawalQueue`; Bridge is an on-chain validator / attestation signer / FUNDER role-holder.
+
+### Roles (via AccessManager)
+
+| Role | Holder | Can do |
+|---|---|---|
+| FUNDER | Bridge | `fundRequest`, `skipSanctionedHead` |
+| PAUSER | GUARDIAN 2/5 | `pause`, `unpause` |
+| ADMIN ops | ADMIN 3/5 | `adminRelease(Pending)` (immediate), `adminReleaseFunded` (24h AccessManager delay, GUARDIAN-cancelable), `adminSweep`, `sweepStale(queueId)`, `upgradeTo` |
+
+### Data structures
+
+```solidity
+enum RequestStatus { Pending, Funded, Claimed, AdminReleased }
+
+struct WithdrawalRequest {
+    address requester;
+    uint256 amount;     // PLUSD, 1:1 with USDC
+    uint64  createdAt;
+    uint64  fundedAt;   // 0 if never funded
+    RequestStatus status;
+}
+
+IERC20 public plusd;
+IERC20 public usdc;
+address public capitalWallet;                 // source of USDC on fundRequest (allowance model)
+IWhitelistRegistry public whitelistRegistry;
+IShutdownController public shutdownController;
+IRecoveryPool public recoveryPool;
+
+uint256 public nextRequestId;
+uint256 public headId;          // lowest queueId with status ∈ {Pending, Funded}
+uint256 public nextToFund;      // lowest queueId with status == Pending
+mapping(uint256 => WithdrawalRequest) public requests;
+
+uint256 public totalPlusdEscrowed;   // sum over Pending ∪ Funded ∪ AdminReleased-with-unswept-PLUSD
+uint256 public totalUsdcEscrowed;    // sum over Funded ∪ AdminReleased-with-unswept-USDC
+
+uint256 public constant MIN_WITHDRAWAL   = 1_000e6;
+uint256 public constant STALE_CLAIM_WINDOW = 180 days;
+```
+
+### Lifecycle
+
+```
+                               fundRequest
+                                    │
+requestWithdrawal                   ▼            claim
+  ─────────────►   Pending  ──────────────►  Funded  ─────────────►  Claimed
+                     │                          │
+                     │  adminRelease(Pending)   │  adminReleaseFunded
+                     │  (ADMIN, immediate)      │  (ADMIN, 24h timelock, GUARDIAN-cancelable)
+                     │                          │
+                     │  skipSanctionedHead      │
+                     │  (FUNDER auto-skip       │  sweepStale (ADMIN, after 180d Funded)
+                     │   if de-whitelisted)     │
+                     ▼                          ▼
+                              AdminReleased  ────────► adminSweep ────► funds out
+```
+
+### Functions
+
+**`requestWithdrawal(uint256 amount) → uint256 queueId`** — `nonReentrant`, `whenNotPaused`, `whenNotShutdown`
+
+- Require `amount >= MIN_WITHDRAWAL`.
+- Require `whitelistRegistry.isAllowed(msg.sender)` — sole sender-side compliance gate. `PLUSD._update` checks `isAllowed(to)` on transfers, not `isAllowed(from)`; on `plusd.transferFrom(LP, queue, amount)` the receiver-side check passes trivially because the queue is a system address. Without this explicit check, a de-whitelisted LP could enter the queue.
+- Pull PLUSD: `plusd.transferFrom(msg.sender, address(this), amount)`.
+- Create request with `status = Pending`, `createdAt = block.timestamp`, `fundedAt = 0`.
+- Increment `totalPlusdEscrowed`.
+- Emit `WithdrawalRequested(indexed queueId, indexed requester, amount)`.
+
+**`fundRequest(uint256 queueId)`** — `restricted` (FUNDER), `whenNotPaused`, `whenNotShutdown`, `nonReentrant`
+
+- Require `queueId == nextToFund`.
+- Require `requests[queueId].status == Pending`.
+- Require `whitelistRegistry.isAllowed(requests[queueId].requester)` — sanctioned LP path goes through `skipSanctionedHead` instead.
+- Pull USDC from Capital Wallet: `usdc.transferFrom(capitalWallet, address(this), amount)`. The Capital Wallet has a pre-approved allowance to the WQ; this call succeeds only if Capital Wallet's allowance and balance are sufficient (Capital Wallet releases are cosigned Trustee + Bridge off-chain via the MPC policy).
+- Set `status = Funded`, `fundedAt = block.timestamp`.
+- Increment `totalUsdcEscrowed`.
+- Advance `nextToFund` while `requests[nextToFund].status != Pending`.
+- Emit `WithdrawalFunded(indexed queueId, indexed requester, amount)`.
+
+**`skipSanctionedHead()`** — `restricted` (FUNDER), `whenNotPaused`, `whenNotShutdown`
+
+- Let `qId = nextToFund`. Require `requests[qId].status == Pending`.
+- Require `!whitelistRegistry.isAllowed(requests[qId].requester)`.
+- Set `status = AdminReleased`. PLUSD stays in contract. (ADMIN sweeps to whitelisted destination later.)
+- Advance `nextToFund` while `requests[nextToFund].status != Pending`.
+- Advance `headId` while `requests[headId].status ∈ {Claimed, AdminReleased}`.
+- Emit `WithdrawalSanctionedSkip(indexed queueId, indexed requester, amount)`.
+
+Rationale: strict-FIFO is a DoS primitive if a sanctioned head blocks all subsequent funding. The Bridge (already holds WHITELIST_ADMIN) does not need to wait for ADMIN Safe mobilization to unstick the queue; Bridge itself verifies `isAllowed` and marks the head `AdminReleased`. The sanctioned LP's PLUSD remains escrowed until ADMIN decides disposition — no funds moved, only a status flip.
+
+**`claim(uint256 queueId)`** — `nonReentrant`, `whenNotPaused`, `whenNotShutdown`
+
+- `msg.sender == requests[queueId].requester`.
+- `requests[queueId].status == Funded`.
+- `whitelistRegistry.isAllowed(msg.sender)` — LP must still be compliant at claim time.
+- **Order:** `status = Claimed`; `plusd.burn(amount)`; `usdc.transfer(msg.sender, amount)`; then decrement totals. This satisfies the invariant `totalPlusdEscrowed == plusd.balanceOf(this)` across the call because the state flip precedes the burn.
+- Advance `headId` while `requests[headId].status ∈ {Claimed, AdminReleased}`.
+- Emit `WithdrawalClaimed(indexed queueId, indexed requester, amount)`.
+
+**`adminRelease(uint256 queueId)`** — `restricted` (ADMIN)
+
+- If `requests[queueId].status == Pending`: **immediate** (no timelock).
+- If `requests[queueId].status == Funded`: call the separate `adminReleaseFunded(queueId)` selector, which carries a 24h AccessManager delay and is GUARDIAN-cancelable. Shared internal `_adminRelease(queueId)` body.
+- On release: `status = AdminReleased`. No token movement.
+- Advance `nextToFund` via `while` loop.
+- Advance `headId` via `while` loop.
+- Emit `WithdrawalAdminReleased(indexed queueId, indexed requester, amount, priorStatus)`.
+
+**`adminSweep(uint256 queueId, address plusdTo, address usdcTo)`** — `restricted` (ADMIN)
+
+- Require `status == AdminReleased`.
+- Transfers any still-escrowed PLUSD and USDC. `plusdTo` subject to `PLUSD._update` check (from=WQ=system, so toSys must be false: any whitelisted LP or venue).
+- Zero `amount` on the request to mark swept.
+- Decrement totals by swept quantities.
+
+**`sweepStale(uint256 queueId, address recipient)`** — `restricted` (ADMIN)
+
+- Require `status == Funded`.
+- Require `block.timestamp >= requests[queueId].fundedAt + STALE_CLAIM_WINDOW` (180d).
+- Require `recipient == requester` (stale claim is still the LP's money — send it to the LP's whitelisted address, or to a treasury sub-account if LP is de-whitelisted; audit logs document rationale).
+- Burn PLUSD and transfer USDC as in `claim`.
+
+Rationale: institutional LPs have turnover (key rotation, custodian migration, entity reorgs). Without a stale path, USDC sits in contract forever and pollutes reconciliation. 180d is long enough that normal claim lapses are rare; ADMIN threshold prevents abuse.
+
+**`claimAtShutdown(uint256 queueId)`** — one-way claim during shutdown; see §7b.
+
+### Invariants
+
+- `totalPlusdEscrowed == plusd.balanceOf(this)` at rest.
+- `totalUsdcEscrowed <= usdc.balanceOf(this)` (surplus = direct sends; detectable via `invariantCheck()`).
+- `∀ id < nextToFund: requests[id].status != Pending`.
+- `∀ id < headId: requests[id].status ∈ {Claimed, AdminReleased}`.
+- `nextToFund >= headId`.
+
+### View functions
+
+- `getRequest(uint256 queueId) → WithdrawalRequest`.
+- `getQueueDepth() → (totalPlusdEscrowed, totalUsdcEscrowed, pendingCount, fundedCount)`.
+- `invariantCheck() → (int256 plusdDrift, int256 usdcDrift)`.
+
+### Custodian-side enforcement (R2)
+
+Two properties of LP withdrawals are enforced by the custodian's MPC policy engine (Fireblocks / BitGo), **not** by WithdrawalQueue:
+
+1. **Destination match.** The USDC destination on a settled withdrawal must be an address in the LP's historic deposit-address set for this protocol. LPs cannot exfiltrate USDC to a new wallet they did not deposit from.
+2. **Cumulative cap.** For every LP, `cumulativeWithdrawn ≤ cumulativeDeposited` measured on the Capital Wallet. The custodian's rule engine maintains the per-LP ledger and rejects any transfer that would violate this.
+
+The contract layer enforces atomic-claim settlement (PLUSD burn and USDC transfer in the same call, from WQ's own escrow) and strict FIFO on funding. Destination and cap constraints live in the custodian's policy rules and are out of audit scope for this spec.
+
+### Failure mode table
+
+| Scenario | PLUSD | USDC | Recovery |
+|---|---|---|---|
+| `fundRequest` then `claim` | Escrowed → burned | Pulled from Capital Wallet → delivered on claim | Happy path |
+| `fundRequest` reverts (allowance, gas, pause) | Escrowed | Not moved | Bridge retries; no partial state |
+| `claim` reverts after fundRequest (receiver de-whitelisted mid-flow) | Escrowed | In WQ | `adminReleaseFunded` (24h) → `adminSweep`, or wait for recovery and LP re-claims |
+| Capital Wallet allowance revoked | N/A | fundRequest reverts | Governance re-approves; LPs keep waiting as Pending |
+| Bridge compromised before any fundRequest | Escrowed | Not moved | GUARDIAN triggers `EmergencyRevoker.revokeAll()`. ADMIN grants FUNDER to new Bridge. Pending requests resume. |
+| Bridge compromised after fundRequest but before LP claim | Escrowed | In WQ (attacker cannot access — only `claim` by requester, or ADMIN `adminReleaseFunded` / `adminSweep`) | No loss; LP still claims or ADMIN releases. |
+| LP de-whitelisted with Pending head | Escrowed | Not moved | `skipSanctionedHead` by Bridge; `adminSweep` by ADMIN later |
+
+---
+
+## 7b. Shutdown Mode (Option A, symmetric haircut)
+
+**Controller contract.** The flag and rate live in a standalone `ShutdownController`, not inside PLUSD. All contracts read via `shutdownController.isActive()` / `recoveryRateBps()`. Single source of truth.
+
+### State (ShutdownController)
+
+```solidity
+bool    public isActive;
+uint16  public recoveryRateBps;            // 1..10_000
+bytes32 public reasonHash;
+uint64  public activatedAt;
+uint256 public totalSupplyAtEntry;         // plusd.totalSupply() frozen at entry
+```
+
+### Trigger
+
+- `RISK_COUNCIL` schedules `enterShutdown(bps, reasonHash)` via `AccessManager.schedule` with 24h delay on the selector.
+- During the 24h window, `GUARDIAN` may `AccessManager.cancel(actionId)`.
+- After 24h, any caller can `AccessManager.execute` — this invokes `ShutdownController.enterShutdown`.
+
+### `enterShutdown(uint16 bps, bytes32 hash)` body
+
+```solidity
+function enterShutdown(uint16 bps, bytes32 hash) external restricted {
+    require(!isActive, "already active");
+    require(bps > 0 && bps <= 10_000, "bad bps");
+
+    // No pre-fund invariant: RISK_COUNCIL sets bps from the pool balance
+    // actually available at execution time. Trustee tops up the pool over
+    // the subsequent weeks/months as capital is repatriated; rate can be
+    // ratcheted up later via adjustRecoveryRateUp.
+
+    isActive = true;
+    recoveryRateBps = bps;
+    reasonHash = hash;
+    activatedAt = uint64(block.timestamp);
+    totalSupplyAtEntry = plusd.totalSupply();
+
+    emit ShutdownEntered(bps, hash, block.timestamp);
+}
+```
+
+**No pre-fund requirement at entry.** A real protocol crisis implies there is no USDC to pre-fund with. RecoveryPool starts at whatever balance it has at entry; `recoveryRateBps` is chosen by RISK_COUNCIL consistent with that balance. Trustee tops up the pool over time as capital is recovered; `adjustRecoveryRateUp` widens the rate as solvency improves.
+
+### Rate adjustment — **up only**
+
+```solidity
+function adjustRecoveryRateUp(uint16 newBps) external restricted;    // RISK_COUNCIL, 24h delay
+```
+
+- Only upward adjustments exist. For post-shutdown recoveries improving the solvency position.
+- Rationale: lowering the rate after entry transfers value from patient LPs to early exiters, which is strictly anti-LP. Rate should only increase as Trustee repatriates capital.
+- Solvency check at adjustment: `pool.balance >= remainingUnredeemedSupply * newBps / 10_000` must hold at the time the adjustment is scheduled; GUARDIAN may cancel during the 24h window if the check would be stale at execution.
+
+### `redeemInShutdown(uint256 plusdAmount)` on PLUSD
+
+See §5. Burns PLUSD from the caller, releases `plusdAmount * bps / 10_000` USDC from RecoveryPool to the caller. LP must be whitelisted at redemption time.
+
+### Funded-request haircut — SYMMETRIC
+
+Per originator decision: Funded requests are **haircut-eligible** in shutdown. Rationale: removes queue-jump exploit class; matches MakerDAO `cage` semantics; simpler LP model ("at shutdown, everyone gets the rate, period").
+
+On `WQ.claimAtShutdown(queueId)`:
+
+```solidity
+function claimAtShutdown(uint256 queueId) external nonReentrant {
+    require(shutdownController.isActive(), "WQ: no shutdown");
+    require(msg.sender == requests[queueId].requester, "WQ: not requester");
+    require(
+        requests[queueId].status == RequestStatus.Pending ||
+        requests[queueId].status == RequestStatus.Funded,
+        "WQ: bad status"
+    );
+    require(whitelistRegistry.isAllowed(msg.sender), "WQ: not whitelisted");
+
+    uint256 plusdAmount = requests[queueId].amount;
+    uint16  bps = shutdownController.recoveryRateBps();
+    uint256 usdcOut = plusdAmount * bps / 10_000;
+
+    RequestStatus priorStatus = requests[queueId].status;
+    requests[queueId].status = RequestStatus.Claimed;
+    requests[queueId].amount = 0;
+
+    plusd.burn(plusdAmount);              // PLUSD still in escrow, burn from WQ balance
+    totalPlusdEscrowed -= plusdAmount;
+
+    if (priorStatus == RequestStatus.Funded) {
+        // WQ holds USDC 1:1 for this request; return the haircut to RecoveryPool,
+        // pay the LP the rate.
+        uint256 returnToPool = plusdAmount - usdcOut;
+        totalUsdcEscrowed -= plusdAmount;
+        usdc.transfer(address(recoveryPool), returnToPool);
+        recoveryPool.recordReturned(returnToPool);
+        usdc.transfer(msg.sender, usdcOut);
+    } else {
+        // Pending: WQ holds no USDC. Pull from RecoveryPool.
+        recoveryPool.release(msg.sender, usdcOut);
+    }
+
+    emit WithdrawalClaimedAtShutdown(queueId, msg.sender, plusdAmount, usdcOut, priorStatus);
+}
+```
+
+Funded-branch returns the haircut (difference) to RecoveryPool so subsequent redemptions remain solvent against the updated supply.
+
+### RecoveryPool
+
+```solidity
+contract RecoveryPool is AccessManagedUpgradeable, ReentrancyGuardUpgradeable, UUPSUpgradeable {
+    IERC20 public usdc;
+    address public plusdContract;
+    address public wqContract;
+    uint256 public totalDeposited;
+    uint256 public totalReleased;
+    uint256 public totalReturned;
+
+    function deposit(uint256 amount) external restricted;         // ADMIN
+    function release(address to, uint256 amount) external nonReentrant {
+        require(msg.sender == plusdContract || msg.sender == wqContract, "RP: unauthorized");
+        totalReleased += amount;
+        usdc.transfer(to, amount);
+    }
+    function recordReturned(uint256 amount) external nonReentrant {
+        require(msg.sender == wqContract, "RP: unauthorized");
+        totalReturned += amount;
+    }
+    function balance() public view returns (uint256) {
+        return usdc.balanceOf(address(this));
+    }
+}
+```
+
+- ~70 LOC.
+- `release` is guarded against reentrancy and restricted to two known callers.
+- On UUPS upgrade of PLUSD or WQ: proxies keep the same addresses, so `plusdContract`/`wqContract` pointers remain valid across upgrades.
+
+### Ongoing-operation solvency
+
+At any point in shutdown, the protocol aims for:
+
+```
+recoveryRateBps × outstandingPlusd / 10_000  ≤  RecoveryPool.balance() + pendingTrusteeInflows
+```
+
+This is a monitoring invariant, not an entry gate. If the left side exceeds the right, RISK_COUNCIL does *not* lower the rate (dropped); instead, redemptions queue until Trustee inflows catch up, or — if the gap persists — the protocol is documented as under-solvent at the rate and LPs understand further top-ups are required to clear the backlog. Rate only ratchets up.
+
+### sPLUSD unwind during shutdown
+
+sPLUSD holders exit as follows:
+
+1. Call `sPLUSD.redeem(shares)` — standard ERC-4626 redeem, returns PLUSD at the vault's current (depegged) share price. The sPLUSD vault remains unpaused post-shutdown specifically to keep this exit path open.
+2. Call `PLUSD.redeemInShutdown(plusdAmount)` — burns PLUSD, receives `plusdAmount × recoveryRateBps / 10_000` USDC from RecoveryPool.
+
+No special-case shutdown conversion function. Race-drain concern is resolved because `redeemInShutdown` pays at a frozen protocol-wide rate, not first-come; the order in which holders unwind does not affect per-unit payout.
+
+### Post-shutdown yield blocked
+
+All PLUSD mint paths (`mintForDeposit`, `yieldMint`) revert when `shutdownController.isActive()`. DepositManager.deposit reverts as a consequence. Any post-shutdown recoveries enter via ADMIN calling `RecoveryPool.deposit(amount)`, which enables RISK_COUNCIL to `adjustRecoveryRateUp`.
+
+---
+
+## 8. WhitelistRegistry
+
+```
+contract WhitelistRegistry is AccessManagedUpgradeable, TimelockPending, UUPSUpgradeable
+```
+
+### Purpose
+
+On-chain allowlist controlling who can hold PLUSD and where PLUSD can move. Three categories of approved addresses.
+
+### Roles (via AccessManager)
+
+| Role | Holder | Can do |
+|---|---|---|
+| WHITELIST_ADMIN | Bridge | LP management (`setAccess`, `refreshScreening`, `revokeAccess`) |
+| PAUSER | GUARDIAN 2/5 | `pause()`, `unpause()` |
+| UPGRADER | ADMIN 3/5 | `upgradeTo` (48h delay) |
+| ADMIN (hub) | ADMIN 3/5 | DeFi venue management, system address management (timelocked), freshness window |
+
+### Three allowlist categories
+
+```solidity
+// 1. KYCed LP wallets — have screening timestamps
+struct LPEntry {
+    bool approved;
+    uint256 approvedAt;  // Chainalysis screening timestamp
+}
+mapping(address => LPEntry) private _lpAllowlist;
+
+// 2. Approved DeFi venues — Curve pools, Uniswap pools, Aave markets
+mapping(address => bool) private _venueAllowlist;
+
+// 3. Protocol/system addresses — sPLUSD vault, WithdrawalQueue, RecoveryPool, Treasury, Capital Wallet
+mapping(address => bool) private _systemAllowlist;
+
+uint256 public freshnessWindow; // default 90 days
+```
+
+### Check functions (called by PLUSD)
+
+**`isAllowed(address account) → bool`**
+- Called by PLUSD `_update` on every non-burn transfer.
+- `require(account != address(0))`
+- Returns `_lpAllowlist[account].approved || _venueAllowlist[account] || _systemAllowlist[account]`
+- **No freshness check.** Allowlist membership is sufficient for transfers.
+
+**`isAllowedForMint(address account) → bool`**
+- Called by PLUSD `_update` on mints only (`from == address(0)`).
+- `require(account != address(0))`
+- If `_systemAllowlist[account]`: return true. System addresses bypass freshness (yield mints to vault/treasury).
+- If `entry.approvedAt == 0`: return false. Guards against underflow with cleared timestamps.
+- Returns `entry.approved && (block.timestamp - entry.approvedAt) < freshnessWindow`.
+
+**`isSystemAddress(address account) → bool`**
+- Reads `_systemAllowlist`. Used by `PLUSD._update` for the non-transferability rule.
+
+**Intentional asymmetry (document for auditors):** DeFi venues pass `isAllowed` but not `isAllowedForMint`. System addresses pass both. An address can exist in multiple categories simultaneously.
+
+### LP management (WHITELIST_ADMIN)
+
+**`setAccess(address lp, uint256 approvedAt)`** — New LP onboarding. Validates `lp != address(0)`, `approvedAt <= block.timestamp`. Sets `LPEntry(true, approvedAt)`. Emits `LPApproved(indexed lp, approvedAt)`.
+
+**`refreshScreening(address lp, uint256 newApprovedAt)`** — Periodic re-screening. Requires `_lpAllowlist[lp].approved`. Validates `newApprovedAt <= block.timestamp`. Updates `approvedAt`. Emits `ScreeningRefreshed(indexed lp, newApprovedAt)`.
+
+**`revokeAccess(address lp)`** — Sanctions/compliance removal. Requires `_lpAllowlist[lp].approved`. Clears to `LPEntry(false, 0)`. Emits `LPRevoked(indexed lp)`.
+
+### DeFi venue management (ADMIN)
+
+**`addDeFiVenue(address venue)`** / **`removeDeFiVenue(address venue)`** — No timelock. Emits `VenueAdded` / `VenueRemoved`.
+
+Note: removing a venue that holds PLUSD creates a black hole — that PLUSD cannot be transferred out. Recovery path: admin re-adds the venue temporarily, venue's LPs withdraw, admin removes again.
+
+### System address management (ADMIN, timelocked)
+
+- `proposeSystemAddress(addr)` / `executeAddSystemAddress(addr)` / `cancelSystemAddressChange()` — 48h timelock.
+- `proposeRemoveSystemAddress(addr)` / `executeRemoveSystemAddress(addr)` / `cancelRemoveSystemAddress()` — 48h timelock.
+
+Timelock rationale for both add and remove: system addresses bypass freshness checks on mints (add = privilege escalation). Removing a system address (e.g., sPLUSD vault, WithdrawalQueue) breaks protocol operations. This is an operational disruption equivalent to a targeted pause. Emergency response uses PLUSD pause (GUARDIAN, instant) rather than system address removal.
+
+### Freshness window management (ADMIN)
+
+```solidity
+uint256 public constant MIN_FRESHNESS = 7 days;
+uint256 public constant MAX_FRESHNESS = 365 days;
+```
+
+**`setFreshnessWindow(uint256 newWindow)`** — Bounded by constants. No timelock — tightening is always safe, loosening is bounded by `MAX_FRESHNESS`.
+
+### Trust assumptions
+
+- Bridge holds WHITELIST_ADMIN and can revoke all LP whitelist entries, freezing all PLUSD transfers. No rate limit on revocations. GUARDIAN's fast pause on PLUSD is the emergency brake for a rogue Bridge doing mass revocations.
+- ADMIN Safe can grant itself WHITELIST_ADMIN and override any whitelist decision.
+
+---
+
+## 9. LoanRegistry
+
+**Context.** Reinstated per originator: "on-chain proofs of deals." One soulbound ERC-721 per originated loan. Holds no capital. Not an input to sPLUSD share price. Yield still flows exclusively through `PLUSD.yieldMint(vault, amount)` when USDC repayment lands in the Capital Wallet. The registry is the audit trail — no more, no less.
+
+### Purpose
+
+- Immutable public record of every loan financed through the protocol (principal, doc hash, originator, borrower, commodity, origination time).
+- Operational state tracking for live loans (status, collateral coverage ratio, commodity location, maturity) — sourced off-chain by the Trustee, written on-chain by the Trustee key.
+- Fully soulbound: tokens are non-transferable after mint. Ownership is symbolic; economic rights do not flow through the NFT.
+
+### Roles (via AccessManager)
+
+| Role | Grantee | Can call |
+|---|---|---|
+| TRUSTEE | Trustee key | `mintLoan`, `updateStatus(loanId, {Performing, Watchlist})`, `updateCCR`, `updateLocation`, `updateMaturity`, `closeLoan` |
+| RISK_COUNCIL | RISK_COUNCIL 3/5 Safe | `setDefault(loanId)` (24h delay, GUARDIAN-cancelable) |
+| PAUSER | GUARDIAN 2/5 | `pause` / `unpause` |
+| UPGRADER | ADMIN 3/5 | `upgradeTo` (48h delay) |
+| ADMIN | ADMIN 3/5 | Contract-level admin ops |
+
+**Separation of duty:** the Trustee can flag a loan as `Watchlist` but cannot flag `Default`. The `Default` transition — which has reputational and reporting consequences — requires RISK_COUNCIL with a 24h timelock (GUARDIAN-cancelable) to protect against front-running on sPLUSD secondary transfers. Trustee can still execute `closeLoan(loanId, Default)` after RISK_COUNCIL has set `Default`, since closure is a routine Trustee operation.
+
+### Data structures
+
+```solidity
+enum LoanStatus   { Performing, Watchlist, Default, Closed }
+enum ClosureReason { None, ScheduledMaturity, EarlyRepayment, Default }
+
+struct ImmutableLoanData {
+    bytes32 docHash;       // IPFS/S3 hash of signed facility docs
+    uint256 principal;     // original facility size, USDC decimals
+    address originator;    // counterparty that took on the loan
+    address borrower;      // end beneficiary (may equal originator)
+    bytes32 commodity;     // short code (e.g. "COCOA-2026-07")
+    uint64  originatedAt;  // block.timestamp at mint
+}
+
+struct MutableLoanData {
+    LoanStatus    status;
+    uint32        ccrBps;        // collateral coverage ratio, basis points
+    bytes32       location;      // warehouse/port short code or coordinates digest
+    uint64        maturity;      // unix timestamp; may be extended
+    ClosureReason closureReason; // set only on transition → Closed
+}
+
+mapping(uint256 loanId => ImmutableLoanData) public immutableData;
+mapping(uint256 loanId => MutableLoanData)   public mutableData;
+
+uint256 public nextLoanId;
+```
+
+### Functions
+
+**`mintLoan(address to, ImmutableLoanData data, uint64 initialMaturity)`** — Restricted to `TRUSTEE`. Mints a new soulbound token to `to`, writes `immutableData`, initializes `mutableData.status = Performing` and `mutableData.maturity = initialMaturity`. Emits `LoanMinted(loanId, originator, principal, docHash)`.
+
+**`updateStatus(uint256 loanId, LoanStatus newStatus)`** — Restricted to `TRUSTEE`. Rejects transitions into `Default` (use `setDefault`) and into `Closed` (use `closeLoan`). Legal transitions: `Performing ↔ Watchlist`. Emits `LoanStatusChanged`.
+
+**`updateCCR(uint256 loanId, uint32 newCcrBps)`** — Restricted to `TRUSTEE`. Reverts if loan is `Closed`. Emits `LoanCCRUpdated`.
+
+**`updateLocation(uint256 loanId, bytes32 newLocation)`** — Restricted to `TRUSTEE`. Reverts if loan is `Closed`. Emits `LoanLocationUpdated`.
+
+**`updateMaturity(uint256 loanId, uint64 newMaturity)`** — Restricted to `TRUSTEE`. Reverts if loan is `Closed`. No constraint that `newMaturity > oldMaturity` — extensions and forward roll-ups allowed; auditors verify via event history. Emits `LoanMaturityUpdated`.
+
+**`setDefault(uint256 loanId)`** — Restricted to `RISK_COUNCIL`, 24h AccessManager delay, GUARDIAN-cancelable. Transitions `status = Default`. Rejects if current status is `Closed`. Emits `LoanDefaulted(loanId)`.
+
+**`closeLoan(uint256 loanId, ClosureReason reason)`** — Restricted to `TRUSTEE`. Sets `status = Closed`, writes `closureReason = reason`. Valid inputs: `ScheduledMaturity`, `EarlyRepayment`, `Default`. The `Default` reason is admissible only if `status` was already `Default` (enforced by internal check). No further mutation allowed after closure.
+
+**`_update(from, to, tokenId, auth)`** (OZ v5.x ERC-721 hook) — Overridden to revert on any transfer where `from != address(0)` (non-mint) and `to != address(0)` (non-burn). Soulbound property.
+
+### Capital separation
+
+- LoanRegistry never moves USDC, PLUSD, or sPLUSD. It has no `IERC20` touchpoints.
+- `closeLoan` does not mint or burn anything. Yield flow (USDC repayment on Capital Wallet → Trustee + Bridge cosigned release cycle → `PLUSD.yieldMint(vault, …)`) is a fully separate sequence.
+- A compromised `TRUSTEE` key can falsify `LoanRepaid`-equivalent state (via `closeLoan(id, EarlyRepayment)`) but cannot produce or move any capital. This is data-integrity damage, not funds damage — see §13.
+
+### Design notes
+
+- **Why soulbound ERC-721 instead of plain struct mapping?** The ERC-721 surface gives auditors, indexers, and downstream integrations (Dune, block explorers) a standard shape for iteration, ownership queries, and event semantics. ~60 lines over a bare mapping; the clarity payoff outweighs it.
+- **Why no on-chain verification of `EarlyRepayment`?** Repayment arrival is a cross-rail event (USDC on Ethereum's Capital Wallet). The contract cannot observe the Capital Wallet's balance change atomically with `closeLoan`. Trustee attests; monitoring reconciles against Capital Wallet USDC inflow.
+- **Why no partial repayments?** Trade finance loans in MVP scope are single-shot (principal + interest paid at maturity or early in one transfer). If multi-tranche repayment becomes operationally needed, `MutableLoanData` gains a `repaidAmount` field and `LoanPartialRepaid` event — additive, non-breaking.
+- **Pausing effect.** When paused, all mutation functions revert. View functions still work. Pausing the registry is *not* in the default incident playbook but exists for completeness.
+
+---
+
+## 10. Deployment
+
+### Prerequisites
+
+1. Three Gnosis Safes deployed: ADMIN 3/5, RISK_COUNCIL 3/5, GUARDIAN 2/5.
+2. Bridge on-chain address (key ceremony complete — internal HSM/MPC setup is an implementation detail of Bridge).
+3. Trustee on-chain address (key ceremony complete; distinct key set from Bridge).
+4. Bridge yield-attestor signing address (EOA for EIP-712 signing).
+5. Custodian yield-attestor contract address (EIP-1271 compliant — provided by the custodian as part of API-Co-Signer or Policy-Engine setup).
+6. Capital Wallet MPC address; Treasury Wallet MPC address.
+
+### Order
+
+```
+Step 0:  Verify every implementation contract constructor calls _disableInitializers().
+         (Audit item; verified before Step 1.)
+Step 1:  Deploy AccessManager(admin = ADMIN Safe).
+Step 2:  Deploy implementation contracts (PLUSD_Impl, DepositManager_Impl, sPLUSD_Impl, WQ_Impl,
+         WhitelistRegistry_Impl, LoanRegistry_Impl, ShutdownController_Impl, RecoveryPool_Impl).
+Step 3:  Deploy ERC1967 proxies for each, initializing with (manager = AccessManager, peers...).
+         Order: WhitelistRegistry, PLUSD, DepositManager, sPLUSD, WQ, LoanRegistry, RecoveryPool, ShutdownController.
+         (Each initialize(...) wires references; ShutdownController last so it can take all peers.)
+Step 4:  Deploy EmergencyRevoker(
+           manager, bridge, trustee, guardianSafe,
+           funderRole, whitelistAdminRole, trusteeRole, yieldMinterRole
+         ).
+         Non-upgradeable. `bridge` and `trustee` are ADMIN-updatable via 48h timelock.
+         v2.3: no longer references PLUSD (no attestor to clear).
+
+Step 5:  AccessManager role → function mappings (setTargetFunctionRole):
+
+         PLUSD:
+           - PLUSD.mintForDeposit          → DEPOSITOR    → DepositManager
+           - PLUSD.yieldMint               → YIELD_MINTER → Bridge  (caller gate; also requires 2-of-2 EIP-712 sigs)
+           - PLUSD.redeemInShutdown        → public (shutdown-gated)
+           - PLUSD.burn                    → BURNER       → WithdrawalQueue
+           - PLUSD.pause / unpause         → PAUSER       → GUARDIAN
+           - PLUSD.setRateLimits           → ADMIN (3/5), tighten-instant / loosen-48h
+           - PLUSD.setMaxTotalSupply       → ADMIN (3/5), tighten-instant / loosen-48h
+           - PLUSD.proposeYieldAttestors / executeYieldAttestorsChange / cancelYieldAttestorsChange → ADMIN (3/5), 48h via TimelockPending
+           - PLUSD.upgradeTo               → UPGRADER     → ADMIN, 48h delay
+
+         DepositManager:
+           - DepositManager.deposit                           → public
+           - DepositManager.pause / unpause                   → PAUSER       → GUARDIAN
+           - DepositManager.proposeCapitalWallet / execute / cancel → ADMIN (3/5), 48h timelock
+           - DepositManager.setMinDeposit                     → ADMIN (3/5)
+           - DepositManager.upgradeTo                         → UPGRADER     → ADMIN, 48h delay
+
+         sPLUSD:
+           - sPLUSD.pause / unpause        → PAUSER       → GUARDIAN
+           - sPLUSD.upgradeTo              → UPGRADER     → ADMIN, 48h delay
+
+         WQ:
+           - WQ.fundRequest                → FUNDER       → Bridge
+           - WQ.skipSanctionedHead         → FUNDER       → Bridge
+           - WQ.claim                      → public (requester-gated)
+           - WQ.claimAtShutdown            → public (shutdown-gated)
+           - WQ.adminRelease(Pending)      → ADMIN ops    → ADMIN Safe, immediate
+           - WQ.adminReleaseFunded         → ADMIN ops    → ADMIN Safe, 24h delay, GUARDIAN-cancelable
+           - WQ.adminSweep                 → ADMIN ops    → ADMIN Safe
+           - WQ.sweepStale                 → ADMIN ops    → ADMIN Safe
+           - WQ.pause / unpause            → PAUSER       → GUARDIAN
+           - WQ.upgradeTo                  → UPGRADER     → ADMIN, 48h delay
+
+         WhitelistRegistry:
+           - WL.setAccess / refreshScreening / revokeAccess → WHITELIST_ADMIN → Bridge
+           - WL admin ops                  → ADMIN (3/5) — local timelocks per §8
+           - WL.pause / unpause            → PAUSER       → GUARDIAN
+           - WL.upgradeTo                  → UPGRADER     → ADMIN, 48h delay
+
+         LoanRegistry:
+           - LR.mintLoan / updateStatus / updateCCR / updateLocation / updateMaturity / closeLoan
+                                           → TRUSTEE     → Trustee key
+           - LR.setDefault                 → RISK_COUNCIL → RISK_COUNCIL Safe, 24h delay, GUARDIAN-cancelable
+           - LR.pause / unpause            → PAUSER       → GUARDIAN
+           - LR.upgradeTo                  → UPGRADER     → ADMIN, 48h delay
+
+         ShutdownController:
+           - SC.enterShutdown              → RISK_COUNCIL, 24h delay, GUARDIAN-cancelable
+           - SC.adjustRecoveryRateUp       → RISK_COUNCIL, 24h delay
+           - SC.upgradeTo                  → UPGRADER     → ADMIN, 48h delay
+
+         RecoveryPool:
+           - RP.deposit                    → ADMIN (3/5)
+           - RP.release                    → (internal — only PLUSD/WQ can call; no role)
+           - RP.recordReturned             → (internal — only WQ; no role)
+           - RP.upgradeTo                  → UPGRADER     → ADMIN, 48h delay
+
+         EmergencyRevoker:
+           - ER.revokeAll                  → GUARDIAN (authorized caller check in contract)
+           - ER.setBridge / setTrustee     → ADMIN, 48h delay via TimelockPending
+
+         AccessManager:
+           - Grant ADMIN_ROLE (id 0) on AccessManager to EmergencyRevoker
+             so it can call revokeRole(*, bridge) and revokeRole(TRUSTEE, trustee).
+
+Step 5a: Role-grant verification checkpoint. Read hasRole for every (role, account) pair
+         before the timelock starts. Special attention to: FUNDER on Bridge, WHITELIST_ADMIN
+         on Bridge, YIELD_MINTER on Bridge, TRUSTEE on Trustee key, RISK_COUNCIL on council
+         Safe, UPGRADER on ADMIN Safe.
+
+Step 6:  Per-target admin delays (setTargetAdminDelay): all role changes gated 48h.
+         Meta-timelock: setTargetAdminDelay itself gated 14d (prevents delay collapse).
+
+Step 7:  Whitelist system addresses (WL timelock, 48h):
+         - propose: DepositManager, sPLUSD vault, WQ, RecoveryPool, ShutdownController, Treasury Wallet, Capital Wallet
+         - wait 48h
+         - execute in batched Safe tx
+
+Step 8:  Capital Wallet → WQ USDC allowance.
+         Capital Wallet MPC (Trustee + Bridge cosigners) approves the WQ to spend
+         USDC up to a ceiling (e.g. $50M, renewable). WQ.fundRequest uses this
+         allowance via usdc.transferFrom(capitalWallet, wq, amount). Bridge itself
+         never custodies USDC.
+         Note: deposits use a different mechanism — LPs approve DepositManager
+         directly on their own wallets, and DepositManager uses the LP's USDC
+         allowance to push USDC to Capital Wallet in one transferFrom.
+
+Step 9:  Custodian MPC policy-engine acceptance (R2). Confirm custodian rules:
+         (a) every LP withdrawal destination must match an address in that LP's
+             historic deposit-address set, and
+         (b) cumulative USDC withdrawn by any LP cannot exceed cumulative USDC
+             that LP has deposited to the Capital Wallet.
+         Plus: custodian provides and operates the EIP-1271 yield-attestation
+         signer (API Co-Signer or Policy Engine webhook integration).
+         Sign-off from custodian operations team is a launch prerequisite.
+
+Step 10: Seed RecoveryPool with 0 USDC. Remains empty until a shutdown is funded.
+
+Step 11: PLUSD.setOperational(true). Final enablement.
+```
+
+### Initial cap parameters (v2.3)
+
+Four numeric caps must be set at deployment (tightening-instant, loosening-48h post-launch). Initial sizing is a business decision that should reflect expected launch TVL and LP onboarding profile:
+
+```
+PLUSD.maxPerWindow        — default $10M / 24h rolling    (aggregate across all LPs)
+PLUSD.maxPerLPPerWindow   — default $5M  / 24h rolling    (per-LP concentration)
+PLUSD.maxTotalSupply      — launch value to be set by Product / Risk
+```
+
+### Pre-launch checklist
+
+- [ ] All 3 Safes deployed with correct thresholds and signers
+- [ ] All impl constructors verified to call `_disableInitializers()`
+- [ ] All proxies deployed and verified on Etherscan
+- [ ] `eip712Domain()` returns matching tuples across all future impls (regression test)
+- [ ] All (target, selector, role, grantee) tuples verified via `hasRole`
+- [ ] 48h admin delay on role changes; 14d meta-timelock on delay changes; 24h on shutdown entry; 24h on setDefault; 24h on adjustRecoveryRateUp
+- [ ] DepositManager, sPLUSD, WQ, RecoveryPool, ShutdownController, Treasury, Capital Wallet in system allowlist
+- [ ] Bridge holds FUNDER, WHITELIST_ADMIN, YIELD_MINTER
+- [ ] DepositManager holds DEPOSITOR on PLUSD
+- [ ] Trustee key holds TRUSTEE
+- [ ] GUARDIAN holds PAUSER on every pausable target (including DepositManager)
+- [ ] GUARDIAN is `authorizedCaller` on EmergencyRevoker
+- [ ] Bridge yield-attestor EOA provisioned
+- [ ] Custodian EIP-1271 yield-attestor contract address provisioned and verified (`isValidSignature` test with a sample digest)
+- [ ] Initial `maxPerWindow`, `maxPerLPPerWindow`, `maxTotalSupply` set and verified
+- [ ] Capital Wallet → WQ USDC allowance set and verified
+- [ ] Reserve invariant smoke test: DepositManager deposit → counters update → yieldMint → counters update → burn via WQ → counters update; invariant holds at every step
+- [ ] Two-party yieldMint test: valid Bridge sig + invalid custodian sig → reverts; vice versa → reverts; both valid → succeeds
+- [ ] Hard supply cap test: mint that would exceed `maxTotalSupply` → reverts
+- [ ] Per-LP cap test: second deposit in same window that breaches `maxPerLPPerWindow` → reverts
+- [ ] Window cap test: N deposits summing > `maxPerWindow` within 24h → next reverts
+- [ ] EIP-712 domain pinning test: upgrade to a modified impl with drift → reverts
+- [ ] Test `DepositManager.deposit` during `shutdownActive` → reverts (because `mintForDeposit` reverts)
+- [ ] Test shutdown unwind: `sPLUSD.redeem` → `PLUSD.redeemInShutdown` full flow
+- [ ] Test `claimAtShutdown` Funded-branch returns haircut to RecoveryPool
+- [ ] Test `skipSanctionedHead` with de-whitelisted head
+- [ ] Test `adminReleaseFunded` 24h delay enforced; GUARDIAN cancel works
+- [ ] Test `sweepStale` at 179d reverts, at 181d works
+- [ ] Rate-limit, freshness window confirmed
+- [ ] Custodian MPC policy engine signed off (R2)
+- [ ] Monitoring dashboards wired to all contract events (incl. LoanRegistry)
+- [ ] Incident response runbook reviewed; `EmergencyRevoker.revokeAll()` tested on testnet
+
+---
+
+## 11. Cross-Contract Interaction Map
+
+### Capital-path calls
+
+| Caller | Target | Function | Trust assumption |
+|---|---|---|---|
+| LP | DepositManager.deposit | Atomic 1:1 USDC→PLUSD | LP pre-approves DepositManager on USDC; whitelist-for-mint check; reserve invariant; hard supply cap; rate limits; no off-chain signer |
+| Bridge | PLUSD.yieldMint | Yield accrual | Triple gate: YIELD_MINTER role; Bridge EIP-712 sig (ecrecover); Custodian EIP-1271 sig; destination constrained to vault/treasury; replay guard on `repaymentRef` |
+| LP | WQ.requestWithdrawal | Enter queue | Whitelist check at entry; pulls PLUSD into WQ |
+| Bridge | WQ.fundRequest | Pull USDC from Capital Wallet into WQ for head | FUNDER role; strict FIFO (`nextToFund`); USDC moves via Capital Wallet allowance — Bridge never custodies |
+| Bridge | WQ.skipSanctionedHead | Unblock DoS from sanctioned head | FUNDER role; Bridge verifies `!isAllowed(head.requester)` |
+| LP | WQ.claim | Burn PLUSD + receive USDC | `msg.sender == requester`; current whitelist required |
+| sPLUSD.deposit / redeem | PLUSD.transferFrom / transfer | Stake / unstake | Vault is system; receiver must be non-system and whitelisted (non-transferability enforces exactly-one-side-system) |
+| ADMIN Safe | WQ.adminRelease(Pending) | Immediate unstick of Pending-status request | ADMIN |
+| ADMIN Safe | WQ.adminReleaseFunded | 24h-timelocked release of Funded | ADMIN; GUARDIAN-cancelable |
+| ADMIN Safe | WQ.sweepStale | 180d stale claim sweep | ADMIN; recipient = original requester |
+
+### Loan-path calls
+
+| Caller | Target | Function |
+|---|---|---|
+| Trustee key | LoanRegistry.{mintLoan, updateStatus, updateCCR, updateLocation, updateMaturity, closeLoan} | TRUSTEE role |
+| RISK_COUNCIL Safe | LoanRegistry.setDefault | 24h delay, GUARDIAN-cancelable |
+
+### Shutdown-path calls
+
+| Caller | Target | Function |
+|---|---|---|
+| RISK_COUNCIL Safe | ShutdownController.enterShutdown | 24h delay, GUARDIAN-cancelable |
+| Any caller after 24h | ShutdownController (via AccessManager.execute) | executes scheduled enterShutdown |
+| RISK_COUNCIL Safe | ShutdownController.adjustRecoveryRateUp | 24h delay |
+| LP (sPLUSD holder) | sPLUSD.redeem | Standard ERC-4626 exit returning (depegged) PLUSD |
+| LP (PLUSD holder) | PLUSD.redeemInShutdown | Burn PLUSD, receive recoveryRate × USDC from RecoveryPool |
+| LP (with pre-shutdown WQ request) | WQ.claimAtShutdown | Burn WQ-held PLUSD, receive recoveryRate × USDC (Funded branch returns haircut to pool) |
+| ADMIN Safe | RecoveryPool.deposit | Top up pool with late recoveries |
+
+### Incident-path calls
+
+| Caller | Target | Function |
+|---|---|---|
+| GUARDIAN Safe | \*.pause() | Instant pause — no timelock (PLUSD, DepositManager, sPLUSD, WQ, WhitelistRegistry, LoanRegistry) |
+| GUARDIAN Safe | AccessManager.cancel(actionId) | Cancel any pending scheduled action |
+| GUARDIAN Safe | EmergencyRevoker.revokeAll | Revoke FUNDER + WHITELIST_ADMIN + YIELD_MINTER from Bridge, TRUSTEE from Trustee |
+| ADMIN Safe | EmergencyRevoker.setBridge / setTrustee | 48h timelock — accommodates operational key rotation |
+| ADMIN Safe | PLUSD.proposeYieldAttestors / execute | 48h timelock — rotate Bridge/custodian yield-sig keys under key-compromise scenario |
+
+### Bridge-to-contract sequences (cross-rail)
+
+| Sequence | Risk | Mitigation |
+|---|---|---|
+| LP calls `DepositManager.deposit(amount)` → USDC moves LP → Capital Wallet → PLUSD minted 1:1 to LP | `transferFrom` succeeds but `mintForDeposit` reverts | Atomic: any revert in `mintForDeposit` propagates and the whole transaction reverts, restoring USDC to LP. |
+| Bridge + custodian co-sign a `YieldAttestation` → Bridge submits `yieldMint(att, bridgeSig, custodianSig)` (vault destination); repeats for treasury destination | First succeeds, second fails: vault yield accreted but treasury share missing | Two separate calls, each idempotent on `repaymentRef`. Bridge retries the failed leg after Trustee/custodian re-co-sign a new attestation with a fresh `salt`. Monitoring treats partial-yield-mint as known intermediate state. |
+| LP submits `requestWithdrawal` → Bridge calls `WQ.fundRequest(queueId)` → LP calls `WQ.claim(queueId)` | Atomic claim. Bridge never custodies USDC. Capital Wallet allowance funds the WQ on `fundRequest` via `usdc.transferFrom(capitalWallet, wq, amount)`. | Capital Wallet allowance is cosigned (Trustee + Bridge). If Bridge is compromised, Trustee can revoke allowance out-of-band. |
+| LP withdrawal USDC leg (Capital Wallet → WQ → LP) | LP attempts to route withdrawal to a new address, or to exfiltrate more than they deposited | Two-leg defence. On-chain: `WQ.claim` pays only the requester. Off-chain (R2): custodian MPC policy engine caps cumulative per-LP outflow and enforces destination-set matching on the Capital Wallet → WQ release. |
+| Trustee originates loan off-chain → Trustee calls `LoanRegistry.mintLoan` | Trustee misses own registry write (tx revert) | Mint is atomic with the on-chain touchpoint; on revert, nothing is recorded and origination is replayed on retry. No coupling to capital flow. |
+| Trustee verifies USDC repayment on Capital Wallet → Bridge calls `PLUSD.yieldMint(vault, yieldAmount)` + Trustee calls `LoanRegistry.closeLoan(id, EarlyRepayment\|ScheduledMaturity)` | Yield mints but registry close fails (or vice versa) | Two independent txs. Yield is the capital-critical leg and is retried until successful; registry close is idempotent (calling on already-Closed reverts). Registry lag does not affect share price. |
+
+### Pause cascade
+
+| Paused | Effect | Unaffected |
+|---|---|---|
+| PLUSD | Full freeze. All mints, transfers, burns revert (except `redeemInShutdown`, via `_setShutdownRedeemPath`). DepositManager, sPLUSD, and WQ all stop (they all depend on PLUSD being mint/burn/transfer-able). | View functions only. |
+| DepositManager | `deposit` reverts. PLUSD itself still operational if not separately paused. | Yield mints, withdrawals, stake/unstake. |
+| sPLUSD | Deposit/redeem/transfers revert. `yieldMint` to vault also reverts because it goes through `PLUSD._update` → pause-check on PLUSD. | Other capital paths if PLUSD unpaused. |
+| WithdrawalQueue | `requestWithdrawal`, `fundRequest`, `skipSanctionedHead`, `claim`, `adminRelease*`, `adminSweep`, `sweepStale`, `claimAtShutdown` all revert. | Deposits (DepositManager), stake/unstake. |
+| LoanRegistry | All mutations revert. Capital flows are unaffected — registry is not in their path. Not in the default incident playbook; reserved for data-integrity incidents. | All capital operations. |
+| ShutdownController | — (never paused by itself; shutdown and pause are orthogonal mechanisms). | |
+| RecoveryPool | `deposit` and `release` revert. | — |
+
+### Shutdown vs pause
+
+- **Pause** (GUARDIAN, instant): defensive brake, fully reversible.
+- **Shutdown** (RISK_COUNCIL 24h + ADMIN execute, GUARDIAN-vetoable): terminal declaration of recovery rate. No programmatic exit (v2.2).
+- During shutdown, PLUSD is paused for normal flow but `redeemInShutdown` is enabled via the transient flag pattern. sPLUSD stays unpaused so holders can `redeem` to PLUSD and then `redeemInShutdown`.
+
+Ops runbook must make cascade explicit. PLUSD pause is the nuclear option.
+
+---
+
+## 12. EmergencyRevoker
+
+Pre-signed revocation transactions have a fatal flaw: Gnosis Safe nonces are sequential. Any Safe transaction (routine admin work, parameter change, role grant) increments the nonce and invalidates all pre-signed revocation txs. The revocations become stale the moment the Safe does anything.
+
+**Solution:** An immutable, parameterless contract deployed at launch:
+
+```solidity
+contract EmergencyRevoker {
+    IAccessManager public immutable manager;
+    address        public immutable guardian;          // authorized caller (GUARDIAN 2/5)
+
+    // Target addresses: ADMIN-updatable via 48h timelock (U7)
+    address public bridge;
+    address public trustee;
+
+    uint64 public immutable funderRole;
+    uint64 public immutable whitelistAdminRole;
+    uint64 public immutable yieldMinterRole;
+    uint64 public immutable trusteeRole;
+
+    // Inlined TimelockPending-style pattern for target rotation
+    mapping(bytes32 => uint256) public pendingTargetChanges;
+
+    function revokeAll() external {
+        require(msg.sender == guardian, "unauthorized");
+        manager.revokeRole(funderRole,         bridge);
+        manager.revokeRole(whitelistAdminRole, bridge);
+        manager.revokeRole(yieldMinterRole,    bridge);
+        manager.revokeRole(trusteeRole,        trustee);
+    }
+
+    function proposeSetBridge(address newBridge) external restricted;    // ADMIN
+    function executeSetBridge(address newBridge) external restricted;    // ADMIN, 48h timelock
+    function cancelSetBridge(address newBridge) external restricted;     // ADMIN
+    // Symmetric functions for trustee.
+}
+```
+
+~50 LOC. `revokeAll` is parameterless, non-reentrant-by-construction, and only callable by GUARDIAN. `bridge` and `trustee` addresses are ADMIN-updatable with 48h timelock — accommodates routine key rotation without redeploy ceremonies. Non-upgradeable. Holds AccessManager ADMIN.
+
+**v2.3 change:** EmergencyRevoker no longer touches PLUSD. With MINT_ATTESTOR retired (M2), there is no attestor to zero. The deposit path is structurally safe because `PLUSD.mintForDeposit` is role-gated to DepositManager, and DepositManager itself is pausable by GUARDIAN (faster mitigation than role revocation). YIELD_MINTER remains a revokable role; compromising it alone still cannot mint (requires custodian co-signature).
+
+**Safety-by-construction (for audit):** despite holding AccessManager ADMIN, EmergencyRevoker exposes only `revokeAll` (and target-rotation functions gated by ADMIN + 48h). There is no fallback, no delegatecall, no arbitrary-call forwarding. An attacker cannot use EmergencyRevoker as a proxy to grant roles or move funds.
+
+**Under attack:** The GUARDIAN 2/5 Safe submits one tx: `EmergencyRevoker.revokeAll()`. One tx, one nonce, four revocations on the hub. The nonce is always fresh because the call is constructed at incident time, not pre-signed. Only 2 of 5 signers needed — same threshold as pause, matching the urgency profile.
+
+**Risk of EmergencyRevoker compromise:** Minimal. The contract is immutable — `revokeAll()` can only disconnect Bridge/Trustee, and only when called by the GUARDIAN Safe. It cannot grant roles, mint tokens, or move funds. The ADMIN Safe can re-grant Bridge/Trustee roles on the AccessManager after investigation.
+
+### Incident response — Bridge compromise
+
+1. **Detection.** Monitoring alerts on anomalous mint/settle/whitelist activity, on divergence between `DepositManager.Deposited` events and `PLUSD.cumulativeLPDeposits`, on `LoanClosed(…, EarlyRepayment)` events without matching USDC inflow, or on reserve-invariant headroom shrinking unexpectedly.
+2. **Immediate (GUARDIAN, < 1 minute):** Pause PLUSD (freezes everything — mints, transfers, burns except shutdown-redeem path); pause DepositManager (stops new deposits explicitly); pause WithdrawalQueue (defense-in-depth).
+3. **Containment (GUARDIAN, < 10 minutes):** Submit one Safe tx calling `EmergencyRevoker.revokeAll()` — atomically revokes FUNDER, WHITELIST_ADMIN, YIELD_MINTER from Bridge and TRUSTEE from Trustee. Even a fully compromised Bridge cannot mint yield alone (custodian signature still required); cannot fund withdrawals (FUNDER revoked); cannot modify whitelist (WHITELIST_ADMIN revoked). Deposits are blocked separately via DepositManager pause.
+4. **Investigation.** Audit logs, determine blast radius. If Trustee was not compromised, Trustee can cosign on Capital Wallet to revoke the Capital Wallet → WQ USDC allowance as an additional barrier. If the compromise was via the Bridge yield-signing key (not the operational EOA), initiate `PLUSD.proposeYieldAttestors(newBridge, sameCustodian)` with 48h timelock — meanwhile yield mints remain blocked (pause + role revocation).
+5. **Recovery.** Deploy/provision new Bridge key. Call `EmergencyRevoker.setBridge(newBridge)` (48h timelock), then ADMIN grants FUNDER/WHITELIST_ADMIN/YIELD_MINTER to the new Bridge on AccessManager. If the yield-signing key was also compromised, execute the pending `executeYieldAttestorsChange`. Unpause PLUSD, DepositManager, and WQ.
+
+---
+
+## 13. Audit Brief Outline
+
+### Scope
+
+- 7 Solidity files in primary audit scope: TimelockPending.sol, PLUSD.sol, SPLUSD.sol, WithdrawalQueue.sol, WhitelistRegistry.sol, ShutdownController.sol, RecoveryPool.sol, EmergencyRevoker.sol. AccessManager is deployed from OZ v5.x (no custom code).
+- LoanRegistry.sol is **excluded from primary audit scope** — it holds no capital and has no effect on sPLUSD share price, PLUSD supply, or withdrawal settlement. Internal review only.
+- Target: Tier 1 audit (Trail of Bits, ChainSecurity, OpenZeppelin, or equivalent).
+- Estimated engagement: 2.5–3 weeks (up from v2.1 due to UUPS, ShutdownController, claim-model WQ).
+
+### Threat model
+
+| Threat | Likelihood | Impact | On-chain mitigation |
+|---|---|---|---|
+| Compromised Bridge (backend) | Medium | **Bounded** — cannot mint deposit PLUSD (deposits are atomic LP-driven); cannot mint yield alone (requires custodian co-sig); can call FUNDER / WHITELIST_ADMIN / (solo-submit) YIELD_MINTER | Deposit leg has no Bridge dependency — DepositManager is role-gated to itself, LP controls `transferFrom`. Yield leg requires custodian EIP-1271 co-signature; compromised Bridge alone → zero yield mint. Rate limits + per-LP cap + hard supply cap cap any accidental or malicious flow. WHITELIST_ADMIN compromise without mint-capability is not a drain path (cannot redirect funds to attacker). GUARDIAN pauses PLUSD, DepositManager, WQ instantly. `EmergencyRevoker.revokeAll()` atomically disconnects. Bridge never custodies USDC. |
+| Compromised Bridge yield-attestor key (EOA) | Low–Med | **Bounded** — cannot mint alone (custodian must co-sign each mint) | Two-party attestation: custodian EIP-1271 independently verifies repayment. 48h rotation via `proposeYieldAttestors`. `usedRepaymentRefs` replay guard. |
+| Compromised custodian yield-attestor | Low | **Bounded** — cannot mint alone (Bridge must co-sign; Bridge must hold YIELD_MINTER) | Two-party attestation. Custodian cannot forge yield solo. 48h rotation via `proposeYieldAttestors`. Custodian has independent legal/compliance controls. |
+| Compromised Trustee key | Medium | Medium — data-integrity loss on LoanRegistry, plus ability to cosign malicious Capital Wallet releases (requires Bridge cosign too) | TRUSTEE role can `mintLoan` ghost loans, `closeLoan(..., EarlyRepayment)` without actual repayment, or set arbitrary CCR/location/maturity. No capital touchpoints in LoanRegistry. Capital Wallet releases require Bridge cosign — a single-key Trustee compromise cannot move USDC alone. `EmergencyRevoker.revokeAll` revokes TRUSTEE. Monitoring reconciles `LoanClosed(…, EarlyRepayment)` against Capital Wallet inflows. `Default` transition requires RISK_COUNCIL — not reachable by Trustee. |
+| Reserve-invariant drift (counter desync) | Very Low | High — could mask over-minting | Counters updated in lockstep with `_mint` / `_burn` inside single function bodies. `_requireReserveInvariant` checks `totalSupply <= backing` before every mint. Full test coverage of the counter-updating paths, plus fuzz tests on the mint/burn sequences. |
+| `maxTotalSupply` breach | Very Low | High | Hard cap enforced in `_requireReserveInvariant` before every mint. Loosening requires 48h timelock. |
+| Malicious shutdown (RISK_COUNCIL + ADMIN collusion) | Very Low | Protocol-ending | 24h delay + GUARDIAN veto; distinct Safe signer sets. No pre-fund invariant (crisis-realistic), but also no degenerate "higher than cash" state because rate is chosen against actual pool balance and can only go up. |
+| Upgrade malice (ADMIN compromised) | Low | Protocol-ending | 48h delay; GUARDIAN veto; 14d meta-timelock; EIP-712 domain pin check in `_authorizeUpgrade`; EmergencyRevoker non-upgradeable. |
+| Queue-jump in distress | N/A | N/A | Resolved by symmetric haircut — Funded requests also pay the rate. |
+| DoS via sanctioned head | N/A | N/A | `skipSanctionedHead` by FUNDER auto-skips. |
+| `adminReleaseFunded` front-run of LP `claim` | Very Low | High | 24h timelock + GUARDIAN cancel. |
+| sPLUSD shutdown race drain | N/A | N/A | Rate is frozen protocol-wide via `recoveryRateBps`; order of unwind does not affect per-unit payout. |
+| Double-mint on yield path | Very Low | High | `usedRepaymentRefs` replay key; deterministic `keccak256(chainId, repaymentTxHash)` format; two-party sig requirement means collusion needed in addition to replay. |
+| `setDefault` front-run on sPLUSD secondary | Low | Medium | 24h timelock; GUARDIAN-cancelable. |
+| GUARDIAN compromise (2/5) | Low | Medium — can grief via cancel; can force revokeAll; **cannot escalate roles or move funds.** | Accepted per Morpho sentinel pattern. ADMIN rotates GUARDIAN signers. |
+| Stale Funded claim (dead LP) | Low | Low | `sweepStale` at 180d, ADMIN-executed, recipient = original requester. |
+| EmergencyRevoker targets stale after key rotation | N/A | N/A | `setBridge`/`setTrustee` with 48h timelock. |
+| Malicious LP (sanctions evasion) | Medium | Medium — regulatory exposure | Chainalysis freshness window on mints; whitelist revocation; custodian-level destination/cap rules (R2). |
+| MEV / front-running | Low | Low | No AMM; no sandwich-profitable paths. Rate-limit fixed-window 2× worst case bounded by custodial caps. |
+| Smart contract vulnerability | Low (post-audit) | Variable | OZ v5.x base incl. audited AccessManager, UUPS; custom surface ~450 LOC; flat topology. |
+
+### Focus areas
+
+1. PLUSD `_update` correctness — non-transferability rule (`fromSys != toSys`), shutdown guard with `_isShutdownRedeemPath` flag, rate limits (per-window / per-LP, with system-address exemption), whitelist-for-mint, ERC20Permit linearization.
+2. **Reserve invariant correctness** — counters updated in lockstep with mint/burn; `_requireReserveInvariant` called on every mint path; `maxTotalSupply` enforced before mint; fuzz tests on counter arithmetic.
+3. **DepositManager atomicity** — `deposit` pulls USDC from LP to Capital Wallet and mints PLUSD in the same tx; any revert inside `mintForDeposit` rolls back the USDC transfer; no USDC can arrive without PLUSD being minted (and vice versa).
+4. **Two-party yieldMint signature verification** — Bridge ECDSA + custodian EIP-1271 both verified on each call; `usedRepaymentRefs` replay guard; EIP-712 domain pinning on upgrade; deadline enforcement.
+5. WithdrawalQueue lifecycle — FIFO on funding, atomic claim, `skipSanctionedHead` correctness, `adminReleaseFunded` 24h timelock path, `sweepStale` boundary.
+6. Capital Wallet → WQ allowance pattern — `usdc.transferFrom(capitalWallet, ...)` on `fundRequest`; invariant that Bridge itself never holds USDC.
+7. ShutdownController & RecoveryPool — entry path with no pre-fund requirement, up-only rate adjustment, symmetric Funded-branch haircut with pool return.
+8. AccessManager role topology — per-target admin delays, UPGRADER gating on every `_authorizeUpgrade`, EmergencyRevoker's `ADMIN_ROLE` safety-by-construction, DEPOSITOR role scoped to DepositManager only.
+
+### Known properties (not bugs)
+
+- Rate limit fixed-window boundary: worst-case 2× `maxPerWindow`.
+- `windowMinted` does not decrease on burn.
+- LoanRegistry mutable state (status, CCR, location, maturity, `closeLoan(..., EarlyRepayment)`) is Trustee-attested, not on-chain-verified; only `setDefault` is gated on RISK_COUNCIL.
+- DeFi venue removal creates PLUSD black hole (documented recovery path).
+- Addresses can exist in multiple allowlist categories simultaneously.
+- ADMIN Safe can re-grant revoked Bridge/Trustee roles (EmergencyRevoker disarmable by admin).
+- Recovery rate only ratchets up. Post-entry discoveries of further losses do not reduce the rate; LPs who have not yet redeemed wait on Trustee inflows, not a rate cut.
+
+### Accepted trust-footprint items
+
+- **B1 — Trustee signatures over location/valuation/CCR updates are off-chain attestations.** Verified off-chain by Bridge before calling `updateLocation` / `updateCCR`. Trustee is the only caller of `TRUSTEE_ROLE` functions.
+- **B2 — `EmergencyRevoker` is disarmable by the ADMIN Safe.** ADMIN 3/5 can `revokeRole(ADMIN_ROLE, emergencyRevoker)` on AccessManager, disarming GUARDIAN's ability to cut off the Bridge/Trustee. Accepted consequence; mitigation is off-chain (deployment runbook + monitoring alerts on relevant `RoleRevoked` events).
+- **B3 — No on-chain backing oracle.** Protocol does not verify on-chain that `PLUSD.totalSupply()` is backed 1:1 by USD-equivalent assets. Backing computed off-chain by Bridge/treasury service from reconciled on-chain state combined with custody attestations (USDC in Capital Wallet, USYC holdings).
+
+### Pre-audit deliverables
+
+- [ ] Gas benchmarks: PLUSD transfer cost (with external WhitelistRegistry call), `claim` cost, worst-case `_advanceHead`-style loops.
+- [ ] Full test suite with coverage report.
+- [ ] Deployment script exercised on testnet.
+- [ ] ERC20Permit linearization test (permit + transferFrom to LP-to-LP / non-whitelisted).
+- [ ] Donation attack math at $50M TVL documented.
+- [ ] UUPS upgrade drill on testnet including EIP-712 domain pin assertion.
+
+---
+
+## 14. Testing Strategy
+
+### Phase 1: Full-scenario local test suite (pre-audit)
+
+Complete Foundry test environment with mock actors, tokens, and time manipulation. Every branch of every contract exercised.
+
+**Mock actors:**
+
+- Multiple LP wallets (whitelisted, expired screening, revoked, sanctioned mid-flow).
+- Bridge service (FUNDER / YIELD_MINTER / WHITELIST_ADMIN / yield-attestor signer — mock or harness).
+- Custodian EIP-1271 signer (mock contract implementing `isValidSignature`).
+- Trustee key (TRUSTEE role caller on LoanRegistry).
+- ADMIN Safe, RISK_COUNCIL Safe, GUARDIAN Safe (mock multisig callers configured as AccessManager role grantees).
+- Capital Wallet mock (MPC address with USDC balance and a pre-approved allowance to WQ).
+- Malicious actors (non-whitelisted, re-entrant contracts, griefing bots).
+- Real OZ v5.x AccessManager deployment; tests configure target-role mappings in `setUp`.
+
+**Mock infrastructure:**
+
+- Mock USDC (mintable ERC-20 for test purposes).
+- Mock WhitelistRegistry oracle (controllable freshness timestamps).
+- `vm.warp`, `vm.prank`, `deal`, `vm.sign` for EIP-712 signing.
+
+**Scenario matrix:**
+
+| Category | Scenarios |
+|---|---|
+| **Deposit (DepositManager)** | Happy-path `deposit`; LP without USDC allowance reverts; LP with zero balance reverts; sub-minimum deposit reverts; non-whitelisted LP reverts; expired-screening LP reverts; revoked LP reverts; rate-limit per-window caps deposit; per-LP per-window caps deposit (LP paths only, system addresses exempt); hard supply cap caps deposit; `DepositManager` paused reverts; PLUSD paused reverts (propagates); shutdown-active reverts; reserve invariant holds after every deposit. |
+| **Reserve invariant (PLUSD)** | Counters advance in lockstep with `totalSupply`; burn decrements and invariant holds; double-entry arithmetic preserved across deposit + yield + burn mix; fuzz sequences of `(deposit, yieldMint, burn)` randomly ordered — invariant holds at every state; `maxTotalSupply` breach reverts. |
+| **Yield mint (two-party)** | Happy path to vault with valid both sigs; happy path to treasury; valid Bridge sig + invalid custodian sig reverts; vice versa reverts; replay same `repaymentRef` reverts even with fresh `salt`; caller without YIELD_MINTER reverts; destination ≠ vault/treasury reverts; deadline exceeded reverts; shutdown-active reverts; EIP-1271 stub returning non-magic value reverts. |
+| **Non-transferability** | LP→LP reverts; LP→WQ succeeds; WQ→LP succeeds; sys→sys (e.g., Treasury→Vault) reverts; permit+transferFrom to non-whitelisted reverts; permit+transferFrom LP→LP reverts. |
+| **Staking** | Deposit, redeem, share price after yield mint, first-deposit inflation attack attempt, redeem to non-whitelisted receiver, redeem to LP (non-system) works, pause during active positions. |
+| **Withdrawal** | Full lifecycle (request → fund → claim), fund on non-head reverts (strict FIFO on funding), `claim` on non-Funded reverts, MIN_WITHDRAWAL enforcement, head advancement with AdminReleased/Claimed gaps, `claim` by non-requester reverts, `claim` after LP de-whitelisted reverts. |
+| **Cross-rail funding** | `fundRequest` pulls USDC from Capital Wallet via `transferFrom`; Bridge never custodies (verify Bridge balance unchanged); Capital Wallet allowance revoked → `fundRequest` reverts; Capital Wallet insufficient balance → `fundRequest` reverts; no intermediate state where PLUSD is burned without USDC in WQ. |
+| **Sanctioned-head DoS** | `skipSanctionedHead` with de-whitelisted head; `skipSanctionedHead` with whitelisted head reverts; `skipSanctionedHead` advances `nextToFund` past the skipped request. |
+| **Admin operations** | `adminRelease(Pending)` immediate unstick advances head; `adminReleaseFunded` respects 24h timelock (enforced by AccessManager); GUARDIAN can `cancel` pending `adminReleaseFunded` schedule; `adminSweep` after `adminReleaseFunded` moves both PLUSD and USDC; `sweepStale` at 179d reverts, 181d works; `sweepStale` to non-requester reverts. |
+| **Whitelist** | LP onboard/refresh/revoke, venue add/remove/black-hole, system address add/remove (both timelocked), freshness boundary, multi-category membership, fuzz `isAllowedForMint` across full `uint256` range of `approvedAt` (must never return true for stale or future-dated). |
+| **Loan lifecycle** | `mintLoan` happy path (immutable fields locked), `updateStatus` legal (Performing ↔ Watchlist) and illegal (Default/Closed via update reverts), `setDefault` restricted to RISK_COUNCIL, `setDefault` respects 24h timelock and GUARDIAN cancel, `closeLoan` reason enum validation, soulbound transfer revert, all mutations revert after close, all mutations revert when paused. |
+| **Access control** | Unauthorized caller → `AccessManagedUnauthorized`; role grant takes effect only after per-target delay; revoked role loses access immediately; `EmergencyRevoker.revokeAll()` by non-GUARDIAN reverts; ADMIN can re-grant revoked Bridge/Trustee roles. |
+| **Upgrade** | Unauthorized `upgradeTo` reverts; scheduled upgrade respects 48h delay; GUARDIAN cancels pending upgrade; impl with modified EIP-712 domain reverts (domain pin check); impl without `_disableInitializers` fails pre-launch verification; `setTargetAdminDelay` respects 14d meta-timelock. |
+| **Shutdown** | `enterShutdown` only by RISK_COUNCIL after 24h; GUARDIAN cancel during window; `redeemInShutdown` only callable while `isActive`; `mintForDeposit` / `yieldMint` revert while `isActive`; `DepositManager.deposit` reverts while `isActive` (via mintForDeposit revert); sPLUSD holders exit via standard `redeem` → `redeemInShutdown` and receive correct pro-rata recovery-rate USDC; `claimAtShutdown` Pending-branch pulls from pool; `claimAtShutdown` Funded-branch returns haircut to pool and pays recoveryRate; `adjustRecoveryRateUp` respects 24h delay; no `adjustRecoveryRateDown` selector exists. |
+| **Incident response** | GUARDIAN pause cascade (PLUSD pause freezes everything, DepositManager pause blocks new deposits specifically); `EmergencyRevoker.revokeAll` by GUARDIAN lands four role revocations in one tx (FUNDER/WHITELIST_ADMIN/YIELD_MINTER from Bridge + TRUSTEE from Trustee); two-party yield mint continues to require custodian sig even mid-incident; recovery path: revoke → `setBridge` with 48h → ADMIN re-grants roles to new Bridge → unpause; if yield-attestor keys compromised, `proposeYieldAttestors` with 48h timelock; invariants hold at every intermediate state. |
+| **Invariants** | `totalPlusdEscrowed == plusd.balanceOf(this)` at rest after every sequence; `totalUsdcEscrowed <= usdc.balanceOf(this)`; `∀ id < nextToFund: status != Pending`; `∀ id < headId: status ∈ {Claimed, AdminReleased}`; `windowMinted` tracks correctly across window resets. |
+| **Bank run** | All LPs call `DepositManager.deposit` followed by `requestWithdrawal` simultaneously; queue depth stress; rate limits (per-window / per-LP) block rapid minting during panic re-deposit; `maxTotalSupply` caps aggregate exposure; strict-FIFO ordering under pressure. |
+
+**Permit path coverage.** Dedicated test: ERC20Permit `permit(owner, spender, amount, ...)` followed by `transferFrom(owner, nonWhitelisted, amount)` must revert in `PLUSD._update` at the non-transferability or whitelist check. Plus LP-to-LP permit+transferFrom reverts even if both LPs are whitelisted.
+
+**Test harness hygiene.** Any shared `BaseTest` helper must be exercised by at least one test or removed before merge.
+
+**Actor-critic review process.** Test scenarios designed in iterations. After each iteration, an adversarial reviewer (critic agent) examines the test suite for missing branches, weak assertions, and scenarios that pass trivially. Multiple rounds until critic finds no new gaps.
+
+### Phase 2: Adversarial agentic loop (post-implementation)
+
+Automated red team / blue team cycle on a local Anvil fork.
+
+**Attacker agent:** unlimited test capital (flash loans from Aave V3 fork, or `vm.deal` + `deal`). Goals: break invariants, drain funds, grief operations. Attack vectors: reentrancy, flash loan manipulation, rate limit gaming, whitelist state manipulation, front-running `claim` / `fundRequest` / `setDefault`, donation attacks on sPLUSD, AccessManager role escalation via admin-delay manipulation, shutdown-boundary exploits (e.g., mint-then-shutdown), attestation replay via alt-chain or different domain.
+
+**Defender agent:** security specialist reviewing attacker findings. Root-cause analysis, patch proposal, regression test.
+
+**Loop structure.**
+
+```
+┌─────────────────────────────────────────────────┐
+│  Round N                                         │
+│                                                  │
+│  Attacker: runs attack suite against contracts   │
+│         ↓                                        │
+│  Results: list of (vector, outcome, evidence)    │
+│         ↓                                        │
+│  Defender: analyzes results, patches contracts   │
+│         ↓                                        │
+│  Regression: full test suite + new attack tests  │
+│         ↓                                        │
+│  If all pass → Round N+1 (attacker gets smarter) │
+│  If fail → Defender fixes, re-run regression     │
+└─────────────────────────────────────────────────┘
+```
+
+Terminates when attacker finds no new vectors across N consecutive rounds (suggest N = 3).
+
+**Separate hardening loop.**
+
+```
+┌───────────────────────────────────────────────┐
+│  Full test suite runner                        │
+│                                                │
+│  Run all tests (unit + scenario + adversarial) │
+│         ↓                                      │
+│  Failures? → Fix agent patches, re-runs        │
+│         ↓                                      │
+│  All pass? → White-hat findings incorporated   │
+│         ↓                                      │
+│  Final coverage report + gas benchmarks        │
+└───────────────────────────────────────────────┘
+```
+
+---
+
+## 15. Out of Scope
+
+- Bridge service architecture (separate spec). Bridge's internal key material (HSM, Fireblocks-backed signers, MPC shards) is an implementation detail of Bridge, not an architectural actor.
+- Trustee tooling and signer operations (separate spec).
+- LP and protocol dashboards (separate spec).
+- **MPC wallet configuration and policy engine rules (R2)** — including LP withdrawal destination matching and cumulative withdrawal cap. Enforced by the custodian (Fireblocks / BitGo) on the USDC leg of every Capital Wallet release and *not* duplicated on-chain.
+- USYC auto-allocation of idle LP capital by the custodian's policy engine.
+- Off-chain price feed and notification system.
+- Gnosis Safe deployment and signer management.
+- IOU token mechanics (deferred past MVP).
+- On-chain backing oracle (B3; deferred past MVP).
+- sPLUSD transferable-gating beyond the PLUSD redeem whitelist.
+- Public bug bounty programme (Phase 2).
+
+---
+
+## Appendix A — Resolved open questions (originator confirmed)
+
+| ID | Decision |
+|---|---|
+| C1 | `mintForDeposit` and `yieldMint` gated by `!shutdownActive`. Explicit revert. `DepositManager.deposit` reverts transitively. |
+| C2 | sPLUSD shutdown exit via standard `redeem` + `PLUSD.redeemInShutdown`. No special conversion function. Race-drain solved by protocol-wide frozen rate. |
+| C3 | `adminRelease(Funded)` is 24h-timelocked and GUARDIAN-cancelable; `adminRelease(Pending)` immediate. |
+| H1 | Symmetric haircut: Funded requests also pay recoveryRate; haircut difference returned to RecoveryPool. |
+| H3 | **Downward recovery-rate adjustments disallowed.** Rate only ratchets up via `adjustRecoveryRateUp`. Lowering would be anti-LP. |
+| M1 | EmergencyRevoker's `bridge` and `trustee` targets are ADMIN-updatable with 48h timelock. |
+| M2 | WQ stale `Funded` requests: `sweepStale` eligible at 180 days, recipient == original requester. |
+| U6 (mint, v2.3) | Direct `PLUSD.mint(address,uint256)` removed. Fresh PLUSD enters supply only via `mintForDeposit` (DEPOSITOR, called by DepositManager atomically with USDC transfer to Capital Wallet) or `yieldMint` (YIELD_MINTER + two EIP-712 sigs from Bridge and custodian, destination-constrained to vault/treasury). MINT_ATTESTOR retired. |
+| F-8 | **Pre-fund pool-solvency invariant at shutdown entry dropped.** Crisis-realistic: rate is set against actual pool balance; Trustee tops up; rate can ratchet up. |
+| setDefault timelock | **24 hours** (aligned with shutdown entry delay). |
+
+## Appendix B — Carry-overs (not re-decided)
+
+- **FIFO funding.** Strict FIFO on `fundRequest` ordering; parallel `claim` on Funded requests.
+- **sPLUSD transferability.** Transferable; PLUSD redeem gate neutralizes non-KYC secondary-market value.
+- **GUARDIAN concentration.** Accepted as defensive concentration; GUARDIAN cannot escalate roles or move funds (Morpho sentinel pattern).

--- a/docs/superpowers/plans/2026-04-22-update-specs-v2.3.md
+++ b/docs/superpowers/plans/2026-04-22-update-specs-v2.3.md
@@ -1,0 +1,1169 @@
+# Update Product Specs to v2.3 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Update all affected product specs in `docs/product-specs/` to reflect the v2.3 smart-contract and backend design, replacing the v0.3.8-era descriptions with the confirmed v2.3 architecture.
+
+**Architecture:** v2.3 replaces the Bridge-mediated deposit attestation flow with an atomic on-chain DepositManager; retires MINT_ATTESTOR; adds two-party yield attestation; restructures the WithdrawalQueue lifecycle; and removes Bridge from the loan disbursement and USDC↔USYC rebalancing paths.
+
+**Tech Stack:** Markdown docs, TypeScript lint script (`npx tsx scripts/lint-docs.ts`)
+
+---
+
+## File Map
+
+| File | Action | What changes |
+|---|---|---|
+| `docs/references/index.md` | Modify | Register three new reference docs |
+| `docs/product-specs/deposits.md` | Rewrite | DepositManager atomic flow replaces bridge-mediated mint; remove per-tx cap and mint queue |
+| `docs/product-specs/smart-contracts.md` | Rewrite | 8 contracts + AccessManager + EmergencyRevoker; role renames; new PLUSD mint architecture |
+| `docs/product-specs/bridge-service.md` | Rewrite | Remove deposit flow, loan disbursement, rebalancing; two-party yield attestation; lazy USYC yield |
+| `docs/product-specs/withdrawals.md` | Rewrite | New Pending→Funded→Claimed/AdminReleased lifecycle; remove partial fills and cancelWithdrawal |
+| `docs/product-specs/yield.md` | Modify | Lazy USYC yield on stake/unstake; two-party attestation; remove bridge rebalancing |
+| `docs/product-specs/lp-onboarding.md` | Modify | Fix freshness-gate attribution (now DepositManager, not Bridge) |
+
+---
+
+### Task 1: Register reference documents in `docs/references/index.md`
+
+**Files:**
+- Modify: `docs/references/index.md`
+
+- [ ] **Step 1: Update the index**
+
+Replace the `## Source Documents` section and add entries for all three new reference docs:
+
+```markdown
+## Source Documents
+
+- [Initial Technical Spec (PRD)](../initial_spec.md) — Pipeline MVP Technical Specification v0.3.8 (original source of truth)
+- [Smart Contract Design Spec v2.3](./smart-contracts.md) — Canonical smart contract specification; supersedes v0.3.8 contract descriptions
+- [Bridge Backend Spec](./backend.md) — Bridge service scope, flows, data model, and API surface (v2.3)
+- [Mint Trust Model](./security.md) — Threat analysis, peer-protocol survey, and layered defence rationale for the PLUSD mint path (v2.3)
+```
+
+- [ ] **Step 2: Lint**
+
+```bash
+npx tsx scripts/lint-docs.ts
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/references/index.md
+git commit -m "docs: register v2.3 reference documents in references index"
+```
+
+---
+
+### Task 2: Rewrite `docs/product-specs/deposits.md`
+
+**Files:**
+- Modify: `docs/product-specs/deposits.md`
+
+**Summary of changes:**
+- Replace the bridge-mediated EIP-712 attestation deposit flow with the DepositManager atomic flow.
+- LP calls `DepositManager.deposit(amount)` directly; the contract atomically: checks `isAllowedForMint`, checks `maxPerWindow` / `maxPerLPPerWindow` rolling caps, checks `maxTotalSupply` hard ceiling, enforces reserve invariant, does `USDC.transferFrom(lp, capitalWallet, amount)`, calls `PLUSD.mintForDeposit(lp, amount)`.
+- Remove the per-tx cap ($5M) — dropped in v2.3. The `maxPerLPPerWindow` cap bounds single-actor exposure.
+- Remove the deposit mint queue — over-cap deposits revert at contract; LP retries when headroom opens.
+- Remove the below-minimum accumulation counter — not present in v2.3 flow.
+- Update rate-limit parameters table: `maxPerWindow`, `maxPerLPPerWindow`, `maxTotalSupply`.
+- Update API contract section: `DepositManager.deposit`, `PLUSD.mintForDeposit`, `PLUSD.isAllowedForMint`.
+- Update security section to reflect: no off-chain signer to forge; reserve invariant enforced on-chain; hard supply cap.
+
+- [ ] **Step 1: Rewrite the file**
+
+Write the following content to `docs/product-specs/deposits.md`:
+
+```markdown
+# Deposits and PLUSD Minting
+
+## Overview
+
+An LP deposits USDC by calling `DepositManager.deposit(amount)` directly. The contract
+atomically pulls USDC from the LP's wallet to the Capital Wallet and mints PLUSD 1:1 to the
+depositor in a single transaction. Bridge is not involved in the deposit flow — the on-chain
+USDC transfer IS the attestation. Deposits that exceed on-chain rate limits revert; the LP
+retries when window headroom opens.
+
+---
+
+## Behavior
+
+### Deposit Initiation
+
+The LP must first whitelist-approve their wallet via KYC/KYB onboarding (see lp-onboarding
+spec). Before presenting the deposit UI, the app reads the LP's on-chain WhitelistRegistry
+entry via `isAllowedForMint(lp)`:
+
+- If not whitelisted, the deposit UI is disabled and the LP is directed to complete onboarding.
+- If whitelisted but the Chainalysis freshness window has expired, the deposit UI is blocked
+  and the LP is prompted to re-verify. Bridge calls `WhitelistRegistry.refreshScreening` on a
+  clean Chainalysis result to update `approvedAt`.
+
+To deposit, the LP first calls `USDC.approve(depositManager, amount)` from their wallet, then
+calls `DepositManager.deposit(amount)`.
+
+### On-Chain Deposit Contract (DepositManager)
+
+`DepositManager.deposit(uint256 usdcAmount)` enforces all checks in a single atomic
+transaction, in this order:
+
+1. **Whitelist + freshness check.** `PLUSD.isAllowedForMint(msg.sender)` must return true.
+   Reverts with `NotAllowedForMint` if the LP is not whitelisted or the Chainalysis screen is
+   stale (> 90-day freshness window).
+2. **Per-LP rolling window cap.** `lpWindowMinted[msg.sender] + amount <= maxPerLPPerWindow`.
+   Reverts if a single LP would exceed their window allocation.
+3. **Global rolling window cap.** `windowMinted + amount <= maxPerWindow`. Reverts if total
+   minted in the current rolling window would exceed the protocol-wide cap.
+4. **Hard total supply cap.** `PLUSD.totalSupply() + amount <= maxTotalSupply`. Reverts if
+   the protocol hard ceiling would be breached.
+5. **Reserve invariant check.** `totalSupply + amount <= cumulativeLPDeposits + amount +
+   cumulativeYieldMinted - cumulativeLPBurns`. Enforced inside `mintForDeposit` atomically.
+6. **USDC pull.** `USDC.transferFrom(msg.sender, capitalWallet, usdcAmount)`. Fails if LP has
+   not approved.
+7. **PLUSD mint.** `PLUSD.mintForDeposit(msg.sender, usdcAmount)`. Increments
+   `cumulativeLPDeposits` in the same transaction. Emits `Deposited(lp, amount)`.
+
+If any step reverts, the entire transaction rolls back atomically. The LP's USDC is never
+moved without the corresponding PLUSD mint succeeding in the same transaction.
+
+### Over-Rate-Limit Deposits
+
+If a deposit would breach `maxPerWindow` or `maxPerLPPerWindow`, the contract reverts. There
+is no queue: the LP must retry when window headroom has reopened. The Bridge API endpoint
+`GET /v1/protocol/limits` exposes current window utilisation and per-LP utilisation so the
+deposit UI can show live cap status before the LP submits.
+
+### PLUSD Mint
+
+`PLUSD.mintForDeposit(address lp, uint256 amount)` is callable only by the DepositManager
+(DEPOSITOR role). The function:
+
+- Increments `cumulativeLPDeposits` by `amount`.
+- Checks the reserve invariant: `totalSupply + amount <= cumulativeLPDeposits +
+  cumulativeYieldMinted - cumulativeLPBurns`. Reverts on invariant failure.
+- Mints PLUSD 1:1 to `lp`.
+- Enforces the `_update` hook: recipient must satisfy `WhitelistRegistry.isAllowed(lp)`.
+
+PLUSD is minted 1:1 to USDC received. No fee is deducted at mint time.
+
+---
+
+## API Contract
+
+### DepositManager.deposit
+
+```solidity
+function deposit(uint256 usdcAmount) external;
+// Access: public (whitelisted LPs only — enforced via isAllowedForMint)
+// Checks (in order):
+//   1. isAllowedForMint(msg.sender) == true
+//   2. lpWindowMinted[msg.sender] + usdcAmount <= maxPerLPPerWindow
+//   3. windowMinted + usdcAmount <= maxPerWindow
+//   4. PLUSD.totalSupply() + usdcAmount <= maxTotalSupply
+//   5. USDC.transferFrom(msg.sender, capitalWallet, usdcAmount)
+//   6. PLUSD.mintForDeposit(msg.sender, usdcAmount)
+// Emits: Deposited(address indexed lp, uint256 amount)
+```
+
+### PLUSD.mintForDeposit
+
+```solidity
+function mintForDeposit(address lp, uint256 amount) external;
+// Access: DEPOSITOR role (DepositManager proxy only)
+// Enforces:
+//   - Reserve invariant: totalSupply + amount <= cumulativeLPDeposits + amount +
+//     cumulativeYieldMinted - cumulativeLPBurns
+//   - WhitelistRegistry.isAllowed(lp) == true (via _update hook)
+// Increments cumulativeLPDeposits by amount.
+// Emits: Transfer(address(0), lp, amount)
+```
+
+### WhitelistRegistry.isAllowedForMint
+
+```solidity
+function isAllowedForMint(address lp) external view returns (bool);
+// Returns true if lp is whitelisted AND (block.timestamp - approvedAt) < freshnessWindow
+// Used by DepositManager at deposit time.
+```
+
+### On-chain rate-limit parameters (configurable by ADMIN 3/5 Safe, tightening instant / loosening 48h)
+
+| Parameter | Description |
+|---|---|
+| `maxPerWindow` | Maximum total PLUSD minted across all deposits in the rolling window |
+| `maxPerLPPerWindow` | Maximum PLUSD minted by a single LP in the rolling window |
+| `maxTotalSupply` | Hard ceiling on `PLUSD.totalSupply()` — MakerDAO PSM debt-ceiling analog |
+
+Launch values are a product/risk decision (open item — see references/backend.md decision #13).
+
+---
+
+## Data Model
+
+### Reserve Invariant Counters (on PLUSD contract)
+
+| Field | Type | Description |
+|---|---|---|
+| `cumulativeLPDeposits` | `uint256` | Cumulative USDC deposits minted via DepositManager (6 decimals) |
+| `cumulativeYieldMinted` | `uint256` | Cumulative PLUSD minted via yieldMint |
+| `cumulativeLPBurns` | `uint256` | Cumulative PLUSD burned by WithdrawalQueue |
+
+These counters are updated atomically in the same transaction that moves value. The invariant
+`totalSupply <= cumulativeLPDeposits + cumulativeYieldMinted - cumulativeLPBurns` is checked
+on every mint and burn.
+
+---
+
+## Security Considerations
+
+- **No off-chain signer to forge.** The on-chain USDC transfer IS the deposit evidence. There
+  is no EIP-712 attestation or Bridge key that could be forged to mint unbacked PLUSD on the
+  deposit leg.
+- **Reserve invariant enforced on-chain.** Three cumulative counters updated in the same
+  transaction prevent the Resolv-class over-minting attack (minting more than deposits justify)
+  at the contract level, independently of any off-chain service.
+- **Hard supply cap.** `maxTotalSupply` provides a circuit-breaker bounding total PLUSD
+  supply regardless of deposit volume. Tightening is instant (ADMIN); loosening requires 48h
+  AccessManager delay.
+- **Per-LP window cap.** `maxPerLPPerWindow` bounds single-actor minting within any rolling
+  window, replacing the dropped per-transaction cap.
+- **Smart contracts hold no USDC.** The Capital Wallet is an MPC wallet. A contract exploit
+  cannot drain deposited USDC; the DepositManager only calls `transferFrom` to move USDC
+  from the LP's wallet to the Capital Wallet.
+- **Whitelist enforced at contract, not bridge.** The DEPOSITOR role on PLUSD is held by the
+  DepositManager proxy address. No other caller can invoke `mintForDeposit`. The `_update`
+  hook additionally ensures PLUSD cannot land at a non-whitelisted address.
+```
+
+- [ ] **Step 2: Lint**
+
+```bash
+npx tsx scripts/lint-docs.ts
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/product-specs/deposits.md
+git commit -m "docs(specs): rewrite deposits spec for v2.3 DepositManager atomic flow"
+```
+
+---
+
+### Task 3: Rewrite `docs/product-specs/smart-contracts.md`
+
+**Files:**
+- Modify: `docs/product-specs/smart-contracts.md`
+
+**Summary of changes:**
+- Contract count: 8 functional contracts + AccessManager (OZ) + EmergencyRevoker (was 6 contracts).
+- Add: DepositManager (new in v2.3), ShutdownController (new in v2.2), RecoveryPool (new in v2.2).
+- Replace FoundationMultisig entry with three-Safe governance (ADMIN 3/5, RISK_COUNCIL 3/5, GUARDIAN 2/5).
+- PLUSD role changes: remove MINTER, add DEPOSITOR (DepositManager), rename to YIELD_MINTER (Bridge), keep BURNER (WQ), PAUSER (GUARDIAN).
+- WithdrawalQueue: rename FILLER→FUNDER; new Pending→Funded→Claimed/AdminReleased lifecycle; add `fundRequest`, `claim`, `skipSanctionedHead`, `adminRelease`; remove `fillRequest`.
+- LoanRegistry: rename `loan_manager`→TRUSTEE (held by Trustee key, not Bridge); rename `risk_council` role holder to RISK_COUNCIL Safe.
+- PLUSD: `mint(address,uint256)` removed; new `mintForDeposit` and `yieldMint(att,bridgeSig,custodianSig)`.
+- Non-transferable PLUSD: `_update` requires exactly one of (from, to) to be a system address.
+- AccessManager (OZ): single hub for all role management, timelocked.
+- EmergencyRevoker: revokes FUNDER, WHITELIST_ADMIN, YIELD_MINTER from Bridge and TRUSTEE from Trustee.
+- Update security section (three-safe governance, bounded upgradeability).
+
+- [ ] **Step 1: Rewrite the file**
+
+Write the following content to `docs/product-specs/smart-contracts.md`:
+
+```markdown
+# Smart Contracts
+
+## Overview
+
+The Pipeline protocol deploys eight functional on-chain contracts on Ethereum mainnet, plus a
+shared AccessManager hub and a non-upgradeable EmergencyRevoker. All functional contracts use
+OpenZeppelin v5.x audited library code as their base with custom logic confined to small,
+clearly-scoped extensions. All protocol contracts (except EmergencyRevoker) use UUPS proxies;
+upgrades are gated by the UPGRADER role (ADMIN 3/5) with a 48h AccessManager delay, which
+GUARDIAN 2/5 may cancel.
+
+---
+
+## Governance
+
+Three Gnosis Safes hold all privileged roles across the protocol, with distinct signer sets:
+
+| Safe | Threshold | Role | Timelock |
+|---|---|---|---|
+| ADMIN | 3/5 | Role management, upgrades, parameter changes | 48h (14d on delay changes) |
+| RISK_COUNCIL | 3/5 | Proposes `setDefault` and `enterShutdown` | 24h |
+| GUARDIAN | 2/5 | Instant pause; cancel pending actions; `revokeAll` on EmergencyRevoker | None |
+
+GUARDIAN is defensive-only — it cannot initiate risk-increasing actions, only halt or cancel
+in-flight ones.
+
+---
+
+## Contracts
+
+| Contract | Base standard | Purpose | Custom LOC |
+|---|---|---|---|
+| AccessManager (OZ) | — | Single role-management hub; timelocked actions | 0 |
+| PLUSD | OZ ERC20Pausable + ERC20Permit + AccessManaged + UUPS | Receipt token; minted via DepositManager (1:1 USDC) or `yieldMint` (two-party attested). Non-transferable except between system addresses and whitelisted LPs. | ~110 |
+| DepositManager | AccessManaged + Pausable + ReentrancyGuard + UUPS | Atomic 1:1 USDC→PLUSD deposit. LP calls `deposit(amount)`; contract pulls USDC to Capital Wallet and calls `mintForDeposit`. | ~60 |
+| sPLUSD | OZ ERC-4626 + ERC20Pausable + AccessManaged + UUPS | Yield-bearing vault on PLUSD; open to any PLUSD holder. | ~35 |
+| WhitelistRegistry | AccessManaged + TimelockPending + UUPS | On-chain allowlist: KYCed LP wallets and approved DeFi venues. Tracks Chainalysis `approvedAt` timestamp. | ~95 |
+| WithdrawalQueue | AccessManaged + Pausable + ReentrancyGuard + UUPS | FIFO withdrawal queue; Pending→Funded→Claimed/AdminReleased lifecycle. Full-amount funding only. | ~140 |
+| LoanRegistry | OZ ERC-721 (soulbound) + AccessManaged + Pausable + UUPS | On-chain registry of loan facilities; immutable origination data + mutable lifecycle state. | ~190 |
+| ShutdownController | AccessManaged + UUPS | Freezes normal flow on distress; fixes a `recoveryRateBps`; opens `redeemInShutdown` / `claimAtShutdown` paths. | ~75 |
+| RecoveryPool | AccessManaged + Pausable + ReentrancyGuard + UUPS | Holds USDC for LP recovery payments on shutdown. | ~70 |
+| EmergencyRevoker | standalone, **non-upgradeable** | Single `revokeAll()` call by GUARDIAN atomically strips FUNDER, WHITELIST_ADMIN, YIELD_MINTER from Bridge and TRUSTEE from Trustee. | ~50 |
+
+---
+
+## Contract Interfaces
+
+### PLUSD
+
+| Function | Access | Description |
+|---|---|---|
+| `mintForDeposit(address lp, uint256 amount)` | DEPOSITOR (DepositManager) | Mints PLUSD 1:1 to a USDC deposit. Increments `cumulativeLPDeposits`. Checks reserve invariant and whitelist. |
+| `yieldMint(YieldAttestation att, bytes bridgeSig, bytes custodianSig)` | YIELD_MINTER (Bridge) | Mints yield PLUSD. Verifies two EIP-712 signatures on-chain: Bridge ECDSA (ecrecover on `bridgeYieldAttestor`) and custodian EIP-1271 (on `custodianYieldAttestor`). Destination constrained to sPLUSD vault or Treasury. Checks reserve invariant. |
+| `burn(address from, uint256 amount)` | BURNER (WithdrawalQueue) | Burns PLUSD from escrow when the WQ `claim` step finalises. |
+| `transfer / transferFrom` | public | Standard ERC-20. `_update` hook enforces: exactly one of (from, to) must be a system address (Capital Wallet, Treasury, DepositManager, WQ, sPLUSD vault) or a whitelisted LP. LP↔LP and system↔system both revert. |
+| `pause() / unpause()` | PAUSER (GUARDIAN) | Freezes all mint, burn, and transfer operations. |
+| `reserveHealth()` | public view | Returns `(cumulativeLPDeposits + cumulativeYieldMinted - cumulativeLPBurns - totalSupply)`. Non-negative = internally consistent. |
+
+Direct `mint(address, uint256)` is removed. Fresh PLUSD enters supply only through
+`mintForDeposit` (deposit leg) or `yieldMint` (yield leg).
+
+### DepositManager
+
+| Function | Access | Description |
+|---|---|---|
+| `deposit(uint256 usdcAmount)` | public | Atomic deposit: checks `isAllowedForMint`, rolling caps, supply cap; pulls USDC from LP to Capital Wallet; calls `PLUSD.mintForDeposit`. |
+| `pause() / unpause()` | PAUSER (GUARDIAN) | Freezes all deposits. |
+
+### sPLUSD (ERC-4626)
+
+| Function | Access | Description |
+|---|---|---|
+| `deposit(uint256 assets, address receiver)` | public | Standard ERC-4626 deposit. Open to any PLUSD holder. |
+| `redeem(uint256 shares, address receiver, address owner)` | public | Standard ERC-4626 redeem. Triggers lazy USYC yield mint if NAV delta > 0. |
+| `totalAssets()` | public view | Returns `PLUSD.balanceOf(address(this))`. Increases when yield mints land in the vault. |
+| `pause() / unpause()` | PAUSER (GUARDIAN) | Freezes deposits and redemptions. |
+
+### WhitelistRegistry
+
+| Function | Access | Description |
+|---|---|---|
+| `setAccess(address lp, uint256 approvedAt)` | WHITELIST_ADMIN (Bridge) | Adds or updates a whitelisted LP with the Chainalysis screening timestamp. |
+| `refreshScreening(address lp, uint256 newApprovedAt)` | WHITELIST_ADMIN (Bridge) | Updates `approvedAt` for an existing whitelisted LP after re-screening. |
+| `revokeAccess(address lp)` | WHITELIST_ADMIN (Bridge) or ADMIN | Removes LP from the whitelist immediately. |
+| `isAllowed(address lp)` | public view | Returns true if LP is whitelisted. Used by WithdrawalQueue and PLUSD `_update`. Does not check freshness. |
+| `isAllowedForMint(address lp)` | public view | Returns true if LP is whitelisted AND `(block.timestamp - approvedAt) < freshnessWindow`. Used by DepositManager. |
+| `addDeFiVenue(address venue)` | ADMIN | Adds an approved DeFi pool/vault to the allowlist (held by PLUSD `_update`). |
+
+### WithdrawalQueue
+
+Lifecycle: `Pending → Funded → Claimed | AdminReleased`
+
+| Function | Access | Description |
+|---|---|---|
+| `requestWithdrawal(uint256 amount)` | public | Pulls PLUSD from caller into escrow; assigns `queue_id`; emits `WithdrawalRequested`. Reverts if caller not whitelisted with fresh screen. |
+| `fundRequest(uint256 queueId)` | FUNDER (Bridge) | Funds the queue head in full: pulls USDC from Capital Wallet to WQ via pre-approved allowance. Moves entry to `Funded`. Emits `WithdrawalFunded`. |
+| `skipSanctionedHead()` | FUNDER (Bridge) | Moves a sanctioned (non-`isAllowed`) queue head to `AdminReleased`, unblocking the queue. |
+| `claim(uint256 queueId)` | public (original requester only) | Atomically burns escrowed PLUSD and pays out USDC to LP. Only callable after `Funded`. Emits `WithdrawalClaimed`. |
+| `adminRelease(uint256 queueId)` | ADMIN | Manual release of a stuck entry to `AdminReleased`. |
+| `getQueueDepth()` | public view | Returns `(totalEscrowed, pendingCount, fundedCount)`. |
+| `pause() / unpause()` | PAUSER (GUARDIAN) | Freezes `fundRequest` and `claim`. |
+
+Note: partial fills, `cancelWithdrawal`, and LP-initiated cancellation are not in the MVP.
+The queue is one-way once submitted.
+
+### LoanRegistry
+
+| Function | Access | Description |
+|---|---|---|
+| `mintLoan(address originator, ImmutableLoanData data)` | TRUSTEE | Mints a new loan NFT. Emits `LoanMinted`. |
+| `updateMutable(uint256 tokenId, LoanStatus status, uint256 newMaturityDate, uint256 newCCR, LocationUpdate newLocation)` | TRUSTEE | Updates mutable lifecycle fields. Reverts if newStatus == Default. |
+| `setDefault(uint256 tokenId)` | RISK_COUNCIL | Transitions loan to Default (24h timelock). |
+| `closeLoan(uint256 tokenId, ClosureReason reason)` | TRUSTEE or RISK_COUNCIL | TRUSTEE for {ScheduledMaturity, EarlyRepayment}; RISK_COUNCIL for {Default, OtherWriteDown}. |
+| `getImmutable(uint256 tokenId)` | public view | Returns immutable origination data. |
+| `getMutable(uint256 tokenId)` | public view | Returns current mutable lifecycle data. |
+
+Bridge has **no role on LoanRegistry**. All loan NFT writes are done by the Trustee key directly.
+
+### ShutdownController
+
+| Function | Access | Description |
+|---|---|---|
+| `proposeShutdown(uint256 recoveryRateBps)` | RISK_COUNCIL | Proposes shutdown with a proposed recovery rate. 24h timelock before execution. |
+| `executeShutdown()` | ADMIN via AccessManager | Executes after timelock; freezes normal flow across all contracts; enables `redeemInShutdown` / `claimAtShutdown`. |
+| `adjustRecoveryRateUp(uint256 newRateBps)` | RISK_COUNCIL | Ratchets recovery rate upward (only) as Trustee repatriates capital. 24h timelock. |
+
+Recovery rate ratchets up only; lowering is structurally prevented. sPLUSD holders exit post-shutdown via normal `sPLUSD.redeem()` (returns PLUSD) then `PLUSD.redeemInShutdown` for USDC at the frozen recovery rate.
+
+---
+
+## Role Assignments
+
+| Contract | Role | Held by |
+|---|---|---|
+| PLUSD | DEPOSITOR | DepositManager (proxy address) |
+| PLUSD | YIELD_MINTER | Bridge service |
+| PLUSD | BURNER | WithdrawalQueue |
+| PLUSD | PAUSER | GUARDIAN 2/5 Safe |
+| PLUSD | UPGRADER | ADMIN 3/5 Safe |
+| DepositManager | PAUSER | GUARDIAN 2/5 Safe |
+| DepositManager | UPGRADER | ADMIN 3/5 Safe |
+| sPLUSD | PAUSER | GUARDIAN 2/5 Safe |
+| sPLUSD | UPGRADER | ADMIN 3/5 Safe |
+| WhitelistRegistry | WHITELIST_ADMIN | Bridge service |
+| WhitelistRegistry | ADMIN | ADMIN 3/5 Safe |
+| WhitelistRegistry | PAUSER | GUARDIAN 2/5 Safe |
+| WhitelistRegistry | UPGRADER | ADMIN 3/5 Safe |
+| WithdrawalQueue | FUNDER | Bridge service |
+| WithdrawalQueue | PAUSER | GUARDIAN 2/5 Safe |
+| WithdrawalQueue | ADMIN ops | ADMIN 3/5 Safe |
+| WithdrawalQueue | UPGRADER | ADMIN 3/5 Safe |
+| LoanRegistry | TRUSTEE | Trustee key (Pipeline Trust Company) |
+| LoanRegistry | RISK_COUNCIL | RISK_COUNCIL 3/5 Safe |
+| LoanRegistry | PAUSER | GUARDIAN 2/5 Safe |
+| LoanRegistry | UPGRADER | ADMIN 3/5 Safe |
+| ShutdownController | RISK_COUNCIL | RISK_COUNCIL 3/5 Safe |
+| ShutdownController | ADMIN (execute) | ADMIN 3/5 Safe via AccessManager |
+| EmergencyRevoker | GUARDIAN | GUARDIAN 2/5 Safe |
+
+---
+
+## Data Models
+
+### ImmutableLoanData (set at mint, never changes)
+
+| Field | Type | Notes |
+|---|---|---|
+| originator | address | Originator's on-chain identifier |
+| borrowerId | bytes32 | Hashed borrower identifier |
+| commodity | string | e.g. Jet fuel JET A-1 |
+| corridor | string | e.g. South Korea → Mongolia |
+| originalFacilitySize | uint256 | 6-decimal USDC units |
+| originalSeniorTranche | uint256 | Senior portion at origination |
+| originalEquityTranche | uint256 | Equity portion at origination |
+| originationDate | uint256 | Block timestamp at mint |
+| originalMaturityDate | uint256 | Originally agreed maturity |
+| governingLaw | string | e.g. English law, LCIA London |
+| metadataURI | string | Optional IPFS pointer |
+
+### MutableLoanData (updated by TRUSTEE / RISK_COUNCIL)
+
+| Field | Type | Notes |
+|---|---|---|
+| status | LoanStatus | Performing \| Watchlist \| Default \| Closed |
+| currentMaturityDate | uint256 | May be extended from original |
+| lastReportedCCR | uint256 | Basis points (e.g. 14000 = 140%) |
+| lastReportedCCRTimestamp | uint256 | When CCR was last updated |
+| currentLocation | LocationUpdate | Embedded struct |
+| closureReason | ClosureReason | Set when status = Closed |
+
+Enums: `LoanStatus { Performing, Watchlist, Default, Closed }` ·
+`ClosureReason { None, ScheduledMaturity, EarlyRepayment, Default, OtherWriteDown }` ·
+`LocationType { Vessel, Warehouse, TankFarm, Other }`
+
+---
+
+## Security Considerations
+
+- **No single point of mint compromise.** Deposit-leg mints require a contract-to-contract
+  call through DepositManager (no off-chain signer). Yield-leg mints require Bridge ECDSA
+  signature + custodian EIP-1271 signature + YIELD_MINTER caller role — three independent
+  controls. Compromising any one party mints zero PLUSD.
+- **Reserve invariant on every mint path.** On-chain cumulative counters prevent over-minting
+  against the contract's own ledger. Full Proof of Reserve (Chainlink PoR) is deferred to
+  phase 2.
+- **Bounded upgradeability.** 48h ADMIN delay on upgrades with GUARDIAN veto prevents a
+  "collapse-delay-then-exploit" sequence. A 14-day meta-timelock on delay changes closes the
+  second-order attack.
+- **Three-Safe governance separation.** ADMIN cannot enter shutdown or declare default;
+  RISK_COUNCIL cannot perform upgrades or manage roles; GUARDIAN cannot initiate
+  risk-increasing actions.
+- **Smart contracts hold no USDC.** Capital Wallet and Treasury Wallet are MPC-controlled
+  addresses. A contract exploit cannot drain investor capital unilaterally.
+- **Non-transferable PLUSD.** The `_update` hook requires exactly one of (from, to) to be a
+  system address or whitelisted LP, closing the LP↔LP laundering and system↔system
+  laundering attack classes.
+```
+
+- [ ] **Step 2: Lint**
+
+```bash
+npx tsx scripts/lint-docs.ts
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/product-specs/smart-contracts.md
+git commit -m "docs(specs): rewrite smart-contracts spec for v2.3 architecture"
+```
+
+---
+
+### Task 4: Rewrite `docs/product-specs/bridge-service.md`
+
+**Files:**
+- Modify: `docs/product-specs/bridge-service.md`
+
+**Summary of changes:**
+- Bridge is no longer the deposit mint gate — remove sections 3 (PLUSD Minting Authority), 4 (Deposit Mint Queue), and the deposit-related USDC Transfer event.
+- Remove loan disbursement preparation from bridge scope — Trustee + Team cosign directly on Capital Wallet.
+- Remove USDC↔USYC rebalancing from bridge scope — managed by custodian MPC policy engine; Bridge only requests liquidity when needed.
+- Replace MINTER role with FUNDER (WQ), WHITELIST_ADMIN (WhitelistRegistry), YIELD_MINTER (PLUSD).
+- Bridge has no role on LoanRegistry — Trustee key holds TRUSTEE role directly.
+- Replace simple `PLUSD.mint()` with two-party `yieldMint(att, bridgeSig, custodianSig)`.
+- Replace weekly USYC yield cron with lazy mint triggered on sPLUSD stake/unstake.
+- Update event monitoring list: add DepositManager.Deposited; update WQ events to new lifecycle.
+- Update role assignments table.
+- Update security section.
+
+- [ ] **Step 1: Rewrite the file**
+
+Write the following content to `docs/product-specs/bridge-service.md`:
+
+```markdown
+# Bridge Service
+
+## Overview
+
+The Pipeline Bridge Service is a backend service operated by the Pipeline team. It watches
+on-chain events, reconciles protocol state, co-signs yield attestations, and submits
+operational transactions. **Bridge is not in the critical path for deposits** — deposits are
+atomic user-driven calls to DepositManager. Bridge also has no role in loan disbursements or
+USDC↔USYC rebalancing; those operations are managed by the Trustee and custodian.
+
+The bridge is designed so that its compromise does not enable unbacked PLUSD minting. Yield
+minting requires a second independent signature from the custodian's EIP-1271 contract;
+compromising Bridge alone produces zero yield PLUSD.
+
+---
+
+## Behavior
+
+### 1. Deposit Observation (Bridge not in critical path)
+
+Deposits are fully atomic and user-driven. The LP calls `DepositManager.deposit(amount)`;
+the contract handles all checks and the USDC → PLUSD exchange. Bridge observes
+`DepositManager.Deposited` events for reconciliation and exposes deposit history via the LP
+API. Bridge is not a signer or a gate on the deposit flow.
+
+Bridge also exposes live rate-limit state (`maxPerWindow`, `maxPerLPPerWindow`, current
+window utilisation, per-LP utilisation) via `GET /v1/protocol/limits` so the deposit UI can
+show cap status before the LP submits.
+
+### 2. Withdrawal Queue Funding
+
+When a `WithdrawalRequested` event is observed, Bridge processes the queue head:
+
+1. **Whitelist check.** Calls `WhitelistRegistry.isAllowed(requester)`. If not allowed, calls
+   `WQ.skipSanctionedHead()` to unblock the queue.
+2. **Freshness check.** Bridge checks Chainalysis freshness (bridge-side). If stale but not
+   revoked: calls `WhitelistRegistry.refreshScreening(lp, newApprovedAt)` after a clean
+   Chainalysis re-screen, then proceeds. If re-screen returns a flag, calls `revokeAccess`
+   first, then `skipSanctionedHead`. If Chainalysis is unreachable, Bridge halts and alerts
+   ops — the queue head is stuck pending manual `adminRelease`.
+3. **Balance check.** Reads Capital Wallet USDC balance. If insufficient, requests a USYC →
+   USDC redemption via the custodian MPC API and retries after settlement.
+4. **Fund.** Calls `WQ.fundRequest(queueId)`. The WQ contract pulls USDC from Capital Wallet
+   via a pre-approved allowance. The LP's entry moves to `Funded`; the LP then calls
+   `WQ.claim()` to atomically burn PLUSD and receive USDC.
+
+### 3. Yield Minting — Repayment
+
+When a loan repayment USDC inflow arrives at the Capital Wallet (classified from the indexed
+USDC Transfer log), Bridge initiates the two-party yield mint flow:
+
+1. **Detect and classify.** Bridge indexes USDC inflows to Capital Wallet. The inflow
+   classifier matches each transfer to a category: deposit settlement, repayment, rebalance,
+   or unknown quarantine.
+2. **Trustee approval.** Bridge presents the detected repayment to the Trustee via
+   `GET /v1/trustee/repayments/pending`. The Trustee submits final split amounts (vault share
+   / treasury share) via `POST /v1/trustee/repayments/{id}/approve`.
+3. **Bridge signs.** Signer service constructs two `YieldAttestation` structs (one per
+   destination: vault and treasury) and signs each with the `bridgeYieldAttestor` key:
+   ```
+   YieldAttestation {
+     bytes32 repaymentRef;  // keccak256(chainId, repaymentTxHash, destinationTag)
+     address destination;   // sPLUSD vault OR Treasury
+     uint256 amount;
+     uint64  deadline;
+     uint256 salt;
+   }
+   ```
+   Vault and treasury legs use distinct `repaymentRef` values (`"vault"` / `"treasury"` tag).
+4. **Custodian co-signs.** Bridge posts the structs + Bridge sigs to the custodian's API
+   (Fireblocks Co-Signer / BitGo webhook). The custodian independently verifies the USDC
+   inflow and co-signs via EIP-1271.
+5. **Submit.** Bridge calls `PLUSD.yieldMint(att, bridgeSig, custodianSig)` for each leg via
+   the transaction outbox. PLUSD verifies both signatures on-chain, checks the reserve
+   invariant, and mints to the destination.
+
+Neither Bridge alone nor the custodian alone can mint yield PLUSD — both signatures plus the
+YIELD_MINTER caller role are required.
+
+### 4. Yield Minting — USYC (Lazy, Stake/Unstake-Triggered)
+
+USYC NAV grows continuously. sPLUSD share price advances only when `yieldMint` runs. To keep
+the share price current without a time-based cron, yield is minted **lazily** on every sPLUSD
+`Deposit` or `Withdraw` event:
+
+1. Bridge reads current USYC NAV from the Hashnote API.
+2. Computes `yield_delta = current_NAV - last_minted_NAV` (applied to Capital Wallet USYC
+   holdings). If `delta <= 0`, skip.
+3. If `delta > 0`: builds two `YieldAttestation` structs (vault + treasury) with refs scoped
+   to the NAV timestamp. Gets Bridge sig + custodian co-sig (same flow as repayment yield).
+4. Submits both `yieldMint` calls via outbox.
+5. Advances `last_minted_NAV` baseline only after both legs confirm on-chain.
+
+Between mints, Bridge polls USYC NAV (e.g., every minute) and exposes accrued-but-undistributed
+yield via `GET /v1/vault/stats` for dashboard display.
+
+### 5. WhitelistRegistry Maintenance
+
+- **On Sumsub APPROVED + Chainalysis clean result:** calls
+  `WhitelistRegistry.setAccess(lpAddress, currentBlockTimestamp)` immediately.
+- **On failed passive re-screen:** calls `revokeAccess(lpAddress)` and routes to compliance
+  review queue.
+- **On manual compliance approval:** calls `setAccess(lpAddress, approvedAt)`.
+- **Periodic batch re-screen:** Bridge calls `refreshScreening(lp, newTs)` for each LP on a
+  configurable cadence to maintain freshness.
+
+### 6. Price Feed and CCR Monitoring
+
+Bridge monitors every active loan in the LoanRegistry:
+
+- Polls Platts/Argus commodity prices on a configurable cadence (working assumption: every 15
+  minutes during market hours).
+- Computes CCR = collateral_value / outstanding_senior_principal in basis points.
+- On threshold crossings, notifies configured recipients and submits a TRUSTEE-gated
+  `LoanRegistry.updateMutable` call to update `lastReportedCCR`.
+
+| Event | Trigger | Recipients |
+|---|---|---|
+| Watchlist | CCR falls below 130% | Team, Originator, Trustee |
+| Maintenance margin call | CCR falls below 120% | Team, Originator, Borrower, Trustee |
+| Margin call | CCR falls below 110% | Team, Originator, Borrower, Trustee |
+| Payment delay (amber) | Scheduled repayment > 7 days late | Team, Originator, Trustee |
+| Payment delay (red) | Scheduled repayment > 21 days late | Team, Originator, Trustee |
+| AIS blackout | Vessel tracking loss > 12 hours | Team, Originator, Trustee |
+| CMA discrepancy | Reported collateral > 3% from CMA | Team, Originator, Trustee |
+| Status transition | Any LoanRegistry mutable status change | Team, Originator, Trustee |
+
+### 7. Reserve Reconciliation
+
+After every state-changing event, Bridge evaluates and publishes the full backing invariant:
+
+```
+PLUSD totalSupply  ==  USDC in Capital Wallet
+                     +  USYC NAV in Capital Wallet
+                     +  USDC out on active loans
+                     +  USDC in transit
+```
+
+| Drift | Status | Action |
+|---|---|---|
+| < 0.01% | Green | Normal |
+| 0.01%–1% | Amber | Alert on-call + Trustee |
+| > 1% | Red | Page on-call + Trustee; consider pausing DepositManager |
+
+Bridge also cross-checks: `sum(DepositManager.Deposited.amount) == PLUSD.cumulativeLPDeposits()`.
+Any drift is a bug or indexer lag — alert ops immediately.
+
+---
+
+## On-Chain Events Monitored
+
+| Contract | Event | Purpose |
+|---|---|---|
+| DepositManager | `Deposited(lp, amount)` | Reconciliation; deposit history for LP API |
+| USDC | `Transfer(*, capitalWallet, amount)` | Repayment inflow classification |
+| PLUSD | `Transfer(0x0, lp, amount)` | Mint cross-check vs DepositManager.Deposited |
+| WithdrawalQueue | `WithdrawalRequested` | Flow 2 trigger |
+| WithdrawalQueue | `WithdrawalFunded / WithdrawalClaimed / WithdrawalSanctionedSkip / WithdrawalAdminReleased` | Status tracking |
+| sPLUSD | `Deposit / Withdraw` | Trigger lazy USYC yield (Flow 4) |
+| LoanRegistry | `LoanMinted / LoanUpdated / LoanClosed` | Loan book mirror |
+| PLUSD | `RateLimitsChanged / MaxTotalSupplyChanged` | Update local cache |
+| WhitelistRegistry | `LPApproved / ScreeningRefreshed / LPRevoked` | Whitelist sync |
+| ShutdownController | `ShutdownEntered` | Halt all normal flows |
+| All pausable | `Paused() / Unpaused()` | Halt/resume flows |
+
+---
+
+## Role Assignments on Contracts
+
+| Contract | Role | Held by |
+|---|---|---|
+| PLUSD | YIELD_MINTER | Bridge service |
+| PLUSD | PAUSER | GUARDIAN 2/5 Safe |
+| sPLUSD | PAUSER | GUARDIAN 2/5 Safe |
+| WhitelistRegistry | WHITELIST_ADMIN | Bridge service |
+| WhitelistRegistry | ADMIN | ADMIN 3/5 Safe |
+| WithdrawalQueue | FUNDER | Bridge service |
+| WithdrawalQueue | PAUSER | GUARDIAN 2/5 Safe |
+
+Bridge has **no role on LoanRegistry**. Loan NFT writes are done by the Trustee key directly.
+Bridge is **not a signer for loan disbursements** — those require Trustee + Team co-signature
+on the Capital Wallet directly.
+Bridge **does not manage the USDC↔USYC ratio** — the custodian's MPC policy engine and
+Trustee manage the band; Bridge only requests a USYC redemption at withdrawal funding time
+when Capital Wallet USDC is insufficient.
+
+---
+
+## Security Considerations
+
+**Two-party yield attestation.** Yield minting requires Bridge ECDSA signature + custodian
+EIP-1271 signature + YIELD_MINTER caller role — three independent controls. Bridge alone
+cannot mint yield PLUSD.
+
+**Narrow on-chain roles.** Bridge holds only FUNDER (WQ), WHITELIST_ADMIN (WhitelistRegistry),
+and YIELD_MINTER (PLUSD). These are bounded roles: FUNDER can only trigger WQ pulls for
+existing queue entries; WHITELIST_ADMIN cannot mint; YIELD_MINTER still requires custodian
+co-sig. Bridge has zero roles on LoanRegistry, DepositManager, or governance Safes.
+
+**Deposit path is Bridge-free.** The deposit flow has no Bridge keys on the critical path.
+A complete Bridge compromise does not stop deposits or allow unbacked deposit mints.
+
+**Key storage.** Bridge hot keys (FUNDER, WHITELIST_ADMIN, YIELD_MINTER submitter) are stored
+in HSM-backed KMS. The `bridgeYieldAttestor` key used for yield EIP-712 signing is stored
+separately in an HSM with no internet egress. MPC key shares are managed through the custodian
+vendor's key ceremony.
+
+**Audit log.** Every bridge action is recorded in an append-only audit log mirrored in
+near-real-time to an independent third-party log sink.
+```
+
+- [ ] **Step 2: Lint**
+
+```bash
+npx tsx scripts/lint-docs.ts
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/product-specs/bridge-service.md
+git commit -m "docs(specs): rewrite bridge-service spec for v2.3 roles and scope"
+```
+
+---
+
+### Task 5: Rewrite `docs/product-specs/withdrawals.md`
+
+**Files:**
+- Modify: `docs/product-specs/withdrawals.md`
+
+**Summary of changes:**
+- New lifecycle: `Pending → Funded → Claimed | AdminReleased` (was `Pending | PartiallyFilled | Settled | Cancelled`).
+- Funding is full-amount only — Bridge calls `fundRequest(queueId)`; no partial fills in funding.
+- Claim is a separate LP-initiated step — LP calls `claim(queueId)` which atomically burns PLUSD and receives USDC.
+- No `cancelWithdrawal` in MVP — queue is one-way once submitted.
+- Sanctioned head: Bridge calls `skipSanctionedHead()`, moving entry to `AdminReleased` and unblocking queue.
+- Admin intervention: `adminRelease(queueId)` available for stuck entries.
+- No above-envelope partial fills — if Capital Wallet USDC is insufficient, Bridge requests USYC redemption and retries.
+- Treasury redemption three-party flow is unchanged.
+- Update API interface, events, and data model.
+
+- [ ] **Step 1: Rewrite the file**
+
+Write the following content to `docs/product-specs/withdrawals.md`:
+
+```markdown
+# Withdrawals — Product Spec
+
+## Overview
+
+LPs exit by redeeming sPLUSD for PLUSD, then queuing PLUSD via the WithdrawalQueue contract
+for USDC payout. The queue is strict FIFO. Bridge funds the queue head in full via
+`fundRequest`; the LP then calls `claim` to atomically burn PLUSD and receive USDC. PLUSD
+is held in escrow until the LP's `claim` call, keeping the PLUSD backing invariant valid
+throughout the lifecycle.
+
+---
+
+## Behavior
+
+### Step 1 — sPLUSD to PLUSD
+
+If the LP holds sPLUSD, they first call `sPLUSD.redeem(shares, receiver, owner)`. The vault
+burns the sPLUSD shares and transfers PLUSD at the current share price to the receiver. The
+receiver must satisfy `WhitelistRegistry.isAllowed(receiver)` — if not, the PLUSD transfer
+reverts at the PLUSD contract level.
+
+Before processing the redemption downstream, Bridge checks whether a lazy USYC yield mint is
+due (NAV delta since last mint > 0) and executes it, keeping the share price current.
+
+### Step 2 — WithdrawalQueue.requestWithdrawal()
+
+The LP calls `WithdrawalQueue.requestWithdrawal(amount)`. The contract checks:
+
+- **Whitelist check:** `msg.sender` must be currently whitelisted (`isAllowed`).
+- **Freshness check:** the `approvedAt` timestamp must be within the freshness window
+  (default 90 days).
+
+On success, the contract pulls `amount` PLUSD from the caller into escrow, assigns a
+sequential `queue_id`, and emits `WithdrawalRequested(lpAddress, amount, queueId)`.
+The entry status is `Pending`.
+
+### Queue Funding — Bridge calls fundRequest
+
+Bridge processes the queue head in strict FIFO order:
+
+1. Checks `isAllowed(requester)`. If not allowed (sanctioned or revoked), calls
+   `WQ.skipSanctionedHead()` — the entry moves to `AdminReleased` and the next entry
+   becomes the head.
+2. Checks Chainalysis freshness (Bridge-side). If stale, re-screens via Chainalysis API. On
+   clean result, calls `WhitelistRegistry.refreshScreening(lp, newTs)`, then proceeds. On
+   flagged result, calls `revokeAccess`, then `skipSanctionedHead`.
+3. Reads Capital Wallet USDC balance. If insufficient, requests a USYC → USDC redemption
+   via the custodian MPC API and waits for settlement before retrying `fundRequest`.
+4. Calls `WQ.fundRequest(queueId)`. The WQ contract pulls the full `amount` in USDC from
+   the Capital Wallet via a pre-approved allowance. The entry status moves to `Funded`.
+   Emits `WithdrawalFunded(queueId)`.
+
+Funding is always full-amount. There are no partial fills. If Capital Wallet USDC is
+insufficient for the full amount, Bridge requests a USYC redemption rather than partially
+filling.
+
+### Step 3 — LP calls claim()
+
+After their entry is `Funded`, the LP calls `WQ.claim(queueId)`. The contract atomically:
+
+1. Burns the escrowed PLUSD (`amount`) — increments `cumulativeLPBurns` on PLUSD.
+2. Transfers the corresponding USDC from WQ to the LP's address.
+3. Moves entry to `Claimed`. Emits `WithdrawalClaimed(queueId)`.
+
+Only the original requester may call `claim`. PLUSD is not burned until `claim` executes,
+preserving the backing invariant throughout the funding-to-claim window.
+
+### Sanctioned Head Handling
+
+If `isAllowed(requester)` returns false at funding time, Bridge calls `skipSanctionedHead()`.
+The WQ contract moves the entry to `AdminReleased` status, unlocking the queue. Escrowed
+PLUSD in the skipped entry is held in the contract; ADMIN must decide disposition separately
+via a governance action.
+
+### Admin Release
+
+ADMIN (3/5 Safe) may call `adminRelease(queueId)` to manually move a stuck `Pending` entry
+to `AdminReleased` when automated processing is blocked and manual intervention is needed
+(e.g., Chainalysis API unavailable for extended period).
+
+### Above-Envelope Payouts
+
+Bridge's custodian MPC payout policy applies auto-signing bounds (per-tx cap and rolling 24h
+aggregate) on the Capital Wallet USDC outflows. Payouts exceeding these bounds surface in the
+Trustee tooling signing queue; the Trustee and Pipeline team co-sign via MPC.
+
+### Treasury Wallet Redemption — Stage A (PLUSD to USDC)
+
+The Treasury Wallet redeems accumulated PLUSD revenue via the same WithdrawalQueue mechanics,
+with three-party authorisation:
+
+1. **Team operator A** initiates the redemption (specifies PLUSD amount).
+2. **Team operator B** (distinct authenticated session) verifies and confirms.
+3. **Trustee** provides the final co-signature via MPC.
+
+On all three signatures, Bridge escrows PLUSD and executes the USDC payout from the Capital
+Wallet to a protocol-controlled withdrawal endpoint.
+
+### Treasury Wallet Redemption — Stage B (USDC to bank account)
+
+Once USDC is at the withdrawal endpoint, Team operator A initiates off-ramp. The destination
+bank account must be from the **pre-approved bank account list** maintained by the ADMIN Safe.
+Free-text entry is not permitted. Authorisation mirrors Stage A (two team operators + Trustee).
+
+---
+
+## API Contract
+
+```solidity
+interface IWithdrawalQueue {
+    /// @notice Pulls PLUSD from caller into escrow; creates a Pending queue entry.
+    /// @dev Reverts if caller is not whitelisted with a fresh screen.
+    function requestWithdrawal(uint256 amount) external returns (uint256 queueId);
+
+    /// @notice Funds the queue head in full by pulling USDC from Capital Wallet.
+    /// @dev Only callable by FUNDER (Bridge). Moves entry to Funded.
+    function fundRequest(uint256 queueId) external;
+
+    /// @notice Skips a sanctioned queue head; moves it to AdminReleased.
+    /// @dev Only callable by FUNDER (Bridge). Requires !isAllowed(head requester).
+    function skipSanctionedHead() external;
+
+    /// @notice Atomically burns escrowed PLUSD and pays USDC to original requester.
+    /// @dev Only callable by the original requester. Entry must be Funded.
+    function claim(uint256 queueId) external;
+
+    /// @notice Manually releases a stuck Pending entry to AdminReleased.
+    /// @dev Only callable by ADMIN (3/5 Safe).
+    function adminRelease(uint256 queueId) external;
+
+    /// @notice Returns current queue state.
+    function getQueueDepth()
+        external view returns (
+            uint256 totalEscrowed,
+            uint256 pendingCount,
+            uint256 fundedCount
+        );
+
+    function pause() external;
+    function unpause() external;
+}
+```
+
+**Key events**
+
+```solidity
+event WithdrawalRequested(address indexed lp, uint256 amount, uint256 indexed queueId);
+event WithdrawalFunded(uint256 indexed queueId);
+event WithdrawalClaimed(uint256 indexed queueId, uint256 amountPaid);
+event WithdrawalSanctionedSkip(uint256 indexed queueId);
+event WithdrawalAdminReleased(uint256 indexed queueId);
+```
+
+---
+
+## Data Model
+
+```
+WithdrawalEntry {
+  queueId:         uint256   // Sequential, assigned at requestWithdrawal()
+  lp:              address   // Original requester
+  amount:          uint256   // Full escrowed PLUSD amount
+  status:          enum { Pending, Funded, Claimed, AdminReleased }
+  createdAt:       uint256   // Block timestamp of requestWithdrawal()
+  fundedAt:        uint256   // Block timestamp of fundRequest() — zero if not yet funded
+  claimedAt:       uint256   // Block timestamp of claim() — zero if not yet claimed
+}
+```
+
+PLUSD is held in escrow from `requestWithdrawal` through `claim`. It is burned only at
+`claim`, when USDC simultaneously leaves the contract. This preserves the PLUSD backing
+invariant throughout the full withdrawal lifecycle.
+
+---
+
+## Security Considerations
+
+- **Two-step settlement.** Funding (USDC to WQ) and claiming (PLUSD burn + USDC to LP) are
+  separate transactions. PLUSD backing invariant holds because `totalSupply` does not decrease
+  until USDC has physically left the Capital Wallet and `claim` burns the PLUSD.
+- **No partial fills.** Funding is all-or-nothing. Atomicity of the USDC transfer + PLUSD burn
+  is guaranteed by the `claim` step; there is no state where PLUSD is partially burned against
+  partial USDC.
+- **Sanctioned head skip.** `skipSanctionedHead` prevents a sanctioned LP from permanently
+  blocking queue progress for all other LPs behind them.
+- **Queue is one-way.** `cancelWithdrawal` is not available in MVP. Once PLUSD enters escrow
+  it remains there until `claim` or `adminRelease`.
+- **Destination is implicitly the original requester.** `claim` pays to the original `lp`
+  address on the queue entry — there is no payment-to parameter the requester can redirect.
+- **MPC policy cap on Capital Wallet outflows.** The custodian's policy engine bounds
+  automated Bridge-initiated USDC outflows by per-tx and rolling aggregate caps, independent
+  of Bridge software.
+- **GUARDIAN pause.** GUARDIAN 2/5 can freeze all `fundRequest` and `claim` operations
+  immediately on incident detection.
+```
+
+- [ ] **Step 2: Lint**
+
+```bash
+npx tsx scripts/lint-docs.ts
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/product-specs/withdrawals.md
+git commit -m "docs(specs): rewrite withdrawals spec for v2.3 Pending/Funded/Claimed lifecycle"
+```
+
+---
+
+### Task 6: Update `docs/product-specs/yield.md`
+
+**Files:**
+- Modify: `docs/product-specs/yield.md`
+
+**Summary of changes:**
+- Step 3 of repayment delivery: replace `PLUSD.mint(sPLUSDvault, ...)` / `PLUSD.mint(TreasuryWallet, ...)` with `yieldMint(att, bridgeSig, custodianSig)` two-party attestation flow. Add note that Trustee provides final split amounts (waterfall is not computed on-chain in MVP).
+- Step 4 of repayment delivery: remove "bridge automatically converts senior_principal_returned USDC into USYC" — USDC/USYC rebalancing is now managed by custodian MPC policy engine, not Bridge.
+- Weekly USYC NAV yield distribution section: replace with lazy mint on sPLUSD stake/unstake. Update the subsection to reflect: no weekly cron; yield is minted when NAV delta > 0 on each stake/unstake event using the same two-party attestation as repayment yield.
+- Remove the "Automated USDC/USYC rebalancing" subsection — this is now managed by the custodian and is out of Bridge scope.
+- Update "RepaymentSettled event" language — it is no longer an EIP-712 off-chain attestation signed by the Trustee; instead, the Trustee approves the split amounts via the Bridge API, and Bridge constructs the `YieldAttestation` structs.
+
+- [ ] **Step 1: Read the full current yield.md**
+
+Read `docs/product-specs/yield.md` in full before editing to confirm line numbers for each section to replace.
+
+```bash
+cat -n docs/product-specs/yield.md
+```
+
+- [ ] **Step 2: Replace repayment on-chain delivery section**
+
+Find the block that describes `PLUSD.mint(sPLUSDvault, ...)` and replace with the two-party
+attestation mechanism. The replacement for steps 2–4 under "RepaymentSettled event and
+on-chain delivery":
+
+```markdown
+Once the trustee confirms the waterfall breakdown via
+`POST /v1/trustee/repayments/{id}/approve`, the Bridge executes on-chain yield delivery:
+
+1. The trustee instructs the on-ramp provider to convert the senior portion
+   (`senior_principal_returned + senior_coupon_net + protocol fees`) from USD to USDC,
+   settling into the Capital Wallet.
+2. The bridge verifies that the USDC inflow matches the Trustee-approved amounts.
+3. The bridge constructs two `YieldAttestation` structs (one for the sPLUSD vault, one for
+   the Treasury Wallet), signs each with the `bridgeYieldAttestor` key, and requests
+   custodian co-signatures via the custodian's EIP-1271 API:
+   - Vault leg: `yieldMint(att_vault, bridgeSig, custodianSig)` mints `senior_coupon_net`
+     PLUSD to the sPLUSD vault, increasing `totalAssets` and accreting NAV for all stakers.
+   - Treasury leg: `yieldMint(att_treasury, bridgeSig, custodianSig)` mints
+     `management_fee + performance_fee + oet_allocation` PLUSD to the Treasury Wallet.
+   Both legs are submitted and confirmed independently. Neither Bridge alone nor the custodian
+   alone can mint — both EIP-712 signatures are verified on-chain.
+```
+
+- [ ] **Step 3: Replace weekly USYC distribution section**
+
+Replace the "Weekly USYC NAV yield distribution" subsection with:
+
+```markdown
+### USYC NAV yield distribution (lazy, stake/unstake-triggered)
+
+USYC in the Capital Wallet accrues NAV continuously. To keep sPLUSD share price current
+without a time-based cron, yield is minted **lazily** on each sPLUSD `Deposit` or `Withdraw`
+event:
+
+1. Bridge reads the current USYC NAV from the Hashnote API.
+2. Computes `yield_delta = current_NAV - last_minted_NAV` (applied to Capital Wallet USYC
+   holdings). If `delta <= 0`, no yield mint occurs.
+3. If `delta > 0`: Bridge constructs two `YieldAttestation` structs (vault 70%, treasury 30%
+   of `yield_delta`), gets Bridge sig + custodian co-sig, and submits two `yieldMint` calls
+   via the transaction outbox.
+4. After both `yieldMint` transactions confirm on-chain, Bridge advances the `last_minted_NAV`
+   baseline. Until both confirm, the baseline is unchanged — idempotent retry is safe.
+
+Between mints, Bridge polls USYC NAV (e.g., every minute) and exposes accrued-but-undistributed
+yield via `GET /v1/vault/stats` for dashboard display. USYC is not redeemed during yield
+distribution; it remains in the Capital Wallet.
+```
+
+- [ ] **Step 4: Remove the automated USDC/USYC rebalancing subsection**
+
+Delete the "Automated USDC/USYC rebalancing" subsection entirely. USDC↔USYC ratio management
+is now the custodian MPC policy engine's responsibility, not Bridge's. Only a reference
+sentence remains appropriate in the relevant context (e.g., Bridge requests USYC redemption
+at withdrawal funding time if USDC is insufficient — covered in the withdrawals spec).
+
+- [ ] **Step 5: Lint**
+
+```bash
+npx tsx scripts/lint-docs.ts
+```
+
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/product-specs/yield.md
+git commit -m "docs(specs): update yield spec for v2.3 two-party attestation and lazy USYC distribution"
+```
+
+---
+
+### Task 7: Update `docs/product-specs/lp-onboarding.md`
+
+**Files:**
+- Modify: `docs/product-specs/lp-onboarding.md`
+
+**Summary of changes:**
+- One targeted fix: the "Chainalysis Re-Screening Freshness Window" section currently says "the authoritative check is performed by the bridge service before any PLUSD mint is executed." In v2.3, the authoritative check is performed by the DepositManager contract (`isAllowedForMint`), not by Bridge. Bridge no longer gates deposits.
+- No other substantive changes — the onboarding flow (Sumsub, Chainalysis, whitelist write) is unchanged.
+
+- [ ] **Step 1: Read the current file**
+
+Read `docs/product-specs/lp-onboarding.md` to locate the exact sentence to fix.
+
+```bash
+cat -n docs/product-specs/lp-onboarding.md
+```
+
+- [ ] **Step 2: Fix the freshness gate attribution**
+
+Find the sentence in the "Chainalysis Re-Screening Freshness Window" section:
+
+> The frontend freshness gate is a UX convenience; the authoritative check is performed by
+> the bridge service before any PLUSD mint is executed (see deposits spec).
+
+Replace with:
+
+> The frontend freshness gate is a UX convenience; the authoritative check is enforced
+> on-chain by the DepositManager contract (`isAllowedForMint`) at deposit time (see deposits
+> spec).
+
+- [ ] **Step 3: Lint**
+
+```bash
+npx tsx scripts/lint-docs.ts
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/product-specs/lp-onboarding.md
+git commit -m "docs(specs): fix deposit freshness-gate attribution (DepositManager, not Bridge)"
+```
+
+---
+
+## Self-Review
+
+### Spec coverage check
+
+| v2.3 change | Covered by task |
+|---|---|
+| M1 — DepositManager atomic 1:1 deposit | Task 2 (deposits), Task 3 (smart-contracts) |
+| M2 — MINT_ATTESTOR retired | Task 3 (smart-contracts), Task 4 (bridge-service) |
+| M3 — DEPOSITOR role on PLUSD | Task 3 (smart-contracts), Task 2 (deposits) |
+| M4 — Reserve invariant (3 cumulative counters) | Task 2 (deposits), Task 3 (smart-contracts) |
+| M5 — Two-party yield attestation | Task 3 (smart-contracts), Task 4 (bridge-service), Task 6 (yield) |
+| M6 — Economic caps (maxPerLPPerWindow, maxTotalSupply; drop per-tx cap) | Task 2 (deposits), Task 3 (smart-contracts) |
+| M7 — EmergencyRevoker simplified | Task 3 (smart-contracts) |
+| U3 — WithdrawalQueue Pending/Funded/Claimed/AdminReleased | Task 5 (withdrawals), Task 3 (smart-contracts) |
+| FILLER→FUNDER rename | Task 3 (smart-contracts), Task 5 (withdrawals), Task 4 (bridge-service) |
+| LOAN_MANAGER→TRUSTEE rename | Task 3 (smart-contracts), Task 4 (bridge-service) |
+| Bridge no role on LoanRegistry | Task 4 (bridge-service), Task 3 (smart-contracts) |
+| Bridge no role in deposit flow | Task 4 (bridge-service), Task 2 (deposits) |
+| Bridge no role in loan disbursement | Task 4 (bridge-service) |
+| USDC↔USYC rebalancing out of Bridge scope | Task 4 (bridge-service), Task 6 (yield) |
+| Weekly USYC cron → lazy mint on stake/unstake | Task 4 (bridge-service), Task 6 (yield) |
+| Partial fills dropped from WQ funding | Task 5 (withdrawals), Task 3 (smart-contracts) |
+| cancelWithdrawal not in MVP | Task 5 (withdrawals) |
+| Three-Safe governance (ADMIN, RISK_COUNCIL, GUARDIAN) | Task 3 (smart-contracts) |
+| ShutdownController + RecoveryPool new contracts | Task 3 (smart-contracts) |
+| Register reference docs | Task 1 |
+| lp-onboarding freshness gate attribution | Task 7 |

--- a/scripts/lint-docs.ts
+++ b/scripts/lint-docs.ts
@@ -122,7 +122,8 @@ function checkReachability() {
     (f) =>
       !visited.has(f) &&
       !f.includes("exec-plans/active/") &&
-      !f.includes("exec-plans/completed/")
+      !f.includes("exec-plans/completed/") &&
+      !f.includes("superpowers/")
   );
 
   if (unreachable.length === 0) {


### PR DESCRIPTION
## Summary

- Rewrote `deposits.md`: DepositManager atomic flow replaces bridge-mediated EIP-712 attestation; removed per-tx cap and mint queue; added reserve invariant counters and new economic caps (`maxPerWindow`, `maxPerLPPerWindow`, `maxTotalSupply`)
- Rewrote `smart-contracts.md`: 8 contracts + AccessManager + EmergencyRevoker; three-Safe governance (ADMIN/RISK_COUNCIL/GUARDIAN); DepositManager, ShutdownController, RecoveryPool added; MINTER role removed; FILLER→FUNDER and LOAN_MANAGER→TRUSTEE renames; non-transferable PLUSD model
- Rewrote `bridge-service.md`: Bridge removed from deposit flow, loan disbursements, and USDC↔USYC rebalancing; two-party yield attestation; lazy USYC yield on stake/unstake; updated role assignments (FUNDER, WHITELIST_ADMIN, YIELD_MINTER)
- Rewrote `withdrawals.md`: Pending→Funded→Claimed/AdminReleased lifecycle; no partial fills; LP `claim()` step; `skipSanctionedHead`; removed `cancelWithdrawal`
- Updated `yield.md`: two-party attestation for both yield paths; lazy USYC distribution on stake/unstake; removed bridge-managed rebalancing section
- Fixed `lp-onboarding.md`: deposit freshness gate attributed to DepositManager contract, not Bridge
- Registered v2.3 reference docs in `docs/references/index.md`; excluded `docs/superpowers/` from lint reachability check

Closes #3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated v2.3 specs: deposits are now atomic on-chain (approve + deposit) with live rate-limit caps visible in the UI.
  * Withdrawal flow changed to a fund‑then‑claim lifecycle (no partial fills/cancels); new queue states and events described.
  * Yield moved to lazy on stake/unstake and two‑party attested repayment mints; monitoring/reconciliation and reserve invariants added.
  * Expanded reference docs and architecture diagrams; updated roles, governance, and security model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->