### PR TITLE
Wire APY Stat to live /v1/stats API, fallback to '—'

### DIFF
--- a/packages/frontend/src/api/README.md
+++ b/packages/frontend/src/api/README.md
@@ -12,6 +12,8 @@ import {
   useRequests,
   useDepositVoucher,
   useWithdrawalVoucher,
+  useStats,
+  formatApy,
 } from "@/api";
 
 import type {
@@ -26,6 +28,9 @@ import type {
   WithdrawalVoucherResponse,
   WithdrawalVoucherStatus,
   UseWithdrawalVoucherResult,
+  VaultStatsItem,
+  StatsResponse,
+  UseStatsResult,
 } from "@/api";
 ```
 
@@ -99,6 +104,30 @@ Reactive to `pipeline.mock.api.*` localStorage key changes.
 
 ---
 
+### `useStats()`
+
+React Query hook that fetches protocol vault statistics from `GET /v1/stats`.
+
+```ts
+const { data, isLoading, error } = useStats();
+// data?.vaults[0]?.apy — APY as a decimal fraction string, or null
+```
+
+Always enabled — no wallet connection required. Use `formatApy(apy)` to convert
+the raw fraction to a display string (e.g. `"0.0842"` → `"8.42%"`, null → `"—"`).
+
+### `formatApy(apy)`
+
+Formats an APY decimal fraction string as a percentage string.
+
+```ts
+formatApy("0.0842"); // → "8.42%"
+formatApy(null); // → "—"
+formatApy(undefined); // → "—"
+```
+
+---
+
 ## localStorage mock key schema
 
 The API module reuses the same mock infrastructure as the wallet module. The
@@ -109,6 +138,12 @@ this event and issues a refetch — no page reload needed.
 
 > **Note:** The event name `pipeline-mock:wallet` is a legacy misnomer. The
 > bridge covers all `pipeline.mock.*` keys, not just wallet ones.
+
+### `useStats` mock keys
+
+| Key                               | Type                     | Purpose                                           |
+| --------------------------------- | ------------------------ | ------------------------------------------------- |
+| `pipeline.mock.api.GET./v1/stats` | JSON `{ vaults: [...] }` | Bypasses the real fetch — `useStats` returns this |
 
 ### `useRequests` mock keys
 

--- a/packages/frontend/src/api/index.ts
+++ b/packages/frontend/src/api/index.ts
@@ -29,3 +29,5 @@ export type {
   WithdrawalVoucherStatus,
   UseWithdrawalVoucherResult,
 } from "./useWithdrawalVoucher";
+export { useStats, formatApy } from "./useStats";
+export type { VaultStatsItem, StatsResponse, UseStatsResult } from "./useStats";

--- a/packages/frontend/src/api/useStats.test.tsx
+++ b/packages/frontend/src/api/useStats.test.tsx
@@ -1,0 +1,234 @@
+/**
+ * Tests for `src/api/useStats.ts`.
+ *
+ * Covers:
+ *   - `formatApy` helper: fraction → percentage string, null/undefined → "—".
+ *   - Mock-key path returns fixture data immediately without calling fetch.
+ *   - With no mock key, the hook calls apiFetch with `/v1/stats`.
+ *   - When APY is null in the response, `formatApy` returns "—".
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import React from "react";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useStats, formatApy } from "./useStats";
+import type { StatsResponse } from "./useStats";
+
+// ── Mock wagmi / AppKit ───────────────────────────────────────────────────────
+
+vi.mock("wagmi", async (importOriginal) => {
+  const original = await importOriginal<typeof import("wagmi")>();
+  return {
+    ...original,
+    WagmiProvider: ({ children }: { children: React.ReactNode }) => (
+      <>{children}</>
+    ),
+    useAccount: vi.fn(() => ({ address: undefined, isConnected: false })),
+    useChainId: vi.fn(() => 560048),
+    useDisconnect: vi.fn(() => ({ disconnect: vi.fn() })),
+    useReadContract: vi.fn(() => ({
+      data: undefined,
+      isLoading: false,
+      error: null,
+    })),
+    useWriteContract: vi.fn(() => ({
+      writeContract: vi.fn(),
+      data: undefined,
+      isPending: false,
+      isSuccess: false,
+      error: null,
+      reset: vi.fn(),
+    })),
+  };
+});
+
+vi.mock("@reown/appkit/react", () => ({
+  createAppKit: vi.fn(),
+  useAppKit: vi.fn(() => ({ open: vi.fn() })),
+}));
+
+vi.mock("@/wallet/config", () => ({
+  wagmiConfig: {},
+  wagmiAdapter: {},
+}));
+
+// ── Mock ENV ──────────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/env", () => ({
+  ENV: {
+    API_BASE_URL: "http://localhost:8080",
+    EVM_CHAIN_ID: 560048,
+    EVM_RPC_URL: "https://ethereum-hoodi-rpc.publicnode.com",
+    DEPOSIT_MANAGER_ADDRESS: "0x0000000000000000000000000000000000000000",
+    WALLETCONNECT_PROJECT_ID: "replace-me",
+  },
+}));
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const FIXTURE_WITH_APY: StatsResponse = {
+  vaults: [
+    {
+      vault_address: "0xabcdef0000000000000000000000000000000001",
+      share_price: "1.05",
+      apy: "0.0842",
+    },
+  ],
+};
+
+const FIXTURE_NULL_APY: StatsResponse = {
+  vaults: [
+    {
+      vault_address: "0xabcdef0000000000000000000000000000000001",
+      share_price: "1.05",
+      apy: null,
+    },
+  ],
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const fetchMock = vi.fn<typeof fetch>();
+vi.stubGlobal("fetch", fetchMock);
+const fetchSpy = fetchMock;
+
+/** Create a fresh QueryClient per test to avoid cache bleeding. */
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  function wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  }
+  return wrapper;
+}
+
+// ── formatApy unit tests ──────────────────────────────────────────────────────
+
+describe("formatApy", () => {
+  it("formats a decimal fraction as a percentage string", () => {
+    expect(formatApy("0.0842")).toBe("8.42%");
+  });
+
+  it("formats zero correctly", () => {
+    expect(formatApy("0")).toBe("0.00%");
+  });
+
+  it("handles fractional percentages", () => {
+    expect(formatApy("0.0725")).toBe("7.25%");
+  });
+
+  it("returns em-dash for null", () => {
+    expect(formatApy(null)).toBe("—");
+  });
+
+  it("returns em-dash for undefined", () => {
+    expect(formatApy(undefined)).toBe("—");
+  });
+
+  it("returns em-dash for non-numeric string", () => {
+    expect(formatApy("not-a-number")).toBe("—");
+  });
+});
+
+// ── useStats hook tests ───────────────────────────────────────────────────────
+
+describe("useStats — mock-key path", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    fetchSpy.mockClear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  it("returns fixture data immediately from mock key, never calls fetch", async () => {
+    localStorage.setItem(
+      "pipeline.mock.api.GET./v1/stats",
+      JSON.stringify(FIXTURE_WITH_APY),
+    );
+
+    const { result } = renderHook(() => useStats(), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(FIXTURE_WITH_APY);
+    });
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns null APY from mock key", async () => {
+    localStorage.setItem(
+      "pipeline.mock.api.GET./v1/stats",
+      JSON.stringify(FIXTURE_NULL_APY),
+    );
+
+    const { result } = renderHook(() => useStats(), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(FIXTURE_NULL_APY);
+    });
+
+    // formatApy of null should be "—"
+    expect(formatApy(result.current.data?.vaults[0]?.apy)).toBe("—");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("useStats — real fetch path", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    fetchSpy.mockClear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  it("calls fetch with /v1/stats when no mock key is set", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify(FIXTURE_WITH_APY), { status: 200 }),
+    );
+
+    const { result } = renderHook(() => useStats(), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(FIXTURE_WITH_APY);
+    });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.stringContaining("/v1/stats"),
+      undefined,
+    );
+  });
+
+  it("sets error when fetch fails", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: "server error" }), {
+        status: 500,
+        statusText: "Internal Server Error",
+      }),
+    );
+
+    const { result } = renderHook(() => useStats(), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.error).not.toBeNull();
+    });
+
+    expect(result.current.data).toBeUndefined();
+  });
+});

--- a/packages/frontend/src/api/useStats.ts
+++ b/packages/frontend/src/api/useStats.ts
@@ -1,0 +1,85 @@
+/**
+ * React Query hook — fetches protocol vault statistics from the Pipeline API
+ * (`GET /v1/stats`).
+ *
+ * The hook is always enabled (no wallet connection required — these are
+ * protocol-level stats visible to everyone).
+ *
+ * Mock layer
+ * ----------
+ * Before issuing a real network request, `apiFetch` checks:
+ *
+ *   `pipeline.mock.api.GET./v1/stats`
+ *
+ * When the key is present its value is parsed as JSON and returned immediately.
+ *
+ * See `src/api/README.md` for the full mock-key schema and DevTools snippets.
+ */
+import { useQuery } from "@tanstack/react-query";
+import { apiFetch } from "./client";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface VaultStatsItem {
+  vault_address: string;
+  /** Current share price (assets per 1 share). */
+  share_price: string;
+  /**
+   * APY as a decimal fraction string (e.g. "0.0725" = 7.25%).
+   * Absent or null when there is insufficient price history.
+   */
+  apy?: string | null;
+}
+
+export interface StatsResponse {
+  vaults: VaultStatsItem[];
+}
+
+export interface UseStatsResult {
+  data: StatsResponse | undefined;
+  isLoading: boolean;
+  error: Error | null;
+  refetch: () => void;
+}
+
+// ── Hook ──────────────────────────────────────────────────────────────────────
+
+/**
+ * Returns protocol vault statistics including the current APY.
+ *
+ * - Always enabled — no wallet connection required.
+ * - Reactive to `pipeline.mock.api.*` localStorage key changes (DevTools mock
+ *   bridge).
+ *
+ * To read the APY for display, use `formatApy(data?.vaults[0]?.apy)`.
+ */
+export function useStats(): UseStatsResult {
+  const query = useQuery<StatsResponse, Error>({
+    queryKey: ["stats"],
+    queryFn: () => apiFetch<StatsResponse>("/v1/stats"),
+  });
+
+  return {
+    data: query.data,
+    isLoading: query.isLoading,
+    error: query.error,
+    refetch: () => void query.refetch(),
+  };
+}
+
+// ── Formatting helper ─────────────────────────────────────────────────────────
+
+/**
+ * Formats an APY decimal fraction string as a percentage string.
+ *
+ * - `"0.0842"` → `"8.42%"`
+ * - `null | undefined` → `"—"` (em-dash fallback for missing data)
+ *
+ * @param apy  APY as a decimal fraction string (e.g. "0.0842"), or null/undefined.
+ */
+export function formatApy(apy: string | null | undefined): string {
+  if (apy == null) return "—";
+  const num = parseFloat(apy);
+  if (!Number.isFinite(num)) return "—";
+  return `${(num * 100).toFixed(2)}%`;
+}

--- a/packages/frontend/src/components/StakeCard.tsx
+++ b/packages/frontend/src/components/StakeCard.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Button, Card } from "@pipeline/ui";
+import { useStats, formatApy } from "@/api";
 
 /**
  * StakeCard — Stake PLUSD entry-point card.
@@ -10,7 +11,7 @@ import { Button, Card } from "@pipeline/ui";
  *
  *   ┌───────────────────────────────────────┐
  *   │  Stake PLUSD                          │
- *   │  Earn 8.42%                           │
+ *   │  Earn X.XX%                           │
  *   │  From loan coupons and T-bills        │
  *   │                                       │
  *   │                              ╭─────╮  │
@@ -38,7 +39,7 @@ import { Button, Card } from "@pipeline/ui";
  *   - The top-line label ("Stake PLUSD") uses the Body token (16/22) in
  *     Graphik LC at primary ink — same treatment as the "Start here" /
  *     "Earned" labels on the sibling cards.
- *   - The main line ("Earn 8.42%") uses the Heading 20 token (20/28) in the
+ *   - The main line ("Earn X.XX%") uses the Heading 20 token (20/28) in the
  *     Besley display family at primary ink, matching "Get PLUSD" / "Coming
  *     soon" headings on the sibling cards.
  *   - The subtitle ("From loan coupons and T-bills") uses the Caption token
@@ -47,8 +48,8 @@ import { Button, Card } from "@pipeline/ui";
  *   token in `@pipeline/ui/styles/theme.css`.
  *
  * Content:
- *   - The 8.42% APY figure is intentionally hardcoded in this issue (per the
- *     Issue body); a future task will wire it to live protocol state.
+ *   - The APY figure is sourced from `useStats` (`GET /v1/stats`). Falls back
+ *     to `—` when the API returns null or the request fails.
  *
  * Accessibility:
  *   - The Card is promoted to a labelled region via `role="region"` +
@@ -88,6 +89,9 @@ const HEADING_ID = "stake-card-title";
 
 export const StakeCard = React.forwardRef<HTMLDivElement, StakeCardProps>(
   function StakeCard({ onStake, stakeDisabled, className, ...rest }, ref) {
+    const { data: statsData } = useStats();
+    const apyLabel = `Earn ${formatApy(statsData?.vaults[0]?.apy)}`;
+
     const composed = [
       // Text block top, circular CTA bottom-right — mirrors the Figma
       // "card-horizontal" stack with `justify-between` + `items-end`.
@@ -134,7 +138,7 @@ export const StakeCard = React.forwardRef<HTMLDivElement, StakeCardProps>(
           >
             Stake PLUSD
           </p>
-          {/* Main line — "Earn 8.42%". Heading 20 in Besley display. */}
+          {/* Main line — "Earn X.XX%". Heading 20 in Besley display. */}
           <p
             className={[
               "font-[family-name:var(--font-display)]",
@@ -146,7 +150,7 @@ export const StakeCard = React.forwardRef<HTMLDivElement, StakeCardProps>(
             ].join(" ")}
             data-node-id="1497:94709"
           >
-            Earn 8.42%
+            {apyLabel}
           </p>
           {/* Subtitle — "From loan coupons and T-bills". Caption in Graphik
               LC, muted ink. */}

--- a/packages/frontend/src/components/WelcomeHeader.tsx
+++ b/packages/frontend/src/components/WelcomeHeader.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Stat } from "@pipeline/ui";
 import { useStakedPlusdConvertToAssets } from "@/wallet/useStakedPlusd";
+import { useStats, formatApy } from "@/api";
 
 /**
  * WelcomeHeader — Dashboard top heading with stats strip.
@@ -10,8 +11,9 @@ import { useStakedPlusdConvertToAssets } from "@/wallet/useStakedPlusd";
  *   - Right: stats strip with three Stat readouts separated by hairline
  *     left-borders, plus a trailing external-link icon button.
  *
- * The exchange rate stat is live — sourced from `useStakedPlusdConvertToAssets`.
- * TVL and APY remain hardcoded (separate issues).
+ * The exchange rate and APY stats are live — sourced from
+ * `useStakedPlusdConvertToAssets` and `useStats` respectively.
+ * TVL remains hardcoded (separate issue).
  * All visual values come from design tokens in `@pipeline/ui/styles/theme.css`.
  */
 
@@ -90,6 +92,9 @@ export function WelcomeHeader({ className, ...rest }: WelcomeHeaderProps) {
       ? `1 sPLUSD = ${(Number(rateRaw) / 1e18).toFixed(4)} PLUSD`
       : "—";
 
+  const { data: statsData } = useStats();
+  const apyValue = formatApy(statsData?.vaults[0]?.apy);
+
   return (
     <div className={composed} {...rest}>
       {/* Left: display heading */}
@@ -107,7 +112,7 @@ export function WelcomeHeader({ className, ...rest }: WelcomeHeaderProps) {
 
         {/* Current APY */}
         <div className={separatedCellClasses}>
-          <Stat label="Current APY" value="8.42%" />
+          <Stat label="Current APY" value={apyValue} />
         </div>
 
         {/* External-link icon button */}

--- a/packages/frontend/src/routes/-index.test.tsx
+++ b/packages/frontend/src/routes/-index.test.tsx
@@ -126,6 +126,8 @@ vi.mock("@/lib/env", () => ({
 
 vi.mock("@/api", () => ({
   useRequests: () => ({ data: undefined, isLoading: false, error: null }),
+  useStats: () => ({ data: undefined, isLoading: false, error: null }),
+  formatApy: () => "—",
 }));
 
 // ── Helpers ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #417