### PR TITLE
fix(#347): rename claim → claimDeposit and decode contract errors

### DIFF
--- a/packages/frontend/src/wallet/abis/depositManager.ts
+++ b/packages/frontend/src/wallet/abis/depositManager.ts
@@ -1,9 +1,12 @@
 /**
  * Minimal DepositManager ABI subset used by the LP UI wallet hooks.
  *
- * Only the five functions consumed by the LP UI are listed here — the full
- * ABI lives in `docs.local/manager_abi.txt`. Typed `as const` so viem picks
- * up exact return types for each function.
+ * Only the functions consumed by the LP UI are listed here — the full ABI
+ * lives in `docs.local/manager_abi.txt`. Custom-error entries from the full
+ * ABI are included so viem can decode reverts into named errors (e.g.
+ * `VerifiedRequestsInvalidSignature()`) instead of "execution reverted".
+ *
+ * Typed `as const` so viem picks up exact return types for each function.
  */
 export const depositManagerAbi = [
   {
@@ -36,7 +39,7 @@ export const depositManagerAbi = [
   },
   {
     type: "function",
-    name: "claim",
+    name: "claimDeposit",
     stateMutability: "nonpayable",
     inputs: [
       { name: "requestId", type: "uint256" },
@@ -44,4 +47,36 @@ export const depositManagerAbi = [
     ],
     outputs: [{ name: "amount", type: "uint256" }],
   },
+
+  // ── Custom errors (decoder hints) ──────────────────────────────────────────
+  { type: "error", name: "AccessManagedInvalidAuthority", inputs: [{ name: "authority", type: "address" }] },
+  { type: "error", name: "AccessManagedRequiredDelay", inputs: [{ name: "caller", type: "address" }, { name: "delay", type: "uint32" }] },
+  { type: "error", name: "AccessManagedUnauthorized", inputs: [{ name: "caller", type: "address" }] },
+  { type: "error", name: "AddressEmptyCode", inputs: [{ name: "target", type: "address" }] },
+  { type: "error", name: "DepositManagerLessThanMinAmount", inputs: [] },
+  { type: "error", name: "DepositManagerSameValue", inputs: [] },
+  { type: "error", name: "DepositManagerZeroAddress", inputs: [] },
+  { type: "error", name: "ECDSAInvalidSignature", inputs: [] },
+  { type: "error", name: "ECDSAInvalidSignatureLength", inputs: [{ name: "length", type: "uint256" }] },
+  { type: "error", name: "ECDSAInvalidSignatureS", inputs: [{ name: "s", type: "bytes32" }] },
+  { type: "error", name: "ERC1967InvalidImplementation", inputs: [{ name: "implementation", type: "address" }] },
+  { type: "error", name: "ERC1967NonPayable", inputs: [] },
+  { type: "error", name: "EnforcedPause", inputs: [] },
+  { type: "error", name: "ExpectedPause", inputs: [] },
+  { type: "error", name: "FailedCall", inputs: [] },
+  { type: "error", name: "InvalidInitialization", inputs: [] },
+  { type: "error", name: "NotInitializing", inputs: [] },
+  { type: "error", name: "RateLimiterExceedsTxLimit", inputs: [] },
+  { type: "error", name: "RateLimiterExceedsWindowLimit", inputs: [] },
+  { type: "error", name: "RateLimiterWrongValue", inputs: [] },
+  { type: "error", name: "SafeERC20FailedOperation", inputs: [{ name: "token", type: "address" }] },
+  { type: "error", name: "UUPSUnauthorizedCallContext", inputs: [] },
+  { type: "error", name: "UUPSUnsupportedProxiableUUID", inputs: [{ name: "slot", type: "bytes32" }] },
+  { type: "error", name: "VerifiedRequestsInvalidRequestId", inputs: [] },
+  { type: "error", name: "VerifiedRequestsInvalidSender", inputs: [] },
+  { type: "error", name: "VerifiedRequestsInvalidSignature", inputs: [] },
+  { type: "error", name: "VerifiedRequestsQueueAlreadyClaimed", inputs: [] },
+  { type: "error", name: "VerifiedRequestsQueueZeroAmount", inputs: [] },
+  { type: "error", name: "VerifiedRequestsSameValue", inputs: [] },
+  { type: "error", name: "VerifiedRequestsZeroAddress", inputs: [] },
 ] as const;

--- a/packages/frontend/src/wallet/useDepositManager.test.tsx
+++ b/packages/frontend/src/wallet/useDepositManager.test.tsx
@@ -524,7 +524,7 @@ describe("useClaim — args pass-through (no mock, non-zero address)", () => {
 
     expect(mockWriteContract).toHaveBeenCalledWith(
       expect.objectContaining({
-        functionName: "claim",
+        functionName: "claimDeposit",
         address: dmAddr,
         args: [99n, "0xdeadbeef"],
         gas: 1_200_000n, // 1_000_000n * 12 / 10

--- a/packages/frontend/src/wallet/useDepositManager.ts
+++ b/packages/frontend/src/wallet/useDepositManager.ts
@@ -498,7 +498,7 @@ export function useClaim(): ClaimResult {
           account: address,
           abi: depositManagerAbi,
           address: DM_ADDRESS,
-          functionName: "claim",
+          functionName: "claimDeposit",
           args: [requestId, verifierSignature],
         });
         setIsEstimating(false);
@@ -511,7 +511,7 @@ export function useClaim(): ClaimResult {
         wagmiWrite.writeContract({
           abi: depositManagerAbi,
           address: DM_ADDRESS,
-          functionName: "claim",
+          functionName: "claimDeposit",
           args: [requestId, verifierSignature],
           gas: result.gas,
         });


### PR DESCRIPTION
Closes #347.

## Summary
- The DepositManager contract renamed `claim(uint256, bytes)` → `claimDeposit(uint256, bytes)`. The frontend kept calling `claim`, hitting the contract's reverting fallback (no revert data), which is what produced the opaque "Execution reverted for an unknown reason" we were chasing in #347.
- Rename `claim` → `claimDeposit` in `depositManagerAbi` and the three call sites in `useClaim` (simulate / estimate / write).
- Add all 30 custom-error entries from `docs.local/manager_abi.txt` to the ABI subset so viem decodes future reverts into named errors (`VerifiedRequestsInvalidSignature`, `VerifiedRequestsQueueAlreadyClaimed`, `RateLimiterExceedsTxLimit`, `EnforcedPause`, …) instead of "execution reverted".

## Test plan
- [x] `yarn tsc --noEmit` passes.
- [x] `yarn eslint` on changed files passes.
- [x] `yarn vitest run src/wallet/useDepositManager.test.tsx` — 26/26 pass (the test asserting `functionName` was updated).
- [ ] Manual: on `/deposit`, complete steps 1–2, click **Claim**. The wallet receives a real `claimDeposit(...)` selector and the tx either succeeds or — if it reverts — the toast/console show a named contract error rather than "execution reverted".

## Out of scope
- The premature "done" state on the Claim step (button flips on broadcast, not on receipt) — tracked separately in #348.