### PR TITLE
docs: frontend code structure rules + utils/hooks catalogues

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ Product & design:
 
 Operational:
 
-- [`docs/PLANS.md`](./docs/PLANS.md) | [`docs/PRODUCT_SENSE.md`](./docs/PRODUCT_SENSE.md) | [`docs/QUALITY_SCORE.md`](./docs/QUALITY_SCORE.md) | [`docs/RELIABILITY.md`](./docs/RELIABILITY.md) | [`docs/SECURITY.md`](./docs/SECURITY.md) | [`docs/FRONTEND.md`](./docs/FRONTEND.md) | [`docs/STORIES.md`](./docs/STORIES.md)
+- [`docs/PLANS.md`](./docs/PLANS.md) | [`docs/PRODUCT_SENSE.md`](./docs/PRODUCT_SENSE.md) | [`docs/QUALITY_SCORE.md`](./docs/QUALITY_SCORE.md) | [`docs/RELIABILITY.md`](./docs/RELIABILITY.md) | [`docs/SECURITY.md`](./docs/SECURITY.md) | [`docs/FRONTEND.md`](./docs/FRONTEND.md) | [`docs/frontend/index.md`](./docs/frontend/index.md) | [`docs/STORIES.md`](./docs/STORIES.md)
 
 Reference:
 

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -41,6 +41,22 @@ Each Phase-3 component issue ships a `.stories.tsx` file alongside the component
 
 TBD — evaluate Shadcn/ui (headless, Tailwind-based) or Radix UI primitives. Decision to be made before frontend sprint begins. Add a tech-debt entry if not resolved before Phase 1 implementation.
 
