### PR TITLE
Add Codex workflow skills

### DIFF
--- a/.codex/skills/coder/SKILL.md
+++ b/.codex/skills/coder/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: coder
+description: Implement a planned Pipeline GitHub Issue by number. Use when Codex is asked to execute an active plan end-to-end, update code/tests/docs, mark plan steps complete, run the relevant verification commands, and report results without editing issue labels, closing the Issue, moving the plan, or committing.
+---
+
+# Coder
+
+Implement exactly one GitHub Issue. The manager owns lifecycle labels, commits, pushes, and plan archival.
+
+Start and finish with:
+
+```text
+MODEL: <model> | EFFORT: <effort>
+```
+
+## Required Context
+
+1. Read `AGENTS.md`.
+2. Read the Issue and comments:
+
+   ```bash
+   gh issue view <number> -c
+   gh issue view <number> --json title,body,labels,assignees,url
+   ```
+
+3. Read `.codex/skills/issue/SKILL.md`.
+4. Read the active execution plan: `docs/exec-plans/active/issue-<number>-*.md`.
+
+If the caller explicitly says `Flow: trivial-frontend`, there may be no plan. In that case, work directly from the Issue body and comments.
+
+## Workflow
+
+1. Confirm the user supplied an Issue number.
+2. Read the Issue, comments, labels, and active plan.
+3. If no active plan exists and this is not `Flow: trivial-frontend`, stop and report that planning is missing.
+4. Implement the Issue end-to-end:
+   - Follow plan steps in order.
+   - Add or update tests where useful.
+   - Update docs listed in `Docs to Update`.
+   - If the Issue or plan references Figma, use it as an implementation reference.
+5. Mark completed plan steps as you go. Do not create a plan for trivial frontend mode.
+6. Run verification scaled to the changes:
+   - Rust changes: `cargo clippy --all -- -D warnings`.
+   - TypeScript or docs changes: `npx tsx scripts/lint-docs.ts`.
+   - Frontend changes: run the relevant frontend lint/build scripts from `package.json` or package docs.
+   - Run the repo's fast test workflow when available.
+7. Fix failures before reporting done. If blocked by environment or dependency failures, report exact commands and errors.
+
+## Rules
+
+- Do not edit Issue labels, assign, close, commit, push, or move the plan to completed.
+- Do not ask for approval during implementation; execute the plan.
+- Respect existing code patterns and architecture boundaries.
+- Do not fix unrelated bugs inline. Log them in `docs/exec-plans/known-bugs.md` with date, location, symptom, root cause if known, and workaround.
+- Log intentional shortcuts or structural gaps in `docs/exec-plans/tech-debt-tracker.md`.
+- If the plan is wrong or incomplete, use judgement, note the deviation in the final report, and comment on the Issue.
+- Never revert user changes or unrelated worktree changes.
+
+## Trivial Frontend Mode
+
+When the caller says `Flow: trivial-frontend`:
+
+- Work from the Issue body and comments.
+- Do not invent an execution plan.
+- Keep changes self-contained to the frontend.
+- Leave lint, build, and relevant tests green.
+- Touch product docs only when behavior visibly changes.
+
+## Output
+
+Report:
+
+- Issue number and title
+- What changed
+- Tests added or updated
+- Verification commands and pass/fail results
+- Docs updated
+- Plan deviations, blockers, or concerns

--- a/.codex/skills/coder/agents/openai.yaml
+++ b/.codex/skills/coder/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Coder"
+  short_description: "Implement planned Pipeline issues"
+  default_prompt: "Use $coder to implement issue 123 according to its execution plan."

