### PR TITLE
docs: agent-agnostic issue protocol (decentralized agent system)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ Before doing anything, orient yourself:
 Planning & tracking:
 
 - [GitHub Issues](https://github.com/eq-lab/pipeline/issues) — team backlog and task board (use `/issue` skill to manage)
+- [`docs/ISSUE_PROTOCOL.md`](./docs/ISSUE_PROTOCOL.md) — agent-agnostic issue/label contract (draft, not yet in force)
 - [`docs/exec-plans/active/`](./docs/exec-plans/active/) — in-flight work with progress and decision logs
 - [`docs/exec-plans/completed/`](./docs/exec-plans/completed/) — archived execution plans
 - [`docs/exec-plans/known-bugs.md`](./docs/exec-plans/known-bugs.md) — bugs found during development, not yet fixed

--- a/docs/ISSUE_PROTOCOL.md
+++ b/docs/ISSUE_PROTOCOL.md
@@ -27,6 +27,7 @@ All dev work is grouped under an epic. An epic describes one business feature.
 
 - **Body must contain:** what needs to happen, why, affected areas. The issue must be a sub-issue of an epic.
 - Modifier `trivial` marks work that needs no planning — the implementing agent may go straight to code.
+- Non-trivial work may use the optional planning statuses (§3): the plan is posted as a comment or linked doc while `planning`, then the issue sits in `planned` until approval. **Approval is recorded as an issue comment** (by a human, or by whoever the agent's own rules designate) before implementation starts.
 - **Done when:** code, tests, and lint are green; a **user-stories doc** for the change exists (see §6); the PR is merged; and a comment linking the user-stories doc is posted on the epic's `qa` issue (see §5.3).
 
 ### `bug` — defect
@@ -69,11 +70,15 @@ One `qa` issue per epic, created together with the epic as its sub-issue. Manual
 | Label | Meaning |
 |---|---|
 | `backlog` | Ready to pick up, unclaimed |
+| `planning` | *Optional* — a plan is being produced (assignee must be set) |
+| `planned` | *Optional* — plan posted, awaiting approval and/or an implementer |
 | `in-progress` | Claimed and being worked (assignee must be set) |
 | `review` | PR open, awaiting human review/merge |
 | `blocked` | Cannot proceed — explain the blocker in a comment |
 
 Closed = done. There is no `completed` label. Every new issue enters as `backlog` or `blocked`.
+
+The planning pair is optional: work that needs no reviewed plan (e.g. `trivial`) goes straight `backlog` → `in-progress`. When used, the plan lives in a comment or a linked doc, and the approval that releases `planned` → `in-progress` is recorded as a comment on the issue. A `planned` issue may stay assigned (the planner implements it) or be unassigned for another agent to claim.
 
 ### Modifier labels (optional, combine freely)
 
@@ -86,11 +91,12 @@ Closed = done. There is no `completed` label. Every new issue enters as `backlog
 ## 4. Status transitions
 
 ```text
-            ┌──────────► blocked ◄──────────┐
-            │               │                │
-backlog ────┴──► in-progress ──► review ──► closed
-   ▲                │
-   └────────────────┘  (work abandoned: unassign + back to backlog)
+backlog ──► planning ──► planned ──► in-progress ──► review ──► closed
+   │            (optional pair)           ▲    │
+   ├──────────────────────────────────────┘    │ (work abandoned:
+   ◄───────────────────────────────────────────┘  unassign + back to backlog)
+
+blocked ◄──► any open state (explain the blocker in a comment)
 ```
 
 A status change is always a remove-then-add pair so exactly one status label is set:
@@ -191,6 +197,8 @@ gh label create bug            --color d73a4a --description "Something isn't wor
 gh label create docs           --color 0075ca --description "Documentation-only change" --force
 gh label create qa             --color D4C5F9 --description "Testing pass for an epic" --force
 gh label create backlog        --color C5DEF5 --description "Ready to pick up, unclaimed" --force
+gh label create planning       --color C5DEF5 --description "Optional — plan being produced" --force
+gh label create planned        --color BFD4F2 --description "Optional — plan posted, awaiting approval" --force
 gh label create in-progress    --color FBCA04 --description "Claimed and being worked" --force
 gh label create review         --color FEF2C0 --description "PR open, awaiting review" --force
 gh label create blocked        --color B60205 --description "Cannot proceed — see comments" --force
@@ -198,4 +206,4 @@ gh label create trivial        --color C2E0C6 --description "No planning step ne
 gh label create priority       --color FF6B6B --description "Pick before other backlog items" --force
 ```
 
-Labels retired by this protocol (delete after migration): `planning`, `planned`, `executing`, `executed`, `testing`, `tested`, `enhancement`, `documentation`.
+Labels retired by this protocol (delete after migration): `executing`, `executed`, `testing`, `tested`, `enhancement`, `documentation`.

--- a/docs/ISSUE_PROTOCOL.md
+++ b/docs/ISSUE_PROTOCOL.md
@@ -27,7 +27,7 @@ All dev work is grouped under an epic. An epic describes one business feature.
 
 - **Body must contain:** what needs to happen, why, affected areas. The issue must be a sub-issue of an epic.
 - Modifier `trivial` marks work that needs no planning — the implementing agent may go straight to code.
-- Non-trivial work may use the optional planning statuses (§3): the plan is posted as a comment or linked doc while `planning`, then the issue sits in `planned` until approval. **Approval is recorded as an issue comment** (by a human, or by whoever the agent's own rules designate) before implementation starts.
+- Non-trivial work may use the optional planning statuses (§3): the plan is posted as a comment or linked doc while `planning`, then the issue sits in `planned` until an implementer picks it up.
 - **Done when:** code, tests, and lint are green; a **user-stories doc** for the change exists (see §6); the PR is merged; and a comment linking the user-stories doc is posted on the epic's `qa` issue (see §5.3).
 
 ### `bug` — defect
@@ -71,14 +71,14 @@ One `qa` issue per epic, created together with the epic as its sub-issue. Manual
 |---|---|
 | `backlog` | Ready to pick up, unclaimed |
 | `planning` | *Optional* — a plan is being produced (assignee must be set) |
-| `planned` | *Optional* — plan posted, awaiting approval and/or an implementer |
+| `planned` | *Optional* — plan posted, awaiting an implementer |
 | `in-progress` | Claimed and being worked (assignee must be set) |
 | `review` | PR open, awaiting human review/merge |
 | `blocked` | Cannot proceed — explain the blocker in a comment |
 
 Closed = done. There is no `completed` label. Every new issue enters as `backlog` or `blocked`.
 
-The planning pair is optional: work that needs no reviewed plan (e.g. `trivial`) goes straight `backlog` → `in-progress`. When used, the plan lives in a comment or a linked doc, and the approval that releases `planned` → `in-progress` is recorded as a comment on the issue. A `planned` issue may stay assigned (the planner implements it) or be unassigned for another agent to claim.
+The planning pair is optional: work that needs no plan (e.g. `trivial`) goes straight `backlog` → `in-progress`. When used, the plan lives in a comment or a linked doc. A `planned` issue may stay assigned (the planner implements it) or be unassigned for another agent to claim. Whether a plan needs review before implementation is each agent's own flow's concern — out of protocol scope.
 
 ### Modifier labels (optional, combine freely)
 
@@ -198,7 +198,7 @@ gh label create docs           --color 0075ca --description "Documentation-only 
 gh label create qa             --color D4C5F9 --description "Testing pass for an epic" --force
 gh label create backlog        --color C5DEF5 --description "Ready to pick up, unclaimed" --force
 gh label create planning       --color C5DEF5 --description "Optional — plan being produced" --force
-gh label create planned        --color BFD4F2 --description "Optional — plan posted, awaiting approval" --force
+gh label create planned        --color BFD4F2 --description "Optional — plan posted, awaiting an implementer" --force
 gh label create in-progress    --color FBCA04 --description "Claimed and being worked" --force
 gh label create review         --color FEF2C0 --description "PR open, awaiting review" --force
 gh label create blocked        --color B60205 --description "Cannot proceed — see comments" --force

--- a/docs/ISSUE_PROTOCOL.md
+++ b/docs/ISSUE_PROTOCOL.md
@@ -1,0 +1,201 @@
+# Issue Protocol
+
+The agent-agnostic contract for working with GitHub Issues in this repository. Any agent — a coding agent, a QA agent, a personal assistant, a human — participates in the same task board by following this document. It defines only what is **observable to other agents**: issue types, labels, status transitions, grouping, and comment conventions. *How* an agent performs its work internally (planning, flows, tooling) is out of scope — each agent brings its own skills on top of this protocol.
+
+## 1. Principles
+
+1. **GitHub Issues are the shared state.** There is no other task tracker. An agent that needs to know "what is the status of X" reads the issue; an agent that changes the status of X edits the issue. No side channels.
+2. **This document is the contract.** Agents derive their own skills/prompts from it. When the protocol changes, this file changes first, via PR.
+3. **Labels carry the machine-readable state.** Type, status, and modifiers are labels with strict rules (below). Free text goes in bodies and comments.
+4. **Comments are the event log.** Decisions, scope changes, blockers, hand-offs, and results are posted as issue comments — never assumed from chat history.
+
+## 2. Issue types
+
+Every open issue carries **exactly one type label**: `epic`, `implementation`, `bug`, `docs`, or `qa`.
+
+### `epic` — business feature container
+
+All dev work is grouped under an epic. An epic describes one business feature.
+
+- **Body must contain:** what the feature is and why, link to the product spec (if one exists), scope boundaries (what is explicitly out).
+- **Structure:** all work issues (`implementation`, `bug`, `docs`, `qa`) are attached as **native GitHub sub-issues** of the epic. GitHub renders the progress automatically.
+- **A `qa` sub-issue is created together with the epic** (see `qa` below).
+- Epics carry no status label — their state is the aggregate of their sub-issues.
+- **Done when:** all sub-issues are closed and the final QA pass is green. The `qa` sub-issue closes last, then the epic.
+
+### `implementation` — code work
+
+- **Body must contain:** what needs to happen, why, affected areas. The issue must be a sub-issue of an epic.
+- Modifier `trivial` marks work that needs no planning — the implementing agent may go straight to code.
+- **Done when:** code, tests, and lint are green; a **user-stories doc** for the change exists (see §6); the PR is merged; and a comment linking the user-stories doc is posted on the epic's `qa` issue (see §5.3).
+
+### `bug` — defect
+
+- **Body must contain:** observed vs expected behavior, reproduction steps, location (page/module).
+- Bugs found while testing an epic are filed as sub-issues of that epic. Bugs with no related epic may stand alone.
+- **Done when:** fixed with a regression test and the PR is merged. If the fix changes user-visible behavior, update the relevant user-stories doc and notify the `qa` issue as in §5.3.
+
+### `docs` — documentation update
+
+- Docs-only change: specs, guides, user docs, generated docs.
+- **Done when:** the docs PR is merged and `npx tsx scripts/lint-docs.ts` passes.
+
+### `qa` — testing pass
+
+One `qa` issue per epic, created together with the epic as its sub-issue. Manual testing does **not** happen after each task — it happens when an agent picks up the `qa` issue.
+
+- **Body:** a checklist of user-stories docs to verify. Implementing agents append to it via comments (§5.3); the QA agent folds comments into the checklist when claiming.
+- **Lifecycle:**
+  1. Created `blocked` (nothing to test yet).
+  2. First merged `implementation`/`bug` sub-issue flips it to `backlog`.
+  3. A QA agent claims it (`in-progress`), executes every linked user-stories doc not yet verified, files found defects as `bug` sub-issues of the same epic, and posts a results comment (stories run, pass/fail per story, bugs filed).
+  4. If the epic still has open work issues → back to `blocked` (waiting for more work to test).
+  5. When all sibling sub-issues are closed and the latest pass is green → close the `qa` issue, then the epic.
+
+## 3. Labels
+
+### Type labels (exactly one per issue)
+
+| Label | Meaning |
+|---|---|
+| `epic` | Business feature container; parent of sub-issues |
+| `implementation` | Code work |
+| `bug` | Defect — observed vs expected + repro in body |
+| `docs` | Documentation-only change |
+| `qa` | Testing pass for an epic |
+
+### Status labels (exactly one per open non-epic issue)
+
+| Label | Meaning |
+|---|---|
+| `backlog` | Ready to pick up, unclaimed |
+| `in-progress` | Claimed and being worked (assignee must be set) |
+| `review` | PR open, awaiting human review/merge |
+| `blocked` | Cannot proceed — explain the blocker in a comment |
+
+Closed = done. There is no `completed` label. Every new issue enters as `backlog` or `blocked`.
+
+### Modifier labels (optional, combine freely)
+
+| Label | Meaning |
+|---|---|
+| `trivial` | Implementation needs no planning step |
+| `priority` | Pick before other backlog items |
+| `frontend` / `backend` | Routing hint — which kind of agent should pick it up |
+
+## 4. Status transitions
+
+```text
+            ┌──────────► blocked ◄──────────┐
+            │               │                │
+backlog ────┴──► in-progress ──► review ──► closed
+   ▲                │
+   └────────────────┘  (work abandoned: unassign + back to backlog)
+```
+
+A status change is always a remove-then-add pair so exactly one status label is set:
+
+```bash
+gh issue edit <number> --remove-label backlog --add-label in-progress
+```
+
+Whoever moves an issue to `blocked` must say why in a comment. Whoever clears the blocker moves it back to `backlog` (or `in-progress` if still assigned).
+
+## 5. Coordination rules
+
+### 5.1 Claiming
+
+1. Read the issue **and its comments** first — they may contain decisions made since creation.
+2. If the issue is assigned to someone else, do not touch it. No exceptions without the assignee's (or a human's) explicit hand-off in a comment.
+3. Claim atomically: self-assign and flip the status in one step.
+
+```bash
+gh issue edit <number> --add-assignee @me --remove-label backlog --add-label in-progress
+```
+
+4. If you stop working on a claimed issue without finishing, unassign yourself, return it to `backlog` (or `blocked` with a reason), and post a comment describing the state you left it in.
+
+### 5.2 Communication
+
+- The issue **body** is the source of truth for *what*; **comments** are the log of *what changed since*. Significant scope changes get folded back into the body with a comment noting the edit.
+- Every decision that another agent might depend on goes in a comment — model choices, deferred work, discovered constraints.
+
+### 5.3 QA hand-off
+
+When an `implementation` or `bug` PR merges, the implementing agent must:
+
+1. Comment on the epic's `qa` issue with a link to the user-stories doc covering the change (path, see §6).
+2. If the `qa` issue is `blocked`, flip it to `backlog`.
+
+This is the only signal QA agents watch — work that skips it is invisible to testing.
+
+### 5.4 Discovering work
+
+```bash
+# what is testable right now
+gh issue list --state open --label qa,backlog
+
+# unclaimed implementation work, priority first
+gh issue list --state open --label implementation,backlog --json number,title,labels
+
+# everything in flight
+gh issue list --state open --label in-progress --json number,title,assignees
+```
+
+## 6. Artifacts
+
+- **User-stories docs** live at `docs/user-stories/epic-<epic-number>/<issue-number>-<slug>.md` and are committed in the same PR as the implementation. Each doc lists story-based test cases: persona, steps, expected outcome — concrete enough for an agent to execute against the running app.
+- Each new doc is linked from `docs/user-stories/index.md` (reachability requirement of `lint-docs`).
+- Stable stories may be promoted into the permanent regression suite by the QA agent after a green pass.
+
+## 7. Command reference
+
+Operations with `gh` CLI and REST equivalents (for agents without `gh`). Replace `{repo}` with `eq-lab/pipeline`.
+
+| Operation | gh CLI | REST |
+|---|---|---|
+| Create issue | `gh issue create --title T --label "implementation,backlog" --body B` | `POST /repos/{repo}/issues` `{title, body, labels}` |
+| Edit labels | `gh issue edit N --remove-label A --add-label B` | `DELETE /repos/{repo}/issues/N/labels/A` + `POST /repos/{repo}/issues/N/labels` `{labels:[B]}` |
+| Assign | `gh issue edit N --add-assignee @me` | `POST /repos/{repo}/issues/N/assignees` `{assignees:[user]}` |
+| Comment | `gh issue comment N --body B` | `POST /repos/{repo}/issues/N/comments` `{body}` |
+| Close | `gh issue close N` | `PATCH /repos/{repo}/issues/N` `{state:"closed"}` |
+| View + comments | `gh issue view N -c` | `GET /repos/{repo}/issues/N` + `GET /repos/{repo}/issues/N/comments` |
+
+### Sub-issues (epic grouping)
+
+The sub-issue API takes the child's **database ID**, not its number:
+
+```bash
+# attach issue <child> to epic <epic>
+CHILD_ID=$(gh api repos/eq-lab/pipeline/issues/<child> --jq .id)
+gh api repos/eq-lab/pipeline/issues/<epic>/sub_issues -F sub_issue_id="$CHILD_ID"
+
+# list an epic's sub-issues
+gh api repos/eq-lab/pipeline/issues/<epic>/sub_issues --jq '.[] | "\(.number) \(.title) [\(.state)]"'
+
+# find an epic's qa sub-issue
+gh api repos/eq-lab/pipeline/issues/<epic>/sub_issues \
+  --jq '.[] | select(.labels[].name == "qa") | .number'
+```
+
+REST: `POST /repos/{repo}/issues/{epic}/sub_issues` `{sub_issue_id}`, `GET /repos/{repo}/issues/{epic}/sub_issues`.
+
+## Appendix: label provisioning
+
+One-time setup for a repo adopting this protocol:
+
+```bash
+gh label create epic           --color a66c36 --description "Business feature container" --force
+gh label create implementation --color 0E8A16 --description "Code work" --force
+gh label create bug            --color d73a4a --description "Something isn't working" --force
+gh label create docs           --color 0075ca --description "Documentation-only change" --force
+gh label create qa             --color D4C5F9 --description "Testing pass for an epic" --force
+gh label create backlog        --color C5DEF5 --description "Ready to pick up, unclaimed" --force
+gh label create in-progress    --color FBCA04 --description "Claimed and being worked" --force
+gh label create review         --color FEF2C0 --description "PR open, awaiting review" --force
+gh label create blocked        --color B60205 --description "Cannot proceed — see comments" --force
+gh label create trivial        --color C2E0C6 --description "No planning step needed" --force
+gh label create priority       --color FF6B6B --description "Pick before other backlog items" --force
+```
+
+Labels retired by this protocol (delete after migration): `planning`, `planned`, `executing`, `executed`, `testing`, `tested`, `enhancement`, `documentation`.


### PR DESCRIPTION
## What

Drafts `docs/ISSUE_PROTOCOL.md` — the agent-agnostic contract for working with GitHub Issues, replacing the manager-centric flow model with a decentralized, label-driven one. Any agent (coding agent, QA agent, personal assistant, human) participates by following this one document; agents derive their own skills from it.

## Key decisions encoded

- **Epic grouping** via native GitHub sub-issues; every work issue belongs to an epic (`epic` label)
- **Issue types** (exactly one per issue): `epic`, `implementation`, `bug`, `docs`, `qa`
- **Minimal status model**: `backlog` → `in-progress` → `review` → closed, plus `blocked`; claiming = self-assign + label flip in one step
- **No step-by-step lifecycle** (plan/execute/test labels retired) — flows are each agent's own concern, out of protocol scope
- **QA batched per epic**: one `qa` sub-issue per epic, created `blocked`, flipped to `backlog` by the first merged implementation; QA agent executes user-stories docs and files bugs as epic sub-issues
- **User-stories docs** per implementation issue at `docs/user-stories/epic-<N>/<issue>-<slug>.md`, committed with the implementation PR
- Dual command reference (gh CLI + REST) so agents without `gh` can comply

## Not in this PR (migration steps, follow-ups)

- Label provisioning / retiring old lifecycle labels (commands included in the doc's appendix)
- Rewriting `issue` / `manager` / `ux-tester` skills against the protocol
- `docs/user-stories/` index scaffold
- Regrouping open issues under epics

`AGENTS.md` gains one nav line marking the doc as draft, not yet in force. `lint-docs` passes with 0 errors.