### PR TITLE
chore(ux-reviewer): require frontend flow label on filed issues

### DIFF
--- a/.claude/skills/ux-reviewer/SKILL.md
+++ b/.claude/skills/ux-reviewer/SKILL.md
@@ -71,12 +71,15 @@ Read additional context only as needed:
    - Use additional `get_screenshot` and `take_screenshot` calls (including per-element `uid` screenshots) when a difference is unclear.
 
 6. **File one Issue per problem**
-   - For each independent difference, file a new GitHub Issue:
+   - For each independent difference, file a new GitHub Issue. **Labels are not optional** — without a flow label the `manager` skill will skip the Issue. Use:
+     - `bug,frontend,backlog` — default for every UX-review finding (visual / styling / copy fix on a frontend page).
+     - `bug,frontend,trivial,backlog` — add `trivial` when the fix is mechanical and self-contained: a CSS tweak, a prop default change, a string prefix, a single-component visual fix with no data-flow or logic change. Trivial Issues skip planning + the approval gate (`coder` runs directly), so reserve it for changes that obviously don't need design judgement or scope discussion.
+     - **Do not** use `bug,backlog` alone — the missing flow label leaves the Issue invisible to the workflow.
 
      ```bash
      gh issue create \
        --title "<short imperative fix>" \
-       --label "bug,backlog" \
+       --label "bug,frontend,backlog" \
        --body "$(cat <<'EOF'
      **Parent issue:** #<number> (omit if no parent Issue was passed)
      **App URL:** <url>


### PR DESCRIPTION
## Summary

The \`ux-reviewer\` skill filed Issues with only \`bug,backlog\` labels. Per \`AGENTS.md\`, any Issue intended for dev work needs exactly one flow label (\`backend\` or \`frontend\`); without it the \`manager\` skill skips the Issue. Six recently-filed UX-review findings (#265–#270) hit this — relabeled manually.

This patch updates step 6 of \`.claude/skills/ux-reviewer/SKILL.md\` to:

- Default the \`gh issue create\` template to \`bug,frontend,backlog\`.
- Document when to add the \`trivial\` modifier (single-component / mechanical fixes).
- Explicitly warn against the bare \`bug,backlog\` combination.

## Test plan

- [ ] Next \`ux-reviewer\` invocation files Issues with the \`frontend\` label.
- [ ] Mechanical visual fixes (single-component CSS / copy tweaks) get \`trivial\` added.