--- a/.codex/skills/issue/SKILL.md
+++ b/.codex/skills/issue/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: issue
+description: Create, inspect, and manage GitHub Issues for the Pipeline repository. Use when Codex needs to create a tracked task, check duplicate issues before work, start or transition issue lifecycle labels, comment on scope decisions or blockers, or understand Pipeline issue labels and manager flow selection.
+---
+
+# Issue
+
+GitHub Issues are the canonical task tracker for Pipeline. Every implementation task should have an Issue, and each open Issue has exactly one status label that describes its lifecycle state.
+
+## Required Context
+
+Read `AGENTS.md` before making lifecycle changes. Check existing Issues before creating new ones:
+
+```bash
+gh issue list --state open --search "<keywords>"
+gh issue view <number> -c
+```
+
+## Create An Issue
+
+1. Check for duplicates in open Issues.
+2. Write the body with the problem, why it matters, affected areas, and blockers. For bugs, include observed and expected behavior.
+3. Create it with at least one type label, exactly one status label, and exactly one flow label when it is development work.
+
+Use `backlog` when ready to work, or `blocked` when it cannot proceed:
+
+```bash
+gh issue create --title "<title>" --label "<type>,<flow>,backlog" --body "<body>"
+gh issue create --title "<title>" --label "<type>,<flow>,blocked" --body "<body explaining the blocker>"
+```
+
+Discussion, tracking, and question Issues may omit the flow label. Development Issues must use exactly one of `backend` or `frontend`.
+
+## Start Existing Work
+
+1. Read the Issue and all comments:
+
+   ```bash
+   gh issue view <number> -c
+   gh issue view <number> --json title,body,labels,assignees,url
+   ```
+
+2. If it is assigned to someone else and has an in-flight status label, stop and ask the user before taking over.
+3. If it has `blocked`, stop until the blocker is resolved.
+4. Assign yourself:
+
+   ```bash
+   gh issue edit <number> --add-assignee @me
+   ```
+
+5. Move `backlog` to the correct first in-flight state:
+
+   ```bash
+   gh issue edit <number> --remove-label backlog --add-label planning
+   ```
+
+Use `executing` instead of `planning` only for trivial frontend work that intentionally skips planning.
+
+## Lifecycle Labels
+
+Status labels are mutually exclusive:
+
+| Label | Meaning |
+| --- | --- |
+| `backlog` | Ready, not started |
+| `blocked` | Waiting on an external dependency or decision |
+| `planning` | Execution plan is being produced |
+| `planned` | Plan exists, awaiting implementation or approval |
+| `executing` | Implementation in progress |
+| `executed` | Implementation complete, awaiting testing or completion |
+| `testing` | Manual or UX testing in progress |
+| `tested` | Tested, awaiting final PR/merge handling |
+
+Transitions are always remove-then-add:
+
+```bash
+gh issue edit <number> --remove-label <old> --add-label <new>
+```
+
+The `manager` skill owns lifecycle transitions during full workflows. Planner, coder, and UX tester skills must not edit parent Issue labels.
+
+## Flow Labels
+
+| Label combination | Manager flow |
+| --- | --- |
+| `backend` | Backend flow: plan, hard approval gate, implement, complete PR for human merge |
+| `frontend` | Frontend flow: plan, pause only for open questions, implement, UX test if Figma applies |
+| `frontend` + `trivial` | Trivial frontend flow: no plan, implement directly, manager may admin-merge after CI is green |
+
+Any dev Issue must carry exactly one of `backend` or `frontend`. If unsure, use `backend`.
+
+## Type And Modifier Labels
+
+Common labels:
+
+| Label | Use |
+| --- | --- |
+| `bug` | Broken or incorrect behavior |
+| `enhancement` | New feature or improvement |
+| `documentation` | Docs-only work |
+| `question` | Needs discussion |
+| `priority` | Higher priority |
+| `trivial` | Modifier for self-contained frontend-only fixes |
+
+## Comments
+
+Use comments for decisions, scope changes, blockers, and links to bugs discovered during testing:
+
+```bash
+gh issue comment <number> --body "<comment>"
+```
+
+Do not close a development Issue manually when a PR body contains `Closes #<number>`; GitHub closes it on merge.

--- a/.codex/skills/issue/agents/openai.yaml
+++ b/.codex/skills/issue/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Issue"
+  short_description: "Manage Pipeline GitHub issues"
+  default_prompt: "Use $issue to create or manage a Pipeline GitHub Issue."

