### PR TITLE
Fix #480: promo card decorative graphic size/position on mobile

### DIFF
--- a/docs/user-stories/epic-463/480-promo-graphic-size.md
+++ b/docs/user-stories/epic-463/480-promo-graphic-size.md
@@ -1,0 +1,36 @@
+# User Stories — #480 ConnectWalletPromoCard decorative graphic size/position (mobile)
+
+Epic: [#463 Home page](https://github.com/eq-lab/pipeline/issues/463)
+Issue: [#480](https://github.com/eq-lab/pipeline/issues/480)
+Status: Initial
+
+---
+
+## Story 1 — WalletIllustration is ~235 px wide on a 402 px mobile viewport
+
+**Given** the home page is rendered at a 402 px wide viewport (mobile breakpoint, below `md` = 768 px)
+**When** a QA agent inspects the computed width of the WalletIllustration inside the ConnectWalletPromoCard
+**Then** the illustration wrapper has a computed width of approximately **235 px**, matching Figma node 1989:9179 in frame 1989-8292.
+
+---
+
+## Story 2 — WalletIllustration is anchored to the lower-right of the card on mobile
+
+**Given** the home page is rendered at a 402 px wide viewport
+**When** a QA agent inspects the position of the WalletIllustration wrapper inside the ConnectWalletPromoCard
+**Then** the wrapper's top offset is approximately **117 px** (placing the centre of the 150 px-tall illustration near the lower half of the 274 px card), and the illustration bleeds off the right card edge — matching the Figma lower-right anchor.
+
+---
+
+## Story 3 — WalletIllustration remains ~314 px wide on desktop (≥ 768 px)
+
+**Given** the home page is rendered at a viewport width of 768 px or wider
+**When** a QA agent inspects the computed width of the WalletIllustration inside the ConnectWalletPromoCard
+**Then** the illustration wrapper has a computed width of approximately **314 px** and uses the original percentage-based vertical position (`top: 70%`), with no regression to desktop layout.
+
+---
+
+## Out of scope
+
+- Desktop card layout or other card variants.
+- Any other illustration or card on the page.

--- a/docs/user-stories/index.md
+++ b/docs/user-stories/index.md
@@ -16,3 +16,4 @@ See [`docs/ISSUE_PROTOCOL.md` §6](../ISSUE_PROTOCOL.md) for conventions.
 | [#475 StartHereCard Buy/Sell button height (mobile)](https://github.com/eq-lab/pipeline/issues/475) | [475-buy-sell-button-height.md](./epic-463/475-buy-sell-button-height.md) | Initial |
 | [#476 StartHereCard Sell button dimmed style](https://github.com/eq-lab/pipeline/issues/476) | [476-sell-button-dimmed.md](./epic-463/476-sell-button-dimmed.md) | Initial |
 | [#477 StakeCard circular Stake button size on mobile](https://github.com/eq-lab/pipeline/issues/477) | [477-stake-button-size.md](./epic-463/477-stake-button-size.md) | Initial |
+| [#480 ConnectWalletPromoCard decorative graphic size/position (mobile)](https://github.com/eq-lab/pipeline/issues/480) | [480-promo-graphic-size.md](./epic-463/480-promo-graphic-size.md) | Initial |

--- a/packages/frontend/src/components/ConnectWalletPromoCard.tsx
+++ b/packages/frontend/src/components/ConnectWalletPromoCard.tsx
@@ -118,12 +118,29 @@ export const ConnectWalletPromoCard = React.forwardRef<
           (clipped by the Card's overflow-hidden), and vertically anchored at
           70% of card height matching the Figma anchor point (left: 376px /
           top: 91px inside a 274px card ≈ vertical centre at ~191px ≈ 70%). */}
-      <WalletIllustration
-        tone="primary"
-        width={314}
-        className="pointer-events-none absolute top-[70%] right-[-48px] -translate-y-1/2"
-        data-node-id="I1497:94566;1360:49452"
-      />
+      {/* On mobile (< md): 235×150 anchored lower-right per Figma node 1989:9179
+          (card ≈ 386px wide, illustration x≈187 → right-bleed). Width set via
+          a wrapper so responsive Tailwind classes control size while the
+          illustration fills 100% of the wrapper.
+          On desktop (md+): original 314px width and vertical position. */}
+      <span
+        className={[
+          "pointer-events-none absolute -translate-y-1/2",
+          // Mobile: 235px wide, top=192px (Figma node 1989:9179 top edge at
+          // y=117px, height=150px → centre at 117+75=192px ≈ 70% of 274px).
+          // -translate-y-1/2 positions by centre, so we supply the centre
+          // value directly rather than the top-edge value.
+          "w-[235px] top-[192px] right-[-48px]",
+          // Desktop: restore original 314px width and percentage-based top.
+          "md:w-[314px] md:top-[70%]",
+        ].join(" ")}
+      >
+        <WalletIllustration
+          tone="primary"
+          width="100%"
+          data-node-id="I1497:94566;1360:49452"
+        />
+      </span>
 
       {/* Heading block — top of the card. `relative` keeps the text above the
           absolutely-positioned illustration in the stacking order. */}


### PR DESCRIPTION
Closes #480

The striped Union graphic in ConnectWalletPromoCard renders ~314×200px and crowds the text block on mobile; the Figma mobile spec (node 1989:9179) is 235×150px anchored lower-right, clipped by the card's right edge. Resizes/repositions the graphic on mobile.