### PR TITLE
Fix whitelist allow logic: skip crystal check when disabled, check is…

### DIFF
--- a/packages/shared/src/kyc_repo.rs
+++ b/packages/shared/src/kyc_repo.rs
@@ -284,7 +284,6 @@ impl KycRepo {
                            SELECT 1 FROM contract_logs c
                            WHERE c.event_name = 'DepositRequested'
                              AND LOWER(c.sender) = p.wallet_address
-                             AND c.crystal_kyt_status = 1
                        )",
                 )
                 .fetch_all(&self.pool)
@@ -313,7 +312,6 @@ impl KycRepo {
                            SELECT 1 FROM contract_logs c
                            WHERE c.event_name = 'DepositRequested'
                              AND LOWER(c.sender) = p.wallet_address
-                             AND c.crystal_kyt_status = 1
                        )",
                 )
                 .fetch_all(&self.pool)

--- a/packages/worker/src/relayer/whitelist.rs
+++ b/packages/worker/src/relayer/whitelist.rs
@@ -7,6 +7,7 @@ sol! {
     contract WhitelistRegistry {
         function allow(address user) external;
         function disallow(address who) external;
+        function isAllowed(address user) external view returns (bool);
     }
 }
 
@@ -57,6 +58,27 @@ async fn process_allows<T, P>(
         let Some(addr) = shared::evm::parse_address(&candidate.wallet_address) else {
             continue;
         };
+
+        // Skip if already allowed on-chain
+        match registry.isAllowed(addr).call().await {
+            Ok(ret) if ret._0 => {
+                tracing::debug!(
+                    wallet = candidate.wallet_address,
+                    "already allowed on-chain, syncing DB"
+                );
+                if let Err(e) = kyc_repo
+                    .set_on_chain_allowed(&candidate.wallet_address)
+                    .await
+                {
+                    tracing::error!(wallet = candidate.wallet_address, error = %e, "failed to sync DB");
+                }
+                continue;
+            }
+            Ok(_) => {} // not allowed yet, proceed
+            Err(e) => {
+                tracing::warn!(wallet = candidate.wallet_address, error = %e, "isAllowed check failed, proceeding with allow");
+            }
+        }
 
         let result: Result<_, alloy::contract::Error> = async {
             registry.allow(addr).send().await?.watch().await?;


### PR DESCRIPTION
…Allowed before tx

- Remove crystal_kyt_status check from EXISTS subquery when crystal_enabled=false — deposits were never matched because the status stays NULL when screening is disabled
- Check isAllowed(user) on-chain before sending allow() tx to avoid redundant transactions and sync DB state