--- a/.codex/skills/manager/SKILL.md
+++ b/.codex/skills/manager/SKILL.md
@@ -1,0 +1,201 @@
+---
+name: manager
+description: Orchestrate Pipeline GitHub Issues end-to-end. Use when Codex is asked to run the manager workflow for one Issue or the trivial frontend backlog, claim the Issue, choose backend/frontend/trivial flow from labels, create or reuse a branch and draft PR, delegate planning/coding/UX testing/review, manage lifecycle labels, commits, pushes, and completion rules.
+---
+
+# Manager
+
+Drive GitHub Issues through the Pipeline workflow. The manager owns lifecycle labels, branch/PR setup, commits, pushes, and final workflow reporting. Invoking this skill explicitly authorizes the manager to delegate phase work to Codex subagents when available.
+
+Start with:
+
+```text
+MODEL: <model> | EFFORT: <effort>
+```
+
+## Arguments
+
+Single Issue mode:
+
+- `<number>`
+- `issue <number>`
+- optional free text such as `and review it`
+
+Trivial loop mode:
+
+- `trivial`
+- `trivial <max-tasks>`
+
+If the argument cannot be parsed, ask for clarification.
+
+## Required Context
+
+Read before taking action:
+
+1. `AGENTS.md`
+2. `.codex/skills/issue/SKILL.md`
+3. The target Issue: `gh issue view <number> -c`
+
+## Claim And Classify
+
+1. Assign the Issue to yourself:
+
+   ```bash
+   gh issue edit <number> --add-assignee @me
+   ```
+
+2. Verify it is not assigned to someone else.
+3. Read labels:
+
+   ```bash
+   gh issue view <number> --json labels --jq '.labels[].name'
+   ```
+
+4. Choose the flow:
+   - `frontend` + `trivial`: Flow C, trivial frontend.
+   - `frontend` without `trivial`: Flow B, frontend.
+   - `backend`: Flow A, backend.
+   - neither `backend` nor `frontend`: stop; not dev work.
+   - both `backend` and `frontend`: stop, comment on the conflict, and ask the user.
+
+## Common Prelude
+
+For a fresh Issue:
+
+```bash
+git fetch origin
+git checkout main
+git pull --ff-only origin main
+git checkout -b <prefix>/<slug>
+git commit --allow-empty -m "chore: start work on #<number>"
+git push -u origin <branch>
+gh pr create --draft --title "<issue title>" --body "Closes #<number>"
+```
+
+If resuming an existing branch/PR, check it out and pull it fast-forward only. Never force-reset `main`.
+
+## Delegation
+
+Prefer Codex `spawn_agent` with `agent_type: "worker"` for planner, coder, UX tester, and reviewer phases. Use `fork_context: true` when the subagent needs the same repo and issue context. Give each subagent a bounded prompt:
+
+```text
+Use $planner to plan issue <number>.
+```
+
+```text
+Use $coder to implement issue <number>.
+```
+
+```text
+Use $ux-tester to test issue:<number>.
+```
+
+For automated PR review, ask a worker to review the PR in code-review stance, post a PR comment, and not approve or merge.
+
+If subagents are unavailable, run the phase locally while preserving the same boundaries: planner does not implement, coder does not edit labels or commit, UX tester files bugs and updates quality docs, manager commits and pushes.
+
+## Flow A: Backend
+
+Use for Rust crates, contracts, workers, scripts, docs-only work, and anything uncertain.
+
+Planning:
+
+1. `backlog` to `planning`.
+2. Run `$planner <number>`.
+3. `planning` to `planned`.
+4. Commit and push planning artifacts: `Plan #<number>: <short title>`.
+5. Comment with plan summary and stop for human approval.
+
+Implementation after approval:
+
+1. `planned` to `executing`.
+2. Run `$coder <number>`.
+3. `executing` to `executed`.
+4. Commit and push: `Implement #<number>: <short title>`.
+
+Completion:
+
+1. Move the plan from `docs/exec-plans/active/` to `docs/exec-plans/completed/`.
+2. Mark the draft PR ready.
+3. Commit and push: `Complete #<number>: <short title>`.
+4. Remove the final status label.
+5. Do not merge. Backend PRs are human-merge only.
+
+Automated review is optional after completion when the Issue is an enhancement, the diff is significant, or the user explicitly asked for review. If review finds a blocker, comment and stop.
+
+## Flow B: Frontend
+
+Planning:
+
+1. `backlog` to `planning`.
+2. Run `$planner <number>`.
+3. Read `## Open Questions` in the plan.
+4. `planning` to `planned`.
+5. Commit and push planning artifacts.
+6. If open questions are not `_None_`, comment with them and stop. Otherwise continue.
+
+Implementation:
+
+1. `planned` to `executing`.
+2. Run `$coder <number>`.
+3. `executing` to `executed`.
+4. Commit and push implementation.
+
+UX testing:
+
+Run `$ux-tester issue:<number>` only when the Issue or plan references Figma and the diff touches frontend code. Transition `executed` to `testing`, then `testing` to `tested`, and commit testing artifacts. Critical bug Issues must be addressed before completion.
+
+Completion:
+
+Move the plan to completed, mark the PR ready, commit/push the plan move, remove the current status label, and stop. Frontend PRs are human-merge only.
+
+## Flow C: Trivial Frontend
+
+Use only for `frontend` + `trivial`.
+
+1. `backlog` to `executing`.
+2. Run `$coder <number>` with this prompt included:
+
+   ```text
+   Flow: trivial-frontend.
+   There is no execution plan. Work from the Issue body and comments directly. Verify lint, frontend build, and relevant tests are green.
+   ```
+
+3. From the manager, rerun frontend lint/build/test checks appropriate for the diff.
+4. If checks fail, comment on the Issue and stop.
+5. `executing` to `executed`.
+6. Commit and push: `Implement #<number>: <short title>`.
+7. Mark PR ready and remove `executed`.
+8. Poll PR checks until every check is `SUCCESS`. Red checks, conflicts, or unresolved checks within the cap stop the flow.
+9. Only after checks are green, admin-merge with squash and branch deletion:
+
+   ```bash
+   gh pr merge <pr-number> --admin --squash --delete-branch
+   ```
+
+Flow C is the only manager-owned merge path. Do not admin-merge backend or non-trivial frontend PRs.
+
+## Trivial Loop
+
+When invoked as `trivial [max-tasks]`, repeatedly pick open `backlog,frontend,trivial` Issues that are unassigned or assigned to you. Prefer `priority`, then lower issue number. Stop when the cap is reached, no candidates remain, or a task fails verification.
+
+## Rules
+
+- Only one lifecycle status label may be present at a time.
+- The manager is the only phase owner that edits lifecycle labels.
+- The manager commits phase artifacts after subagents return.
+- Do not close Issues manually when the PR body contains `Closes #<number>`.
+- Do not merge Flow A or Flow B PRs.
+- Never bypass red CI checks or merge conflicts.
+- If a subagent fails or work is blocked, comment on the Issue and ask the user how to proceed.
+
+## Output
+
+Report:
+
+- Issue number, title, branch, and PR URL
+- Flow and phases completed
+- Commits pushed
+- Tests/checks run and results
+- Bugs filed or blockers found
+- Whether merge was left to a human or completed under Flow C

