### PR TITLE
Fix #182: remove "Balance:" prefix from deposit token rows

### DIFF
--- a/packages/frontend/src/routes/deposit.tsx
+++ b/packages/frontend/src/routes/deposit.tsx
@@ -46,7 +46,7 @@ function Deposit() {
           input={{
             token: "usdc",
             tokenLabel: "USDC",
-            balanceLabel: "Balance: 10,000.00",
+            balanceLabel: "10,000.00",
             placeholderValue: "0",
             quickAmounts: [
               { label: "$1,000 (Min)", selected: true },
@@ -58,7 +58,7 @@ function Deposit() {
           output={{
             token: "plusd",
             tokenLabel: "PLUSD",
-            balanceLabel: "Balance: 0.00",
+            balanceLabel: "0.00",
             value: "0",
           }}
           exchangeRate="1 USDC = 1 PLUSD"

--- a/packages/frontend/src/wallet/README.md
+++ b/packages/frontend/src/wallet/README.md
@@ -88,7 +88,10 @@ before delegating to the real read. Returns `{ data, isLoading, error }`.
 Run the dev server, open the browser DevTools console, and paste:
 
 ```js
-localStorage.setItem("pipeline.mock.wallet.address", "0x1234000000000000000000000000000000000000");
+localStorage.setItem(
+  "pipeline.mock.wallet.address",
+  "0x1234000000000000000000000000000000000000",
+);
 localStorage.setItem("pipeline.mock.wallet.isConnected", "true");
 localStorage.setItem("pipeline.mock.wallet.balance.usdc", "1000000000"); // 1,000 USDC
 ```
@@ -97,8 +100,11 @@ The UI updates instantly (no reload needed). The TopBar switches to its
 connected state and shows the USDC balance. To reset:
 
 ```js
-["pipeline.mock.wallet.address", "pipeline.mock.wallet.isConnected", "pipeline.mock.wallet.balance.usdc"]
-  .forEach(k => localStorage.removeItem(k));
+[
+  "pipeline.mock.wallet.address",
+  "pipeline.mock.wallet.isConnected",
+  "pipeline.mock.wallet.balance.usdc",
+].forEach((k) => localStorage.removeItem(k));
 ```
 
 ---


### PR DESCRIPTION
Closes #182