### PR TITLE
Fix #476: dimmed Sell button styling in StartHereCard

### DIFF
--- a/docs/user-stories/epic-463/476-sell-button-dimmed.md
+++ b/docs/user-stories/epic-463/476-sell-button-dimmed.md
@@ -1,0 +1,56 @@
+# #476 — StartHereCard Sell button dimmed style
+
+**Epic:** #463 Mobile home page  
+**Issue:** https://github.com/eq-lab/pipeline/issues/476  
+**Figma:** https://www.figma.com/design/A43rjYYjSwdTmiwwf5cx5n/Pipeline?node-id=1989-8292 (node 1989:9022)
+
+## Background
+
+On mobile, the Sell button in `StartHereCard` should be visually de-emphasized (32% opacity)
+when the user has no PLUSD to sell — both when the wallet is disconnected and when it is
+connected but has a zero balance. Only when the wallet is connected and holds a positive
+PLUSD or sPLUSD balance should Sell render at full opacity and be interactive.
+
+The `secondary` Button variant already applies `disabled:opacity-[0.32]` via Tailwind.
+The fix ensures the `disabled` prop is set correctly in both the disconnected and
+empty-balance states on mobile.
+
+## User stories
+
+### Story 1 — Wallet disconnected (mobile, < 768px)
+
+**Given** the user opens the home page on a mobile viewport (< 768 px) without a connected wallet  
+**Then** the StartHereCard is visible with a "Start here / Get PLUSD" heading  
+**And** the Buy button is fully opaque and interactive  
+**And** the Sell button is rendered at ~32% opacity (visually dimmed) and is not clickable
+
+### Story 2 — Wallet connected, zero balances (mobile, < 768px)
+
+**Given** the user is on a mobile viewport with a connected wallet but holds 0 PLUSD and 0 sPLUSD  
+**Then** the StartHereCard shows the "Start here / Get PLUSD" heading  
+**And** the Sell button is rendered at ~32% opacity and is not clickable
+
+### Story 3 — Wallet connected, has PLUSD (mobile, < 768px)
+
+**Given** the user is on a mobile viewport with a connected wallet and a positive PLUSD balance  
+**Then** the StartHereCard shows the "PLUSD Balance" heading with the formatted balance  
+**And** the Buy button is fully opaque and interactive  
+**And** the Sell button is fully opaque and interactive
+
+### Story 4 — Wallet connected, has sPLUSD (mobile, < 768px)
+
+**Given** the user is on a mobile viewport with a connected wallet and a positive sPLUSD balance  
+**Then** the StartHereCard shows the "PLUSD Balance" heading  
+**And** both Buy and Sell buttons are fully opaque and interactive
+
+### Story 5 — Desktop viewport (≥ 768px)
+
+**Given** the user opens the home page on a desktop viewport (≥ 768 px)  
+**Then** the StartHereCard in the desktop grid does not apply any opacity dimming to Sell  
+**And** the Sell button is interactive regardless of wallet state
+
+## Test notes
+
+- Opacity check: inspect the Sell `<button>` element and confirm `opacity` resolves to approximately 0.32 in Stories 1 and 2.
+- Confirm `disabled` attribute is present on the button element in Stories 1 and 2.
+- Confirm `disabled` attribute is absent in Stories 3, 4, and 5.

--- a/docs/user-stories/index.md
+++ b/docs/user-stories/index.md
@@ -14,3 +14,4 @@ See [`docs/ISSUE_PROTOCOL.md` §6](../ISSUE_PROTOCOL.md) for conventions.
 | [#465 Mobile home base layout + wallet-not-connected state](https://github.com/eq-lab/pipeline/issues/465) | [465-mobile-home-base.md](./epic-463/465-mobile-home-base.md) | Initial |
 | [#466 Mobile home page balance states (0/0, has PLUSD, has sPLUSD)](https://github.com/eq-lab/pipeline/issues/466) | [466-mobile-home-balance-states.md](./epic-463/466-mobile-home-balance-states.md) | Initial |
 | [#475 StartHereCard Buy/Sell button height (mobile)](https://github.com/eq-lab/pipeline/issues/475) | [475-buy-sell-button-height.md](./epic-463/475-buy-sell-button-height.md) | Initial |
+| [#476 StartHereCard Sell button dimmed style](https://github.com/eq-lab/pipeline/issues/476) | [476-sell-button-dimmed.md](./epic-463/476-sell-button-dimmed.md) | Initial |

--- a/packages/frontend/src/components/StartHereCard.tsx
+++ b/packages/frontend/src/components/StartHereCard.tsx
@@ -93,9 +93,11 @@ export interface StartHereCardProps extends Omit<
    * Mobile-only: connected balance state.
    * When `"plusd"` or `"splusd"`, renders the "PLUSD Balance" connected
    * variant (eyebrow "PLUSD Balance", formatted balance, USDC sub-line, Buy
-   * + Sell both enabled). When `"empty"`, Sell is disabled. When `undefined`
-   * the component renders its default disconnected appearance (no change to
-   * desktop rendering).
+   * + Sell both enabled). When `"empty"`, Sell is disabled and rendered at
+   * 32% opacity (Figma node 1989:9022) — used for both the disconnected mobile
+   * state and the connected-but-zero-balance state. When `undefined` the
+   * component renders its default disconnected appearance without disabling
+   * Sell (desktop context).
    */
   mobileHomeState?: MobileHomeState;
   /**

--- a/packages/frontend/src/routes/index.tsx
+++ b/packages/frontend/src/routes/index.tsx
@@ -196,7 +196,7 @@ function Home() {
                 className="flex-1"
                 onBuy={onBuy}
                 onSell={onSell}
-                mobileHomeState={isConnected ? mobileHomeState : undefined}
+                mobileHomeState={isConnected ? mobileHomeState : "empty"}
                 mobilePlusdBalance={plusdFormatted}
               />
               <EarnedCard mobileHomeState={isConnected ? mobileHomeState : undefined} />


### PR DESCRIPTION
Closes #476

The Sell button in StartHereCard renders as a full-contrast active action; the Figma mobile spec (node 1989:9022) shows it dimmed — secondary ink color at 32% opacity, de-emphasized next to the filled navy Buy button. Applies the dimmed/disabled styling.