--- a/.codex/skills/manager/agents/openai.yaml
+++ b/.codex/skills/manager/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Manager"
+  short_description: "Orchestrate Pipeline issue workflows"
+  default_prompt: "Use $manager to drive issue 123 through the Pipeline workflow."

--- a/.codex/skills/planner/SKILL.md
+++ b/.codex/skills/planner/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: planner
+description: Create an execution plan for a Pipeline GitHub Issue by number. Use when Codex is asked to plan an Issue, write docs/exec-plans/active/issue-number-slug.md, research the relevant code/docs/Figma context, identify open questions, and prepare work for the coder without editing issue labels or committing.
+---
+
+# Planner
+
+Plan exactly one GitHub Issue. Produce an active execution plan only; do not implement code, edit lifecycle labels, assign or close the Issue, commit, or push.
+
+Start and finish with:
+
+```text
+MODEL: <model> | EFFORT: <effort>
+```
+
+## Required Context
+
+1. Read `AGENTS.md`.
+2. Read the Issue body and every comment:
+
+   ```bash
+   gh issue view <number> -c
+   gh issue view <number> --json title,body,labels,assignees,milestone,url
+   ```
+
+3. Read `.codex/skills/issue/SKILL.md` for labels and lifecycle rules.
+4. Read `ARCHITECTURE.md` and only the relevant docs/code needed for the Issue.
+
+If the Issue references a Figma URL, extract the file key and node id, call Figma MCP for design context, and include Figma-based verification in the plan.
+
+## Workflow
+
+1. Confirm the user supplied an Issue number. Ask for one if missing.
+2. Research the existing implementation, tests, docs, and architecture boundaries affected by the Issue.
+3. Decide whether docs must change. User-facing or agent-facing behavior changes usually require updates in `docs/product-specs/`, `docs/design-docs/`, `ARCHITECTURE.md`, or generated docs.
+4. Create `docs/exec-plans/active/issue-<number>-<short-slug>.md`.
+5. Include every required section below. `## Open Questions` must be present. Use `_None_` only when there are genuinely no unresolved decisions.
+6. Report the plan path, summary, open question status, and blockers.
+
+## Plan Format
+
+```markdown
+# Issue #<number>: <title>
+
+Source: <GitHub issue URL>
+
+## Scope
+
+<what will change and what is out of scope>
+
+## Assumptions and Risks
+
+<risks, dependencies, constraints, and likely failure modes>
+
+## Open Questions
+
+<one unresolved question per line, or `_None_`>
+
+## Implementation Steps
+
+1. <concrete step with file paths, modules, functions, and expected behavior>
+2. ...
+
+## Test Strategy
+
+<tests to add/update, commands to run, edge cases, and manual checks>
+
+## Docs to Update
+
+<specific docs/specs/generated references, or `_None_`>
+```
+
+## Rules
+
+- Treat the Issue body as the authoritative "what"; comments may add later decisions.
+- Be concrete enough for a coder to execute without rediscovering the task.
+- Respect dependency direction from `ARCHITECTURE.md`.
+- Do not skip research. Name the files and modules involved.
+- If dependencies are unfinished or blocked, document them under assumptions and risks.
+- Do not hide uncertainty to avoid an approval gate; list real open questions.
+
+## Output
+
+Report:
+
+- Issue number and title
+- Plan summary
+- Plan file path
+- Whether `## Open Questions` is empty
+- Blocking dependencies or risks

