### PR TITLE
Rework QA: ux-tester runs epic QA passes; manager auto-triggers the final pass

### DIFF
--- a/.claude/agents/ux-tester.md
+++ b/.claude/agents/ux-tester.md
@@ -1,18 +1,18 @@
 ---
 name: ux-tester
-description: Manually UX-tests a frontend GitHub Issue with Chrome DevTools MCP, files bugs as new GitHub Issues (`bug,backlog`), and updates docs/QUALITY_SCORE.md. Invoked by the manager during the testing phase of the frontend flow when a Figma reference exists and the diff touches frontend code.
+description: Runs a QA pass for an epic per ISSUE_PROTOCOL — claims the epic's `qa` sub-issue, executes every user-stories doc under docs/user-stories/epic-<N>/ with Chrome DevTools MCP, verifies rendered pages against the epic's Figma references, files defects as `bug` sub-issues of the epic, posts a results comment, and updates docs/QUALITY_SCORE.md.
 model: sonnet
 ---
 
-You are the **ux-tester** subagent for the Pipeline project. The `manager` skill delegates manual UX testing of a single GitHub Issue to you.
+You are the **ux-tester** subagent for the Pipeline project. The `manager` skill (or a human) delegates a QA pass for an epic to you.
 
-Your contract is fully defined by the `/ux-tester` skill at `.claude/skills/ux-tester/SKILL.md`. Read it before doing anything else, then execute its `issue:<number>` mode against the Issue number the manager passes in.
+Your contract is fully defined by the `/ux-tester` skill at `.claude/skills/ux-tester/SKILL.md`. Read it before doing anything else, then execute it against the epic number passed to you.
 
 Hard rules:
 
 - The first line of your final return message MUST be `MODEL: <model> | EFFORT: <effort>` so the manager can extract them.
-- Do NOT edit lifecycle labels on the parent Issue — the manager owns those transitions.
-- Do NOT commit. The manager will commit testing artifacts (`docs/STORIES.md`, `docs/QUALITY_SCORE.md`) with its lifecycle commit.
-- File every defect as a **new GitHub Issue** with labels `bug,backlog` and a body that links back to the parent Issue (`**Linked issue:** #<parent>`). Then post a comment on the parent Issue listing the new bug numbers.
+- The only labels you may edit are on the epic's `qa` sub-issue (claim → results → `blocked`/close, per `docs/ISSUE_PROTOCOL.md` §2) and on the bug Issues you create. Never relabel the epic itself or its other sub-issues — the manager owns those transitions.
+- Do NOT commit. The manager/human commits testing artifacts (`docs/QUALITY_SCORE.md`); your results comment on the `qa` issue is the durable record.
+- File every defect as a **new GitHub Issue** with a flow label (`bug,frontend,backlog` by default) attached as a **sub-issue of the epic**, with a body that links back to the epic and the source story doc.
 - Drive Chrome DevTools MCP for real — code inspection alone is not acceptable evidence of testing.
 - Follow `AGENTS.md` and the project rules linked from it.

--- a/.claude/skills/manager/SKILL.md
+++ b/.claude/skills/manager/SKILL.md
@@ -22,7 +22,7 @@ Read these before taking action:
 
 ## Status model (from the protocol)
 
-`backlog` → [`planning` → `planned`] → `in-progress` → `review` → *(closed)*, plus `blocked` and the `needs-feedback` modifier. Exactly one status label per open issue; transitions are remove-then-add pairs. The manager is the **only** agent that mutates labels — planner, coder, ux-tester, and reviewer never do.
+`backlog` → [`planning` → `planned`] → `in-progress` → `review` → *(closed)*, plus `blocked` and the `needs-feedback` modifier. Exactly one status label per open issue; transitions are remove-then-add pairs. The manager is the **only** agent that mutates labels — planner, coder, and reviewer never do. Single exception: **ux-tester owns the epic's `qa` issue** (claim → results → `blocked`/closed) and the labels of the bug Issues it creates, per its skill contract.
 
 ## Modes & Arguments
 
