### PR TITLE
fix(frontend): console.error tx failures so debug info is visible

### DIFF
--- a/packages/frontend/src/routes/deposit.tsx
+++ b/packages/frontend/src/routes/deposit.tsx
@@ -281,6 +281,7 @@ function Deposit() {
       requestDeposit.error &&
       requestDeposit.error !== prevDepositError.current
     ) {
+      console.error("Deposit failed:", requestDeposit.error);
       toast.update("deposit-tx", {
         tone: "danger",
         title: "Deposit failed",
@@ -310,6 +311,7 @@ function Deposit() {
       toast.update("claim-tx", { tone: "success", title: "PLUSD claimed" });
     }
     if (claim.error && claim.error !== prevClaimError.current) {
+      console.error("Claim failed:", claim.error);
       toast.update("claim-tx", { tone: "danger", title: "Claim failed" });
     }
     prevClaimIsPending.current = claim.isPending;

--- a/packages/frontend/src/routes/withdraw.tsx
+++ b/packages/frontend/src/routes/withdraw.tsx
@@ -269,6 +269,7 @@ function Withdraw() {
       requestWithdrawal.error &&
       requestWithdrawal.error !== prevWithdrawalError.current
     ) {
+      console.error("Withdrawal failed:", requestWithdrawal.error);
       toast.update("withdraw-tx", {
         tone: "danger",
         title: "Withdrawal failed",
@@ -305,6 +306,7 @@ function Withdraw() {
       });
     }
     if (claim.error && claim.error !== prevClaimError.current) {
+      console.error("Withdrawal claim failed:", claim.error);
       toast.update("withdraw-claim-tx", {
         tone: "danger",
         title: "Claim failed",


### PR DESCRIPTION
## Summary
- The `/deposit` and `/withdraw` flows only surfaced a generic "Claim failed" / "Deposit failed" / "Withdrawal failed" toast on error, with no way to see the underlying cause.
- Add `console.error` next to each danger-toast emit (deposit request, deposit claim, withdrawal request, withdrawal claim) so the full error — including viem revert reason and stack — lands in DevTools.
- Toast titles are unchanged.

## Test plan
- [ ] Trigger a failing claim on `/deposit` (e.g. revert it) and confirm the error appears in the browser console.
- [ ] Same for failing deposit, withdrawal, and withdrawal claim.
- [ ] Confirm the toast title is still the short label.