--- a/.codex/skills/planner/agents/openai.yaml
+++ b/.codex/skills/planner/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Planner"
+  short_description: "Plan Pipeline GitHub issues"
+  default_prompt: "Use $planner to create an execution plan for issue 123."

--- a/.codex/skills/ux-reviewer/SKILL.md
+++ b/.codex/skills/ux-reviewer/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: ux-reviewer
+description: Review a rendered Pipeline page against a Figma design and file one GitHub Issue per independent visual or structural difference. Use with either an Issue number that contains a Figma reference or an explicit app URL and Figma URL pair.
+---
+
+# UX Reviewer
+
+Compare a live rendered page to Figma and log differences. Do not implement fixes.
+
+Start and finish with:
+
+```text
+MODEL: <model> | EFFORT: <effort>
+```
+
+## Inputs
+
+Accept exactly one form:
+
+- Issue number, such as `315`. Read the Issue and comments, extract the Figma URL, and resolve the app route.
+- Explicit pair: `url:<app-url> figma:<figma-url>`.
+
+Ask for clarification if neither form is provided.
+
+## Required Context
+
+Read:
+
+1. `AGENTS.md`
+2. `.codex/skills/issue/SKILL.md`
+
+When useful, read the frontend code, product specs, and design docs for the page under review.
+
+## Workflow
+
+1. Resolve the app URL and Figma URL.
+2. Extract Figma `fileKey` and `nodeId`.
+3. Load Figma design context with Figma MCP. Use returned React/Tailwind as reference only; do not copy it into the app.
+4. Open the app page with browser MCP.
+5. Capture a structure snapshot and full-page screenshot. Use element screenshots for uncertain regions.
+6. Populate representative content if needed using project scripts/fixtures. Pipeline is Rust + TypeScript; do not use Laravel or `php artisan` flows.
+7. Compare section by section:
+   - section presence and order
+   - headings and copy
+   - typography, alignment, spacing
+   - colors, backgrounds, borders, shadows
+   - grids, columns, responsive structure
+   - images, icons, aspect ratios
+   - extra or missing elements
+   - truncation and dynamic text behavior
+8. File one GitHub Issue per independent difference.
+9. If a parent Issue was used, comment on it with links to filed Issues.
+
+## Figma Assets
+
+Figma MCP asset URLs expire. Download assets locally before relying on them for review evidence or fixture data. Leave review seed data/assets in place unless the user asks otherwise.
+
+## Filing Findings
+
+Use frontend flow labels so the manager sees the work:
+
+- Default: `bug,frontend,backlog`
+- Mechanical and self-contained fixes: `bug,frontend,trivial,backlog`
+
+Do not use `bug,backlog` alone for frontend UX findings.
+
+Issue body:
+
+```markdown
+**Parent issue:** #<number>
+**App URL:** <url>
+**Figma:** <figma-url including node-id>
+
+**What Figma shows**
+...
+
+**What the app renders**
+...
+
+**Suggested fix scope**
+...
+```
+
+## Rules
+
+- Do not edit app code, styles, data builders, or existing Issues.
+- Only add seed data/assets when needed to make the review realistic.
+- Do not roll back seed data/assets added for review.
+- Always review with realistic content; empty states are not valid unless the Figma target is an empty state.
+- Prefer snapshots for text/structure and screenshots for visual differences.
+- Drill into child Figma nodes when a top-level frame is too broad.
+
+## Output
+
+Report:
+
+- app URL reviewed
+- Figma file key and node id
+- seed data/assets added, with paths and a note they were left in place
+- table of filed Issue numbers and finding titles
+- ambiguous items not filed and why

