### PR TITLE
Fix disallow query: require whitelisted + expired TTL

### DIFF
--- a/packages/shared/src/kyc_repo.rs
+++ b/packages/shared/src/kyc_repo.rs
@@ -164,8 +164,8 @@ impl KycRepo {
     pub async fn fetch_profiles_to_disallow(&self) -> anyhow::Result<Vec<WhitelistCandidate>> {
         let rows = sqlx::query_as::<_, WhitelistCandidate>(
             "SELECT wallet_address FROM lp_profiles
-             WHERE (is_whitelisted = true OR is_whitelisted IS NULL)
-               AND kyc_review_status = 2
+             WHERE is_whitelisted = true
+               AND whitelist_reset_at <= NOW()
                AND (kyc_status != 2 OR aml_status = 3)",
         )
         .fetch_all(&self.pool)


### PR DESCRIPTION
## Summary
- Only call `disallow` on profiles that are already whitelisted (`is_whitelisted = true`) and whose TTL has expired (`whitelist_reset_at <= NOW()`)
- Removed the `is_whitelisted IS NULL` case that was triggering reverts for never-whitelisted profiles

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated profile filtering logic for KYC compliance processes to improve accuracy in profile selection criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->