### PR TITLE
Fix #478: StakeCard copy — 'p.a.' suffix and 'senior' in subtitle

### DIFF
--- a/docs/exec-plans/tech-debt-tracker.md
+++ b/docs/exec-plans/tech-debt-tracker.md
@@ -108,6 +108,13 @@ Shortcuts, structural gaps, and deferred cleanup. Log here, don't fix inline.
 - **Impact:** The local lint gate is permanently red, so agents cannot use `lint` exit status as a pass/fail signal for their own changes; per-file checks are needed instead. New drift accumulates silently.
 - **Suggested fix:** One-shot `prettier --write` pass over the workspace in a dedicated chore PR, then make CI run the same lint script so drift fails fast.
 
+### TD-13: CI does not run the frontend unit test suite (vitest)
+- **Date:** 2026-06-04
+- **Location:** `.github/workflows/` — Lint workflow runs docs lint, Rust clippy, TS typecheck; Tests workflow runs Rust unit tests only
+- **Gap:** `yarn workspace @pipeline/frontend test` (778 vitest tests) is not executed by any CI check, so PRs can merge with a red frontend suite.
+- **Impact:** Already happened: #476 (PR #488) merged green CI but broke `src/routes/-index.test.tsx` ("clicking Sell navigates…") — tracked as Issue #492. Regressions surface only when someone runs the suite locally.
+- **Suggested fix:** Add a frontend-tests job (`yarn workspace @pipeline/frontend test --run`) to the Tests workflow and make it a required check.
+
 ---
 
 ## Post-MVP

--- a/docs/user-stories/epic-463/478-stake-card-copy.md
+++ b/docs/user-stories/epic-463/478-stake-card-copy.md
@@ -1,0 +1,53 @@
+# User Stories: #478 — StakeCard copy fixes
+
+Epic: [#463 — Home page](https://github.com/eq-lab/pipeline/issues/463)
+Issue: [#478](https://github.com/eq-lab/pipeline/issues/478)
+
+Figma references:
+- APY line node: `1989:9039` — "Earn X.XX% p.a."
+- Subtitle node: `1989:9042` — "From senior loan coupons and T-bills"
+
+---
+
+## Story 1 — APY line includes "p.a." suffix
+
+**Given** the home page renders the StakeCard (disconnected or connected, any state)
+**When** the APY figure is available from the API
+**Then** the APY line reads "Earn X.XX% p.a." (with the " p.a." suffix)
+
+### Verification steps
+
+1. Open the app (any viewport).
+2. Locate the StakeCard (the white card advertising staking yield).
+3. Find the large display-font line showing the APY.
+4. Confirm the text ends with "% p.a." — e.g. "Earn 8.42% p.a.".
+
+---
+
+## Story 2 — Subtitle reads "From senior loan coupons and T-bills"
+
+**Given** the home page renders the StakeCard (disconnected or connected, any state except State C)
+**When** the card renders
+**Then** the caption line reads "From senior loan coupons and T-bills"
+
+### Verification steps
+
+1. Open the app (any viewport, wallet disconnected or State A/B).
+2. Locate the StakeCard.
+3. Find the small muted caption below the APY line.
+4. Confirm the text is "From senior loan coupons and T-bills" (note "senior").
+
+---
+
+## Story 3 — Desktop variant uses the same strings
+
+**Given** the app is viewed at a desktop viewport (>= 768px)
+**When** the StakeCard renders
+**Then** the APY line reads "Earn X.XX% p.a." and the subtitle reads "From senior loan coupons and T-bills"
+
+### Verification steps
+
+1. Open the app at a 1280px viewport.
+2. Locate the StakeCard in the desktop grid.
+3. Confirm APY line ends with "% p.a.".
+4. Confirm subtitle includes "senior".

--- a/docs/user-stories/index.md
+++ b/docs/user-stories/index.md
@@ -16,4 +16,5 @@ See [`docs/ISSUE_PROTOCOL.md` §6](../ISSUE_PROTOCOL.md) for conventions.
 | [#475 StartHereCard Buy/Sell button height (mobile)](https://github.com/eq-lab/pipeline/issues/475) | [475-buy-sell-button-height.md](./epic-463/475-buy-sell-button-height.md) | Initial |
 | [#476 StartHereCard Sell button dimmed style](https://github.com/eq-lab/pipeline/issues/476) | [476-sell-button-dimmed.md](./epic-463/476-sell-button-dimmed.md) | Initial |
 | [#477 StakeCard circular Stake button size on mobile](https://github.com/eq-lab/pipeline/issues/477) | [477-stake-button-size.md](./epic-463/477-stake-button-size.md) | Initial |
+| [#478 StakeCard copy fixes (APY p.a. + senior)](https://github.com/eq-lab/pipeline/issues/478) | [478-stake-card-copy.md](./epic-463/478-stake-card-copy.md) | Initial |
 | [#480 ConnectWalletPromoCard decorative graphic size/position (mobile)](https://github.com/eq-lab/pipeline/issues/480) | [480-promo-graphic-size.md](./epic-463/480-promo-graphic-size.md) | Initial |

--- a/packages/frontend/src/components/StakeCard.tsx
+++ b/packages/frontend/src/components/StakeCard.tsx
@@ -136,7 +136,7 @@ export const StakeCard = React.forwardRef<HTMLDivElement, StakeCardProps>(
     const HEADING_ID = `${HEADING_ID_BASE}-${instanceId}`;
 
     const { data: statsData } = useStats();
-    const apyLabel = `Earn ${formatApy(statsData?.vaults[0]?.apy)}`;
+    const apyLabel = `Earn ${formatApy(statsData?.vaults[0]?.apy)} p.a.`;
 
     const composed = [
       // Text block top, circular CTA bottom-right — mirrors the Figma
@@ -299,7 +299,7 @@ export const StakeCard = React.forwardRef<HTMLDivElement, StakeCardProps>(
           >
             {apyLabel}
           </p>
-          {/* Subtitle — "From loan coupons and T-bills". Caption in Graphik
+          {/* Subtitle — "From senior loan coupons and T-bills". Caption in Graphik
               LC, muted ink. */}
           <p
             className={[
@@ -312,7 +312,7 @@ export const StakeCard = React.forwardRef<HTMLDivElement, StakeCardProps>(
             ].join(" ")}
             data-node-id="1497:94711"
           >
-            From loan coupons and T-bills
+            From senior loan coupons and T-bills
           </p>
         </header>
 


### PR DESCRIPTION
Closes #478

StakeCard renders "Earn 8.42%" without the "p.a." suffix and the subtitle omits "senior" ("From loan coupons and T-bills"). Figma (nodes 1989:9039 / 1989:9042) specifies "Earn 8.42% p.a." and "From senior loan coupons and T-bills".