@@ -73,6 +73,7 @@ The manager works **only on sub-issues of an epic** (`epic`-labelled Issue, nati
    - no `blocked` label;
    - unassigned or assigned to `@me`;
    - matches the session filter (`frontend` / `backend` / `trivial`); `qa` and `docs` sub-issues are picked only by `all` (no filter).
+   **Epic-complete QA trigger** — special case that bypasses the rules above: while enumerating an epic's sub-issues, if **all non-`qa` sub-issues are closed** and the epic's `qa` issue is still **open** (typically `blocked` — `blocked` does not disqualify it here) and unassigned, the `qa` issue is a candidate for the **QA flow** regardless of its status label and session filter. This is the final QA pass that lets the epic close.
 3. Order: `priority` first, then by issue number ascending.
 4. Proceed with the chosen Issue immediately — no confirmation pause.
 5. No candidates and nothing to resume → the loop is done. Report and stop.
@@ -81,6 +82,8 @@ The manager works **only on sub-issues of an epic** (`epic`-labelled Issue, nati
 
 1. If `gh issue view <number> --json assignees` shows a non-`@me` assignee: skip the Issue (loop) or stop and ask (single-issue).
 2. Claim atomically: `gh issue edit <number> --add-assignee @me --remove-label <current-status> --add-label <next-status>` (next status per the flow below).
+
+Exception: **`qa` issues are not claimed by the manager** — the ux-tester subagent claims them itself (QA flow below). The manager only performs check 1 (skip if assigned to someone else).
 
 ## Parking a task (`needs-feedback`)
 
@@ -117,8 +120,8 @@ Agent({ description: "Plan issue {n}", subagent_type: "planner",
 Agent({ description: "Implement issue {n}", subagent_type: "coder",
         prompt: "EFFORT: high\nRun /coder {n}.\nDefinition of done additionally requires (ISSUE_PROTOCOL §6): a user-stories doc at docs/user-stories/epic-{epic}/{n}-<slug>.md committed in the same branch and linked from docs/user-stories/index.md." })
 
-Agent({ description: "QA pass for epic {epic}", subagent_type: "ux-tester",
-        prompt: "EFFORT: medium\nRun /ux-tester issue:{n}.\nExecute every user-stories doc under docs/user-stories/epic-{epic}/ (at minimum those not yet verified per the latest results comment on Issue #{n}). File defects as bug Issues. Post a results comment on Issue #{n}: stories run, pass/fail, bugs filed." })
+Agent({ description: "QA pass for epic {epic}", subagent_type: "ux-tester", model: "opus",
+        prompt: "EFFORT: medium\nRun /ux-tester {epic}." })
 
 Agent({ description: "Review PR for issue {n}", subagent_type: "reviewer",
         prompt: "EFFORT: high\nReview PR #<pr> for Issue #{n}. Run /review on the PR, then post the review summary as a PR comment. Do not approve or merge." })
@@ -146,7 +149,7 @@ Plan, park for human plan review, implement, PR ready. No manual testing phase.
 
 ## Frontend flow
 
-Plan, gate only on open questions, implement, PR ready. **No testing phase of any kind** — no ux-tester, no Figma-triggered checks; QA happens later via the epic's `qa` issue when the user requests it.
+Plan, gate only on open questions, implement, PR ready. **No testing phase of any kind** — no ux-tester, no Figma-triggered checks; QA happens later via the epic's `qa` issue (human-requested, or the automatic final pass once the epic's other sub-issues are closed).
 
 1. **Planning** (`backlog` → `planning`): launch the planner; the plan **must** include an `## Open Questions` section (`_None_` when clear). Commit, push, transition to `planned`.
 2. **Conditional gate**: if Open Questions lists items — post them as a comment, add `needs-feedback`, move on (loop) / stop (single). If `_None_` — proceed immediately.
@@ -170,12 +173,17 @@ No planning, no gates, no testing. Quality bar: lint clean, build clean, tests g
 
 ## QA flow
 
-Entry: a `qa` sub-issue in `backlog` — **only a human puts it there** (ISSUE_PROTOCOL §5.3); the manager never flips a `qa` issue to `backlog`.
+Entry — either of:
 
-1. `backlog` → `in-progress`. No feature branch needed unless the pass updates docs (e.g. `docs/QUALITY_SCORE.md`) — then branch + PR as usual.
-2. Launch `ux-tester` (prompt above) against the epic's `docs/user-stories/epic-<N>/` directory.
-3. After it returns: attach every bug Issue it filed as a sub-issue of the epic (`POST .../issues/<epic>/sub_issues`), and verify the results comment exists on the `qa` issue.
-4. If all sibling sub-issues of the epic are closed and the pass is green: close the `qa` issue, then close the epic. Otherwise: `in-progress` → `blocked` (the next pass is again human-requested).
+- **Human-requested**: a `qa` sub-issue in `backlog` (ISSUE_PROTOCOL §5.3). The manager never flips a `qa` issue to `backlog` itself.
+- **Epic-complete trigger**: all non-`qa` sub-issues of the epic are closed and the `qa` issue is still open — even if `blocked`. The epic cannot close without a green final pass, so the manager runs it without waiting for a human.
+
+Steps:
+
+1. Launch `ux-tester` (prompt above — `model: "opus"`, `EFFORT: medium`, argument is the **epic** number). The ux-tester owns the `qa` issue end-to-end: it claims it (`in-progress`), executes the user-stories docs under `docs/user-stories/epic-<N>/`, verifies against the epic's Figma references, files defects as `bug` sub-issues of the epic, posts the results comment, and finishes with the `qa` issue back to `blocked` — or closed (together with the epic) when all siblings are closed and the pass is green. The manager does **not** touch the `qa` issue's labels.
+2. After it returns, verify: the results comment exists on the `qa` issue; the `qa` issue ended `blocked` or closed; filed bugs are attached as sub-issues of the epic. Repair any gap (e.g. attach a missed bug via `POST .../issues/<epic>/sub_issues`).
+3. If the pass updated docs (e.g. `docs/QUALITY_SCORE.md`): branch, commit `QA pass for epic #<N>`, push, PR ready. Human-merge only.
+4. Loop mode: bugs the pass filed are new `backlog` candidates — continue the loop as usual.
 
 ---
 
@@ -191,9 +199,9 @@ Entry: a `qa` sub-issue in `backlog` — **only a human puts it there** (ISSUE_P
 ## Rules
 
 - The manager does **not** write code, tests, plans, specs, or reviews itself — it delegates.
-- The manager is the only label mutator; it claims before acting and verifies the status label after every subagent returns.
+- The manager is the only label mutator; it claims before acting and verifies the status label after every subagent returns. Exception: the epic's `qa` issue and QA-filed bug Issues belong to ux-tester (QA flow) — the manager only verifies and repairs afterwards.
 - The manager owns all lifecycle commits and pushes (plan, implementation, archive).
-- Never close Issues manually — `Closes #<n>` in the PR body does it on merge. Exception: the QA flow closes the `qa` issue and its epic by hand (no PR carries them).
+- Never close Issues manually — `Closes #<n>` in the PR body does it on merge. The `qa` issue and its epic are closed by ux-tester when the final pass is green (no PR carries them); the manager closes them only when repairing a gap ux-tester left.
 - Merge policy per `AGENTS.md`: trivial-frontend admin-merge after explicit green checks is the single exception; everything else is human-merge.
 - A task that needs a human never stalls the loop: park it (`needs-feedback`) or block it (`blocked`) with a comment, and continue.
 

--- a/.claude/skills/ux-tester/SKILL.md
+++ b/.claude/skills/ux-tester/SKILL.md
@@ -1,129 +1,128 @@
 ---
 name: ux-tester
-description: Manually UX-test the application with Chrome DevTools MCP. Maintain story-based test cases in docs/STORIES.md, run issue-scoped or regression test passes, log bugs as GitHub Issues (label `bug,backlog`), and update docs/QUALITY_SCORE.md.
-argument-hint: "[update cases | issue:<number> | regression]"
+description: Run a QA pass for an epic. Takes an epic number as argument — claims the epic's `qa` sub-issue, executes every user-stories doc under docs/user-stories/epic-<N>/ with Chrome DevTools MCP, verifies rendered pages against the epic's Figma references, files defects as `bug` sub-issues of the epic, posts a results comment, and updates docs/QUALITY_SCORE.md.
+argument-hint: "<epic-number>"
 model: sonnet
 effort: medium
 ---
 
 # UX-Tester
 
-Use this skill when the user (or the manager subagent) asks to manually UX-test the application, run regression checks, test a specific completed Issue, update story-based test cases, or record bugs and quality scores from manual QA.
+Use this skill when the user (or the manager subagent) requests a QA pass for an epic: manual story-based testing of the epic's shipped work plus a visual check against the epic's Figma designs.
 
 At the start of your response, output: MODEL: <your model name> | EFFORT: <your effort level>
 
 This line MUST also appear at the start of your final return message to the caller. If invoked as a subagent, the caller only sees your final message — include the MODEL/EFFORT line there as the very first line.
+
+## Arguments
+
+The argument is an **epic Issue number** (e.g. `463` or `epic:463`). The Issue must exist and carry the `epic` label — verify with `gh issue view <number> --json labels`. If no argument is provided, ask the user which epic to test.
 
 ## Required Context
 
 Read these first:
 
 1. `AGENTS.md`
-2. `docs/STORIES.md` (create it if missing — see "Story And Test Case Maintenance" below)
+2. `docs/ISSUE_PROTOCOL.md` — §2 (`qa` lifecycle), §5 (claiming, QA scheduling), §6 (user-stories docs).
 3. `docs/QUALITY_SCORE.md`
 4. The `issue` skill: `.claude/skills/issue/SKILL.md` — for label conventions when filing bugs.
 
 Read additional context only as needed:
 
-- The target Issue: `gh issue view <number> -c` when the caller passes `issue:<number>`.
-- The matching completed plan in `docs/exec-plans/completed/` (or active plan if still in flight) for traceability.
 - Relevant product specs (`docs/product-specs/`) or design docs (`docs/design-docs/`) when a story or acceptance check is unclear.
+- Completed plans in `docs/exec-plans/completed/` for traceability when a story doc is ambiguous.
 
-## Reading the Issue
+## Workflow
+
+### 1. Resolve the epic and its `qa` issue
 
 ```bash
-gh issue view <number> -c                                           # body + comments
-gh issue view <number> --json title,body,labels,assignees,url
+gh issue view <epic> -c                                   # epic body + comments — contains the Figma URL tables
+gh api repos/eq-lab/pipeline/issues/<epic>/sub_issues \
+  --jq '.[] | select(.labels[].name == "qa") | .number'   # the epic's qa sub-issue
 ```
 
-## Core Responsibilities
+- If the epic has no `qa` sub-issue, stop and report — the epic was not set up per `ISSUE_PROTOCOL.md`.
+- Read the `qa` issue and **all its comments** (`gh issue view <qa> -c`). The latest results comment tells you which stories are already verified green.
 
-This skill supports four primary modes:
+### 2. Claim the `qa` issue
 
-1. `ux-tester update cases` — refresh `docs/STORIES.md` against completed Issues.
-2. `ux-tester issue:<number>` — issue-scoped manual testing for one Issue.
-3. `ux-tester regression` — full regression across documented test cases.
-4. Bug logging (as GitHub Issues) and quality-score updates after every meaningful pass.
+- If the `qa` issue is assigned to someone else, **stop** — do not touch it (ISSUE_PROTOCOL §5.1).
+- If it is `backlog`, claim it atomically:
 
-Always use Chrome DevTools MCP for manual browser validation when UI behavior is in scope.
+  ```bash
+  gh issue edit <qa> --add-assignee @me --remove-label backlog --add-label in-progress
+  ```
 
-## Story And Test Case Maintenance
+- If it is still `blocked` but a human invoked this skill directly, treat the invocation as the pass request: claim it the same way, removing `blocked` instead of `backlog`.
 
-When the caller passes `update cases`:
+### 3. Gather test inputs
 
-1. Read `docs/STORIES.md` (create it as an empty test-oriented document if it does not yet exist).
-2. List recently closed Issues: `gh issue list --state closed --limit 50 --json number,title,labels,closedAt`.
-3. Inspect completed plans in `docs/exec-plans/completed/` for tasks represented in the current product surface.
-4. Add missing story coverage for completed Issues that lack usable manual test cases.
-5. Ensure each testable section in `docs/STORIES.md` includes traceability:
-   - Issue number (and URL)
-   - Completed execution plan path
-6. Prefer concrete test cases over abstract statements:
-   - actor
-   - setup or preconditions
-   - steps
-   - expected result
-7. Do not invent coverage for backlog or incomplete Issues unless explicitly asked.
+1. **Figma references** — extract every Figma URL from the epic body (typically tables keyed by state and viewport: desktop / mobile, wallet states, etc.). For each, note the `fileKey`, `nodeId`, and which state/viewport it represents.
+2. **User stories** — list `docs/user-stories/epic-<epic>/*.md`. Every doc in that directory is in scope. At minimum, execute the docs **not yet verified** per the latest results comment on the `qa` issue; rerun previously-green docs when the epic gained new merged work since that pass.
+3. If the directory is missing or empty, stop, report it, and return the `qa` issue to its prior status with an explanatory comment.
 
-Keep `docs/STORIES.md` lean and test-oriented — do not duplicate the product spec.
+### 4. Verify environment readiness
 
-## Issue-Scoped Testing (`issue:<number>`)
+Start or reuse the local app/dev server. Find the app URL from the project README or `package.json` scripts — typically `http://localhost:3000`. Pipeline is a Rust + TS monorepo; look in `scripts/` and `packages/` for seed/fixture commands. Use any seeding instructions embedded in the user-stories docs (e.g. `pipeline.mock.wallet.*` localStorage keys) to reproduce each story's preconditions.
 
-When the caller passes an Issue number:
+### 5. Execute the user stories
 
-1. Resolve scope:
-   - `gh issue view <number> -c` for body + comments + labels.
-   - Open the referenced execution plan (active or completed).
-   - Identify matching stories in `docs/STORIES.md`.
-2. Build a focused test list from those stories.
-3. Verify environment readiness — start or reuse the local app/dev server. Find the app URL from the project README, `package.json` scripts, or by asking the user if unclear. Pipeline is a Rust + TS monorepo — the frontend dev server URL is typically `http://localhost:3000` or the value configured in the user-docs Jekyll site (`docs/user-docs/_config.yml`).
-4. Use Chrome DevTools MCP to exercise the relevant flows manually.
-5. Record pass/fail/blocked status for each tested case.
-6. File any new defects as GitHub Issues (see "Bug Logging" below).
-7. Update `docs/QUALITY_SCORE.md` with the scoped results.
+For each user-stories doc, for each story:
 
-## Regression Testing (`regression`)
+1. Set up the story's preconditions (seeding, viewport size, wallet state) exactly as the doc specifies.
+2. Drive the flow with Chrome DevTools MCP (see "Chrome DevTools MCP Workflow" below) — follow the doc's steps as a user would.
+3. Check every expected outcome the doc lists. A story passes only if all its expected outcomes hold.
+4. Record pass/fail/blocked per story as you go, with a one-line reason for every fail/blocked.
 
-When the caller asks to run regressions:
+### 6. Verify against Figma
 
-1. Read all currently testable cases from `docs/STORIES.md`.
-2. Group them into a practical execution order:
-   - auth / access
-   - core shell / navigation
-   - feature-specific flows
-3. Use Chrome DevTools MCP to drive the browser-based checks.
-4. Reuse terminal commands for setup, fixtures, or bootstrap actions.
-5. Mark each case pass/fail/blocked in working notes.
-6. File new defects as GitHub Issues.
-7. Update `docs/QUALITY_SCORE.md` after the run.
+For each Figma reference from the epic body whose state/viewport you can reproduce, run a structured visual comparison while that state is set up (do it together with the matching story to reuse the seeded state):
 
-Prefer meaningful regressions over superficial page visits — exercise the acceptance checks, not just route loads.
+1. **Load the design:** call `mcp__figma__get_design_context` with the `fileKey` and `nodeId`. **Ignore the returned React/Tailwind code** — do not read it; it biases you toward confirming structure that may not actually be rendered. Use only the layout description and reference screenshot.
+2. **Enumerate sections:** call `mcp__figma__get_metadata` (or inspect the design context) to list the **direct child nodes** of the frame — these are the sections to compare. If there are more than ~8 children, group them into logical sections. This list is the comparison checklist — every entry must be checked.
+3. **Align the viewport:** `mcp__chrome-devtools__resize_page` to the Figma frame's width (read it from the design context — e.g. 1440 for desktop, 402 for mobile). Mismatched viewports cause false "proportion looks different" dismissals.
+4. **Pairwise section comparison — one section at a time.** For every child node:
+   1. Figma side: `mcp__figma__get_screenshot` for the child `nodeId` — a focused, full-resolution view of just that section.
+   2. App side: from `take_snapshot` output, find the corresponding element's `uid` and `mcp__chrome-devtools__take_screenshot` with that `uid`. If the section is missing from the app entirely, **that itself is a finding** — record it and continue.
+   3. Compare against this checklist, answering each line before moving on:
+      - [ ] Is the section present in the app at all?
+      - [ ] Is it in the same position relative to other sections (order)?
+      - [ ] Heading: same text? same size/weight? present at all?
+      - [ ] Body copy: same content? same paragraph splitting?
+      - [ ] Typography: font family, size, weight, alignment, line height
+      - [ ] Colors: text, background, borders, shadows
+      - [ ] Container styling: card vs plain, border radius, padding
+      - [ ] Layout: grid/column count, gap, item alignment
+      - [ ] Images: present? aspect ratio? position?
+      - [ ] Are there elements in the **app** that do **not** appear in Figma?
+      - [ ] Are there elements in **Figma** that do **not** appear in the app? (most commonly missed — bias yourself to look for absences)
+   4. Record findings as you go — one line per mismatch: `section <label>: <what differs>`.
+5. After the loop, do one final full-page scan (full-page screenshot pair) to catch differences in section *ordering* and *spacing between sections* that per-section screenshots miss. **Never rely on the full-page comparison alone** — it is for overview and ordering only.
 
-## Rules
+### 7. File bugs
 
-- Do **not** edit issue labels on the parent Issue. The manager owns lifecycle transitions.
-- Do **not** commit. The manager will commit testing artifacts (`docs/STORIES.md`, `docs/QUALITY_SCORE.md`) together with its lifecycle commit.
-- Bugs are filed as **new GitHub Issues** with the `bug,backlog` labels — never as comments-only.
-- Always run Chrome DevTools MCP for manual browser validation. Code inspection alone is not acceptable evidence of testing.
+File every defect (failed story outcome or Figma mismatch) as a **new GitHub Issue** and attach it as a **sub-issue of the epic** (ISSUE_PROTOCOL §2: bugs found while testing an epic are sub-issues of that epic). One Issue per independent problem — do not batch unrelated defects.
 
-## Bug Logging
+Labels — a flow label is **not optional**; without one the `manager` skill will skip the Issue:
 
-When a defect is found, create a new GitHub Issue:
+- `bug,frontend,backlog` — default for UX findings (visual / styling / copy / behavior on a frontend page).
+- `bug,frontend,trivial,backlog` — add `trivial` only when the fix is mechanical and self-contained: a CSS tweak, a prop default, a string change, a single-component visual fix with no data-flow or logic change.
+- Use `backend` instead of `frontend` when the defect is clearly server-side.
 
 ```bash
 gh issue create \
   --title "<short imperative>" \
-  --label "bug,backlog" \
+  --label "bug,frontend,backlog" \
   --body "$(cat <<'EOF'
-**Linked issue:** #<parent-number>
-**Source story:** <story id from docs/STORIES.md, if applicable>
-**Plan:** <docs/exec-plans/.../path.md, if applicable>
+**Epic:** #<epic-number>
+**Source story:** docs/user-stories/epic-<N>/<doc>.md — Story <n> (or "Figma comparison" with the node-id)
+**Figma:** <figma-url including node-id, if applicable>
 
 **Severity:** critical | high | medium | low
 
 **Reproduction steps**
 1. ...
-2. ...
 
 **Expected result**
 ...
@@ -133,32 +132,44 @@ gh issue create \
 
 **Environment**
 - App URL:
-- Browser:
+- Viewport:
 - Date:
 EOF
 )"
+
+# attach as sub-issue of the epic
+CHILD_ID=$(gh api repos/eq-lab/pipeline/issues/<new-number> --jq .id)
+gh api repos/eq-lab/pipeline/issues/<epic>/sub_issues -F sub_issue_id="$CHILD_ID"
 ```
 
-Capture the new Issue number and add it as a comment on the parent Issue:
-
-```bash
-gh issue comment <parent-number> --body "Filed bug #<new-number> (<severity>) during UX testing: <title>"
-```
-
-Severity guidance (used by the manager for critical-bug handling):
+Severity guidance:
 
 - **critical** — blocks the feature shipping; mismatches against contract / spec; data loss or security risk.
 - **high** — significantly degrades UX or wrong content on a primary surface.
 - **medium** — incorrect styling, minor copy mismatches, edge-case errors.
 - **low** — polish, cosmetic.
 
+### 8. Post results and release the `qa` issue
+
+1. Post a **results comment on the `qa` issue**: stories run (per doc), pass/fail/blocked per story, Figma frames compared, bugs filed (numbers + severity). This comment is the verification history the next pass builds on — make per-story status machine-greppable (e.g. a table or `- [x] doc.md Story 1 — PASS`).
+2. Transition the `qa` issue per ISSUE_PROTOCOL §2:
+   - **Default:** back to `blocked` and unassign yourself (the next pass is again human-requested):
+
+     ```bash
+     gh issue edit <qa> --remove-label in-progress --add-label blocked --remove-assignee @me
+     ```
+
+   - **If all sibling sub-issues are closed and this pass is fully green:** close the `qa` issue, then the epic.
+3. Update `docs/QUALITY_SCORE.md` (see below). Do **not** commit — the manager/human commits testing artifacts.
+
 ## Quality Score Updates
 
-After each scoped or regression pass, update `docs/QUALITY_SCORE.md`. Every update should include:
+After each pass, update `docs/QUALITY_SCORE.md` with:
 
 - test date
-- scope tested (Issue number or "regression")
-- story coverage summary
+- scope tested (epic number + `qa` issue number)
+- story coverage summary (docs run / stories passed / failed / blocked)
+- Figma frames compared
 - bugs filed (Issue numbers) or confirmed
 - a short numeric quality score (0–10 unless the document already establishes a different scale)
 - brief reasoning for the score
@@ -167,27 +178,39 @@ If there is not enough information for a confident score, say so explicitly and 
 
 ## Chrome DevTools MCP Workflow
 
-Use Chrome DevTools MCP as the default manual testing tool. You MUST actually drive the browser.
+Use Chrome DevTools MCP as the default manual testing tool. You MUST actually drive the browser — code inspection alone is not acceptable evidence of testing.
 
-1. Resolve the app URL from project config (README, `package.json`, `docs/user-docs/_config.yml`). Ask the user if unclear.
+1. Reuse a running Chrome DevTools session if available; otherwise start one. If navigation reports a stale-lock error, run `pkill -f "chrome-devtools-mcp/chrome-profile"` once, then retry.
 2. Navigate to the target flows with `mcp__chrome-devtools__navigate_page`.
-3. Interact as a user would (`click`, `fill`, `hover`, `scroll`, etc.).
-4. Use `mcp__chrome-devtools__take_snapshot` as the primary inspection tool to read the DOM / a11y tree.
-5. Use `mcp__chrome-devtools__take_screenshot` when visual evidence is useful.
+3. Interact as a user would (`click`, `fill`, `hover`, scroll, etc.).
+4. Use `mcp__chrome-devtools__take_snapshot` as the primary inspection tool to read the DOM / a11y tree; prefer it over screenshots when inspecting text content.
+5. Use `mcp__chrome-devtools__take_screenshot` for visual styling evidence and Figma comparisons.
 6. Use `list_console_messages` and `list_network_requests` when diagnosing a failure.
 
 When setup is required, prefer existing scripts/fixtures from the repo over manual setup. Document any non-obvious setup in your final report.
 
+## Rules
+
+- **Label edits are limited to the epic's `qa` issue** (claim → results → `blocked`/close) and the status labels of bugs you create. Never relabel the epic itself or its other sub-issues — the manager owns those transitions.
+- Do **not** implement fixes. Testing and filing only.
+- Do **not** commit. The manager/human commits testing artifacts (`docs/QUALITY_SCORE.md`) — your results comment on the `qa` issue is the durable record.
+- Bugs are filed as **new GitHub Issues** attached as sub-issues of the epic — never as comments-only.
+- Empty/unrealistic pages are not valid test targets — seed the state the story doc specifies before testing or comparing.
+- **Do not read the React/Tailwind code returned by `get_design_context`** — it biases the comparison.
+- **Bias toward finding absences.** After each section comparison, explicitly ask: "what is in the Figma screenshot that I cannot point to in the app screenshot?"
+- Align the browser viewport width to the Figma frame width before screenshotting.
+- Respect the 7-day Figma asset URL TTL — download assets locally before referencing them anywhere durable.
+
 ## Output Expectations
 
-When running tests, report:
+Your final message should include:
 
-- scope tested (Issue number or "regression")
-- cases executed
-- passes
-- failures
-- blocked items
+- epic number and `qa` issue number
+- user-stories docs executed, with per-story pass/fail/blocked
+- Figma frames compared (node-ids) and findings
 - bug Issues filed (numbers + severity)
-- quality score updates
+- the `qa` issue's final status (`blocked` / closed)
+- quality score update
+- any blockers or stories that could not be executed, with reasons
 
-If testing could not be completed, explain the blocker clearly and update docs only if there is a justified partial result.
+If testing could not be completed, explain the blocker clearly, return the `qa` issue to an honest status with a comment, and update docs only if there is a justified partial result.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ Every piece of dev work is a **sub-issue of an epic**, tracked per [`docs/ISSUE_
 - **Backend** (`backend` label) — plan → park for human plan feedback → implement → PR.
 - **Frontend** (`frontend` label) — plan (gate only on planner Open Questions) → implement → PR. **No testing phase.**
 - **Trivial frontend** (`frontend` + `trivial`) — implement → PR → manager admin-merge after explicitly green CI.
-- **QA** (`qa` label) — one issue per epic; runs only when a human flips it to `backlog`. The QA agent executes the epic's user-stories docs and files bugs.
+- **QA** (`qa` label) — one issue per epic; runs when a human flips it to `backlog`, or automatically as the **final pass** once all other sub-issues of the epic are closed. The QA agent executes the epic's user-stories docs, verifies against the epic's Figma references, and files bugs.
 
 When uncertain about frontend vs. backend, label it `backend`. Per-flow specifics live in [`.claude/skills/manager/SKILL.md`](./.claude/skills/manager/SKILL.md).
 

--- a/docs/ISSUE_PROTOCOL.md
+++ b/docs/ISSUE_PROTOCOL.md
@@ -43,7 +43,7 @@ All dev work is grouped under an epic. An epic describes one business feature.
 
 ### `qa` — testing pass
 
-One `qa` issue per epic, created together with the epic as its sub-issue. Manual testing does **not** happen after each task — a **human requests a pass** by flipping the `qa` issue to `backlog`, and it happens when an agent picks the issue up.
+One `qa` issue per epic, created together with the epic as its sub-issue. Manual testing does **not** happen after each task — a **human requests a pass** by flipping the `qa` issue to `backlog`, and it happens when an agent picks the issue up. Exception: the **final pass** — when all non-`qa` sibling sub-issues are closed and the `qa` issue is still open (even `blocked`), an agent may run the pass without a human request, since the epic cannot close without it (§5.3).
 
 - **Body:** points to the epic's user-stories directory (`docs/user-stories/epic-<N>/`, see §6). The QA agent discovers the stories to run from that directory; verification history lives in the results comments.
 - **Lifecycle:**
@@ -129,7 +129,9 @@ gh issue edit <number> --add-assignee @me --remove-label backlog --add-label in-
 
 ### 5.3 QA scheduling
 
-QA passes are **requested by humans**, not triggered by agents. Implementing agents only commit user-stories docs in their PRs (§6) — they never edit, comment on, or relabel the epic's `qa` issue. When a human wants a testing pass, they flip the `qa` issue `blocked` → `backlog`; the QA agent that claims it discovers the stories to run from `docs/user-stories/epic-<N>/`.
+Mid-epic QA passes are **requested by humans**, not triggered by agents. Implementing agents only commit user-stories docs in their PRs (§6) — they never edit, comment on, or relabel the epic's `qa` issue. When a human wants a testing pass, they flip the `qa` issue `blocked` → `backlog`; the QA agent that claims it discovers the stories to run from `docs/user-stories/epic-<N>/`.
+
+**Final-pass exception:** when **all non-`qa` sub-issues of an epic are closed** and the `qa` issue is still open, an orchestrating agent may start the pass directly — claiming the `qa` issue from `blocked` or `backlog` — because the epic can only close after a green final pass.
 
 ### 5.4 Discovering work
 


### PR DESCRIPTION
## Summary

**ux-tester reworked around epic QA passes (per `docs/ISSUE_PROTOCOL.md`):**
- `/ux-tester` now takes an **epic number**: it resolves the epic's `qa` sub-issue, claims it atomically (`in-progress` + self-assign), and after posting a results comment returns it to `blocked` — or closes it (then the epic) when all siblings are closed and the pass is green.
- Test inputs come from the protocol's artifacts: Figma URL tables in the epic body and user-stories docs under `docs/user-stories/epic-<N>/`, with the latest results comment determining which stories still need verification. The old `update cases` / `issue:<n>` / `regression` modes and the `docs/STORIES.md` machinery are removed.
- Adds a structured **Figma verification step** ported from ux-reviewer: per-section pairwise screenshots, viewport aligned to the Figma frame width, ignore the returned React/Tailwind code, explicit bias toward finding absences, final full-page ordering/spacing scan.
- Bugs are filed as `bug,frontend,backlog` (+`trivial` when mechanical) and attached as **sub-issues of the epic**.

**Manager updated to match, plus an epic-complete QA trigger:**
- New selection rule: if **all non-`qa` sub-issues of an epic are closed** and the `qa` issue is still open (even `blocked`), the manager runs the final QA pass automatically — launching the ux-tester subagent with `model: opus`, `EFFORT: medium` and the epic number.
- QA flow rewritten for the new contract: ux-tester owns the `qa` issue end-to-end; the manager verifies/repairs afterwards and PRs doc updates (`docs/QUALITY_SCORE.md`). The manager no longer claims `qa` issues.
- `docs/ISSUE_PROTOCOL.md` §2/§5.3 and `AGENTS.md` amended with the **final-pass exception**: mid-epic passes stay human-requested; the final pass may be agent-triggered since the epic cannot close without it.

## Test plan
- [ ] Flip an epic's `qa` issue to `backlog` and run `/ux-tester <epic-number>` — verify it claims the `qa` issue, executes the docs under `docs/user-stories/epic-<N>/`, compares against the epic's Figma frames, files bugs as epic sub-issues, posts a results comment, and returns the issue to `blocked`.
- [ ] On an epic whose non-`qa` sub-issues are all closed, run `/manager` — verify it picks the open (`blocked`) `qa` issue, launches ux-tester (opus / medium), and the `qa` issue + epic close on a green pass.
- [ ] `npx tsx scripts/lint-docs.ts` — 0 errors (run locally: passes).