### PR TITLE
Fix #184: deposit quick-amount chip shape (rounded-rect, no wrap)

### DIFF
--- a/packages/frontend/src/wallet/README.md
+++ b/packages/frontend/src/wallet/README.md
@@ -88,7 +88,10 @@ before delegating to the real read. Returns `{ data, isLoading, error }`.
 Run the dev server, open the browser DevTools console, and paste:
 
 ```js
-localStorage.setItem("pipeline.mock.wallet.address", "0x1234000000000000000000000000000000000000");
+localStorage.setItem(
+  "pipeline.mock.wallet.address",
+  "0x1234000000000000000000000000000000000000",
+);
 localStorage.setItem("pipeline.mock.wallet.isConnected", "true");
 localStorage.setItem("pipeline.mock.wallet.balance.usdc", "1000000000"); // 1,000 USDC
 ```
@@ -97,8 +100,11 @@ The UI updates instantly (no reload needed). The TopBar switches to its
 connected state and shows the USDC balance. To reset:
 
 ```js
-["pipeline.mock.wallet.address", "pipeline.mock.wallet.isConnected", "pipeline.mock.wallet.balance.usdc"]
-  .forEach(k => localStorage.removeItem(k));
+[
+  "pipeline.mock.wallet.address",
+  "pipeline.mock.wallet.isConnected",
+  "pipeline.mock.wallet.balance.usdc",
+].forEach((k) => localStorage.removeItem(k));
 ```
 
 ---

--- a/packages/ui/src/components/QuickAmountChip/QuickAmountChip.tsx
+++ b/packages/ui/src/components/QuickAmountChip/QuickAmountChip.tsx
@@ -18,7 +18,7 @@ import React from "react";
  *   - `--color-pipeline-ink-muted`    — unselected label colour
  *   - `--color-pipeline-line`         — subtle border
  *   - `--color-pipeline-brand`        — focus-visible ring
- *   - `--radius-pipeline-pill`        — fully rounded ends
+ *   - `--radius-pipeline-button`      — small rounded corners (4 px, matches Figma radius-3xl)
  *   - `--font-body`, `--text-pipeline-body`, `--font-weight-emphasized`
  */
 
@@ -39,8 +39,8 @@ export const QuickAmountChip = React.forwardRef<
   const chipClasses = [
     // Layout
     "inline-flex items-center justify-center",
-    "h-9 px-3",
-    "rounded-[var(--radius-pipeline-pill)]",
+    "h-9 px-3 whitespace-nowrap",
+    "rounded-[var(--radius-pipeline-button)]",
     // Border — always present
     "border",
     selected


### PR DESCRIPTION
Closes #184