### PR TITLE
Fix #475: 40px Buy/Sell buttons in StartHereCard on mobile

### DIFF
--- a/docs/exec-plans/tech-debt-tracker.md
+++ b/docs/exec-plans/tech-debt-tracker.md
@@ -101,6 +101,13 @@ Shortcuts, structural gaps, and deferred cleanup. Log here, don't fix inline.
 - **Impact:** Mild bundle size increase from dual stellar-sdk copies. Low risk in practice since both packages use the SDK only internally and types are not shared across the boundary.
 - **Suggested fix:** When blend-sdk releases a version that declares `@stellar/stellar-sdk@^15` as a peer/dependency range, upgrade blend-sdk and verify the direct install deduplications. Track with `yarn why @stellar/stellar-sdk` to confirm dedup. File a follow-up issue if that version ships.
 
+### TD-12: `yarn workspace @pipeline/frontend lint` fails on `main` (Prettier drift in 11 files)
+- **Date:** 2026-06-04
+- **Location:** `packages/frontend/src` — 11 files including `StartHereCard.tsx`, `TopBar.test.tsx`, `WelcomeHeader.tsx`, `routes/index.tsx`, `routes/-index.test.tsx`
+- **Gap:** The frontend lint script's Prettier check exits 1 on a clean `main` checkout — formatting drifted without the gate catching it (CI does not currently fail on it).
+- **Impact:** The local lint gate is permanently red, so agents cannot use `lint` exit status as a pass/fail signal for their own changes; per-file checks are needed instead. New drift accumulates silently.
+- **Suggested fix:** One-shot `prettier --write` pass over the workspace in a dedicated chore PR, then make CI run the same lint script so drift fails fast.
+
 ---
 
 ## Post-MVP

--- a/docs/user-stories/epic-463/475-buy-sell-button-height.md
+++ b/docs/user-stories/epic-463/475-buy-sell-button-height.md
@@ -1,0 +1,36 @@
+# User Stories — #475 StartHereCard Buy/Sell button height (mobile)
+
+Epic: [#463 Home page](https://github.com/eq-lab/pipeline/issues/463)
+Issue: [#475](https://github.com/eq-lab/pipeline/issues/475)
+Status: Initial
+
+---
+
+## Story 1 — Buy and Sell buttons are 40 px tall on a 402 px mobile viewport
+
+**Given** the home page is rendered at a 402 px wide viewport (mobile breakpoint, below `sm` = 640 px)
+**When** a QA agent inspects the computed height of the Buy button (data-node-id `1497:94689`) and the Sell button (data-node-id `1497:94690`) inside the StartHereCard
+**Then** each button has a computed height of **40 px** (Tailwind `h-10`), matching Figma nodes 1989:9021 / 1989:9022 in frame 1989-8292.
+
+---
+
+## Story 2 — Buy and Sell buttons remain 48 px tall on desktop (≥ 768 px)
+
+**Given** the home page is rendered at a viewport width of 768 px or wider
+**When** a QA agent inspects the computed height of the Buy and Sell buttons in the StartHereCard
+**Then** each button has a computed height of **48 px** (Tailwind `h-12`), matching the desktop Figma spec.
+
+---
+
+## Story 3 — The promo card Connect button is unaffected
+
+**Given** the home page is rendered at any viewport width
+**When** a QA agent inspects the height of the Connect button inside the wallet promo card
+**Then** the button height is **48 px** at all breakpoints (no regression).
+
+---
+
+## Out of scope
+
+- Sell button disabled-state opacity — tracked in #476.
+- Any other button or card on the page.

--- a/docs/user-stories/index.md
+++ b/docs/user-stories/index.md
@@ -13,3 +13,4 @@ See [`docs/ISSUE_PROTOCOL.md` §6](../ISSUE_PROTOCOL.md) for conventions.
 |-------|-----|--------|
 | [#465 Mobile home base layout + wallet-not-connected state](https://github.com/eq-lab/pipeline/issues/465) | [465-mobile-home-base.md](./epic-463/465-mobile-home-base.md) | Initial |
 | [#466 Mobile home page balance states (0/0, has PLUSD, has sPLUSD)](https://github.com/eq-lab/pipeline/issues/466) | [466-mobile-home-balance-states.md](./epic-463/466-mobile-home-balance-states.md) | Initial |
+| [#475 StartHereCard Buy/Sell button height (mobile)](https://github.com/eq-lab/pipeline/issues/475) | [475-buy-sell-button-height.md](./epic-463/475-buy-sell-button-height.md) | Initial |

--- a/packages/frontend/src/components/StartHereCard.tsx
+++ b/packages/frontend/src/components/StartHereCard.tsx
@@ -262,6 +262,7 @@ export const StartHereCard = React.forwardRef<
         <Button
           variant="primary-blue"
           onClick={onBuy}
+          className="h-10 md:h-12"
           data-node-id="1497:94689"
         >
           Buy
@@ -270,6 +271,7 @@ export const StartHereCard = React.forwardRef<
           variant="secondary"
           onClick={onSell}
           disabled={mobileHomeState === "empty"}
+          className="h-10 md:h-12"
           data-node-id="1497:94690"
         >
           Sell


### PR DESCRIPTION
Closes #475

Buy/Sell buttons in StartHereCard render 48px tall on mobile; the Figma mobile spec is 40px. Steps the pair down to the 40px button size on mobile.