### PR TITLE
Fix #481: 16px gap between Welcome heading and first card on mobile

### DIFF
--- a/docs/user-stories/epic-463/481-welcome-heading-gap.md
+++ b/docs/user-stories/epic-463/481-welcome-heading-gap.md
@@ -1,0 +1,38 @@
+# User Story #481 — Welcome heading → content gap (mobile)
+
+**Issue:** [#481](https://github.com/eq-lab/pipeline/issues/481)
+**Epic:** #463 Home page
+**Figma ref:** frame `1989:8292`, heading node `1989:8293`
+
+---
+
+## Story
+
+As a mobile user viewing the home page at 402px viewport width,
+I want the spacing between the Welcome heading and the first card below it
+to match the Figma spec (16px),
+so the layout feels tight and purposeful rather than over-spaced.
+
+---
+
+## Acceptance criteria
+
+1. At 402px viewport width the vertical gap between the bottom of the `WelcomeHeader`
+   component and the top of the first card (Connect Wallet promo or portfolio card)
+   is **16px** (Tailwind `gap-4`).
+
+2. At 768px viewport width and above (md breakpoint) the gap remains **48px**
+   (Tailwind `gap-12`) — desktop spacing is unchanged.
+
+3. No other layout dimensions are affected.
+
+---
+
+## Test steps (QA agent)
+
+1. Open the app at http://localhost:5173/ with viewport set to 402×900px.
+2. Inspect the vertical distance between the bottom edge of the `WelcomeHeader`
+   block and the top edge of the `ConnectWalletPromoCard`.
+3. Confirm the gap is 16px.
+4. Resize the viewport to 1280×900px.
+5. Confirm the gap between `WelcomeHeader` and the outer white card is 48px.

--- a/docs/user-stories/index.md
+++ b/docs/user-stories/index.md
@@ -18,3 +18,4 @@ See [`docs/ISSUE_PROTOCOL.md` §6](../ISSUE_PROTOCOL.md) for conventions.
 | [#477 StakeCard circular Stake button size on mobile](https://github.com/eq-lab/pipeline/issues/477) | [477-stake-button-size.md](./epic-463/477-stake-button-size.md) | Initial |
 | [#478 StakeCard copy fixes (APY p.a. + senior)](https://github.com/eq-lab/pipeline/issues/478) | [478-stake-card-copy.md](./epic-463/478-stake-card-copy.md) | Initial |
 | [#480 ConnectWalletPromoCard decorative graphic size/position (mobile)](https://github.com/eq-lab/pipeline/issues/480) | [480-promo-graphic-size.md](./epic-463/480-promo-graphic-size.md) | Initial |
+| [#481 Welcome heading → content gap (mobile)](https://github.com/eq-lab/pipeline/issues/481) | [481-welcome-heading-gap.md](./epic-463/481-welcome-heading-gap.md) | Initial |

--- a/packages/frontend/src/routes/index.tsx
+++ b/packages/frontend/src/routes/index.tsx
@@ -159,7 +159,7 @@ function Home() {
       {/* Centred main column. `py-12` (48px) gives the welcome heading air
           under the TopBar; horizontal padding lets the column breathe at
           narrower widths without ever exceeding the 1200px design cap. */}
-      <main className="mx-auto flex w-full max-w-[1200px] flex-col gap-12 px-2 py-12 md:px-8">
+      <main className="mx-auto flex w-full max-w-[1200px] flex-col gap-4 px-2 py-12 md:gap-12 md:px-8">
         {/* WelcomeHeader: on mobile, pass isConnected so the greeting says
             "Welcome back" for connected users and "Welcome" otherwise.
             The prop is ignored on desktop (the desktop block renders at md+). */}


### PR DESCRIPTION
Closes #481

The mobile home page renders a 48px gap between the Welcome heading and the Connect Wallet card; the Figma mobile spec (node 1989:8293) is 16px. Reduces the heading→content spacing on mobile.