+## Code structure rules
+
+These rules apply to everything under `packages/frontend/` and `packages/ui/`. They exist so a reader can find the logic, the view, or the shared utility without spelunking — and so reused code earns the testing it deserves.
+
+1. **One component per file.** A file exports exactly one React component. Co-located children (small layout subcomponents that are not used elsewhere) are still each in their own file. The file name matches the component name (`StakeCard.tsx` exports `StakeCard`, etc.).
+
+2. **Separate view from logic via a co-located hook.** A component's `.tsx` file is JSX-and-styling only. Any non-trivial state, derivation, side effect, or external integration lives in a `useXxx` hook next to the component (`StakeCard.tsx` + `useStakeCard.ts`). The view calls the hook and renders. This keeps components diff-friendly under UX review, makes the logic unit-testable without a DOM, and gives reviewers one place to look for behaviour.
+
+3. **Extract common utils — and always test them.** When the same helper (formatter, parser, predicate, comparator, mock-resolver, etc.) is needed in two or more places, lift it into a dedicated `utils/` module and import it from there. Every extracted util ships with a unit test in the same commit. Inline duplication is a code smell; an untested util is a regression waiting to happen.
+
+4. **Catalogue every extracted util.** Each shared util is listed in [`docs/frontend/utils.md`](./frontend/utils.md) with its import path and a one-line description. The PR that introduces or moves a util updates this catalogue in the same commit.
+
+5. **Catalogue every reused hook.** Each hook used by two or more components (or intended for reuse) is listed in [`docs/frontend/hooks.md`](./frontend/hooks.md) with its import path and a one-line description. Component-local hooks following rule 2 (e.g. `useStakeCard`) stay out of this list; the catalogue is for genuinely shared hooks.
+
+See [`docs/frontend/index.md`](./frontend/index.md) for the catalogue index.
+
 ## Application structure
 
 File-based routing is provided by [TanStack Router](https://tanstack.com/router) (`@tanstack/react-router`). Route files live in `packages/frontend/src/routes/`. The plugin (`@tanstack/router-plugin`) auto-generates `src/routeTree.gen.ts` on every `vite build` / `vite dev` run; that file is committed (so `tsc` works on a fresh clone without first running the dev server / build) but must not be edited manually.

--- a/docs/frontend/hooks.md
+++ b/docs/frontend/hooks.md
@@ -1,0 +1,18 @@
+# Frontend hooks
+
+Catalogue of reused React hooks. Governed by [`docs/FRONTEND.md` → Code structure rules](../FRONTEND.md#code-structure-rules).
+
+**Inclusion criteria.** A hook appears here when it is consumed by two or more components, or is explicitly designed for reuse (e.g. shipped from `@pipeline/ui` or the wallet module). Component-local hooks following the "view + co-located hook" rule (e.g. `useStakeCard` next to `StakeCard.tsx`) are intentionally **excluded** — they have one owner and one call site.
+
+Entries are sorted alphabetically by name.
+
+| Name | Import path | Description |
+|------|-------------|-------------|
+| `useUsdcBalance` | `@/wallet` | Returns the connected wallet's USDC balance, formatted and raw. Honours `pipeline.mock.wallet.balance.usdc` for mock testing. |
+| `useWallet` | `@/wallet` | Returns the connected wallet's address, connection state, chain id, and `connect`/`disconnect` actions. Backed by wagmi + Reown AppKit; honours `pipeline.mock.wallet.*` localStorage keys. |
+
+## How to add a row
+
+1. Land the hook in code with the tests that cover its public contract.
+2. Add a row above with the export name, the `@pipeline/...` (or `@/...`) import path, and a one-sentence description (what it returns and its primary side effect, if any).
+3. Keep the table sorted alphabetically. If the hook is renamed, moved, or retires from "reused" status, update the row in the same commit.

--- a/docs/frontend/index.md
+++ b/docs/frontend/index.md
@@ -1,0 +1,14 @@
+# Frontend catalogues
+
+Internal catalogues of shared frontend code. The rules that govern what belongs here are in [`docs/FRONTEND.md` → Code structure rules](../FRONTEND.md#code-structure-rules).
+
+- [Utils](./utils.md) — shared helpers (formatters, parsers, predicates, mock resolvers, etc.). Every entry is unit-tested.
+- [Hooks](./hooks.md) — reused React hooks. Component-local hooks (one component owner, e.g. `useStakeCard`) are intentionally excluded.
+
+## How to add an entry
+
+1. Land the util or hook in code with its test(s).
+2. In the same commit, add a row to the relevant table below: name + import path + one-line description. Keep entries sorted alphabetically by name.
+3. If the entry is removed or moved, update the catalogue in the same commit that touches the code.
+
+A reviewer should be able to scan these tables and immediately know whether a helper already exists before writing a new one.

--- a/docs/frontend/utils.md
+++ b/docs/frontend/utils.md
@@ -1,0 +1,17 @@
+# Frontend utils
+
+Catalogue of shared frontend utility helpers. Governed by [`docs/FRONTEND.md` → Code structure rules](../FRONTEND.md#code-structure-rules).
+
+**Inclusion criteria.** A helper appears here when it is used in two or more places and has been lifted into a dedicated module under `packages/frontend/src/utils/` or `packages/ui/src/utils/`. Every entry must ship with unit tests in the same commit that adds it.
+
+Entries are sorted alphabetically by name.
+
+| Name | Import path | Description |
+|------|-------------|-------------|
+| _none yet_ | — | First extraction will land here. |
+
+## How to add a row
+
+1. Land the util in code with its `*.test.ts` next to it. Test must cover the cases the call sites rely on.
+2. Add a row above with the export name, the `@pipeline/...` import path, and a one-sentence description (what it returns, not how it's implemented).
+3. Keep the table sorted alphabetically. If the util is renamed or moved, update the row in the same commit.


### PR DESCRIPTION
## Summary

Sets up the frontend documentation scaffolding requested in chat:

1. **One component per file** — file name matches component name; co-located children each in their own file.
2. **Separate view from logic via a co-located hook** — `Foo.tsx` is JSX-and-styling only; non-trivial state/derivation/side-effects live in `useFoo.ts` next to it.
3. **Extract shared utils — and always test them** — when a helper is needed in 2+ places, lift it into a `utils/` module and ship a unit test in the same commit.
4. **Catalogue every extracted util** in [`docs/frontend/utils.md`](../blob/docs/frontend-code-structure-rules/docs/frontend/utils.md) with import path + one-line description.
5. **Catalogue every reused hook** in [`docs/frontend/hooks.md`](../blob/docs/frontend-code-structure-rules/docs/frontend/hooks.md). Component-local hooks from rule 2 are intentionally excluded.

## Changes

- `docs/FRONTEND.md` — new \"Code structure rules\" section listing rules 1–5 and linking the catalogues.
- `docs/frontend/index.md` — catalogue index + \"how to add an entry\" workflow.
- `docs/frontend/utils.md` — empty catalogue table (no shared utils have been extracted yet).
- `docs/frontend/hooks.md` — pre-seeded with `useWallet` and `useUsdcBalance` from the wallet module.
- `AGENTS.md` — adds `docs/frontend/index.md` next to `docs/FRONTEND.md` in the Operational navigation so agents discover the catalogues from the standard entry point.

## Test plan

- [x] All new files render correctly on GitHub (Markdown tables, relative links)
- [x] Cross-links resolve (`docs/FRONTEND.md` ↔ `docs/frontend/{index,utils,hooks}.md`, `AGENTS.md` → `docs/frontend/index.md`)
- [ ] Reviewer sanity-check: are the inclusion criteria for utils vs hooks crisp enough for an agent to follow without a human?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive frontend development guidelines establishing code structure conventions, component organization patterns, and best practices
  * Introduced dedicated catalogues for reusable React hooks and shared utility functions with standardized documentation templates
  * Created framework for documenting frontend utilities requiring alphabetical ordering, inclusion criteria verification, and accompanying unit tests

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eq-lab/pipeline/pull/210)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->