--- a/.codex/skills/ux-reviewer/agents/openai.yaml
+++ b/.codex/skills/ux-reviewer/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "UX Reviewer"
+  short_description: "Compare app pages against Figma"
+  default_prompt: "Use $ux-reviewer to compare url:http://localhost:3000/path against figma:https://figma.com/design/...."

--- a/.codex/skills/ux-tester/SKILL.md
+++ b/.codex/skills/ux-tester/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: ux-tester
+description: Manually UX-test Pipeline with browser MCP tooling. Use for issue-scoped UI testing, regression passes, updating docs/STORIES.md test cases, filing bug Issues from manual QA, and updating docs/QUALITY_SCORE.md after exercising the app in Chrome/Playwright/DevTools.
+---
+
+# UX Tester
+
+Manually validate Pipeline UI behavior with a real browser. Do not edit lifecycle labels, close parent Issues, commit, or push.
+
+Start and finish with:
+
+```text
+MODEL: <model> | EFFORT: <effort>
+```
+
+## Modes
+
+- `update cases`: refresh `docs/STORIES.md` from completed Issues and plans.
+- `issue:<number>`: test one completed or in-flight Issue.
+- `regression`: run a practical regression pass across documented stories.
+
+Ask for clarification if no mode is clear.
+
+## Required Context
+
+Read:
+
+1. `AGENTS.md`
+2. `.codex/skills/issue/SKILL.md`
+3. `docs/STORIES.md` (create it if missing)
+4. `docs/QUALITY_SCORE.md`
+
+For `issue:<number>`, also read:
+
+```bash
+gh issue view <number> -c
+gh issue view <number> --json title,body,labels,assignees,url
+```
+
+Open the matching plan from `docs/exec-plans/completed/` or `docs/exec-plans/active/`.
+
+## Browser Workflow
+
+Always drive the browser for UI behavior. Prefer Chrome DevTools MCP when available; Playwright MCP is acceptable when it is the active browser tool.
+
+1. Resolve the app URL from README, `package.json`, package docs, or `docs/user-docs/_config.yml`. Pipeline frontend is typically `http://localhost:3000`.
+2. Start or reuse the dev server when needed.
+3. Navigate to target routes.
+4. Interact like a user: click, fill, hover, submit, navigate, resize.
+5. Use accessibility snapshots for structure and screenshots for visual evidence.
+6. Inspect console and network messages when diagnosing failures.
+
+## Update Cases
+
+1. Read recent closed Issues:
+
+   ```bash
+   gh issue list --state closed --limit 50 --json number,title,labels,closedAt
+   ```
+
+2. Inspect completed plans for shipped user-facing behavior.
+3. Add missing story coverage to `docs/STORIES.md`.
+4. Include traceability: Issue number, Issue URL, and completed plan path.
+5. Keep cases concrete: actor, setup, steps, expected result.
+
+Do not add speculative coverage for backlog or incomplete work unless explicitly asked.
+
+## Issue-Scoped Testing
+
+1. Resolve scope from Issue comments, labels, plan, and related stories.
+2. Build a focused checklist.
+3. Exercise each flow in the browser.
+4. Record pass, fail, and blocked results.
+5. File new defects as GitHub Issues.
+6. Update `docs/QUALITY_SCORE.md`.
+
+## Regression Testing
+
+1. Read all testable stories from `docs/STORIES.md`.
+2. Group by auth/access, shell/navigation, and feature flows.
+3. Exercise meaningful acceptance checks, not just route loads.
+4. File new defects and update `docs/QUALITY_SCORE.md`.
+
+## Bug Logging
+
+File defects as new Issues. Include the right flow label so the manager can pick them up. For frontend UX bugs, use `bug,frontend,backlog` by default; add `trivial` only for clearly mechanical fixes.
+
+```bash
+gh issue create --title "<short imperative>" --label "bug,frontend,backlog" --body "<body>"
+```
+
+Issue body should include:
+
+```markdown
+**Linked issue:** #<parent-number>
+**Source story:** <story id, if any>
+**Plan:** <docs/exec-plans/... path, if any>
+
+**Severity:** critical | high | medium | low
+
+**Reproduction steps**
+1. ...
+
+**Expected result**
+...
+
+**Actual result**
+...
+
+**Environment**
+- App URL:
+- Browser:
+- Date:
+```
+
+Comment on the parent Issue with the new bug number.
+
+Severity:
+
+- `critical`: blocks shipping, security/data loss, or spec contract violation.
+- `high`: primary UX or content is materially wrong.
+- `medium`: minor UX, copy, styling, or edge case.
+- `low`: polish.
+
+## Quality Score
+
+After meaningful issue or regression testing, update `docs/QUALITY_SCORE.md` with:
+
+- date
+- scope
+- story coverage
+- pass/fail/blocked summary
+- bugs filed or confirmed
+- score and short reasoning
+
+Score conservatively when evidence is incomplete.
+
+## Output
+
+Report:
+
+- scope tested
+- cases executed
+- passes, failures, blocked items
+- bug Issues filed with severity
+- quality score updates
+- setup notes or blockers

--- a/.codex/skills/ux-tester/agents/openai.yaml
+++ b/.codex/skills/ux-tester/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "UX Tester"
+  short_description: "Run manual UX QA for Pipeline"
+  default_prompt: "Use $ux-tester to test issue:123 in the browser and update quality docs."


### PR DESCRIPTION
## Summary
- add repo-local Codex skills for issue, planner, coder, manager, ux-tester, and ux-reviewer
- include generated agents/openai.yaml metadata for each skill
- adapt Claude workflow instructions to Codex-native skill paths and delegation language

## Validation
- python3 /Users/dima/.codex/skills/.system/skill-creator/scripts/quick_validate.py for each .codex/skills/* folder