### PR TITLE
chore: add front:dev script and load .env from repo root

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "lint:docs": "npx tsx scripts/lint-docs.ts",
     "codegen": "echo 'TODO: codegen'",
-    "prepare": "husky"
+    "prepare": "husky",
+    "front:dev": "yarn workspace @pipeline/frontend dev"
   },
   "devDependencies": {
     "husky": "9.1.7",

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -6,6 +6,7 @@ import runtimeEnv from "vite-plugin-runtime-env";
 import path from "path";
 
 export default defineConfig({
+  envDir: path.resolve(__dirname, "../.."),
   plugins: [TanStackRouterVite(), react(), tailwindcss(), runtimeEnv()],
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

- Adds a root \`yarn front:dev\` script that runs the frontend workspace dev server.
- Configures the frontend Vite project to read \`.env\` from the repo root via \`envDir\`.

Both edits were made during a prior session but were lost when uncommitted changes were overtaken by squash-merges from subagent worktrees that started from a clean \`main\`. This re-lands them as a proper commit.

## Test plan

- [ ] \`yarn front:dev\` from the repo root starts the dev server.
- [ ] The dev server picks up \`VITE_*\` values from the root \`.env\` file.