### PR TITLE
Fix #482: 8px mobile header padding (56px TopBar)

### DIFF
--- a/docs/user-stories/epic-463/482-mobile-header-padding.md
+++ b/docs/user-stories/epic-463/482-mobile-header-padding.md
@@ -1,0 +1,53 @@
+# User stories — #482 Mobile header height/padding
+
+Epic: [#463 Home page](https://github.com/eq-lab/pipeline/issues/463)
+Issue: [#482 Mobile header height — TopBar padding](https://github.com/eq-lab/pipeline/issues/482)
+Figma: node `1989:9052` in frame `1989-8292`
+
+---
+
+## Context
+
+The TopBar component previously used 16px padding on all sides, making the
+header 73px tall at a 402px viewport. The Figma mobile spec requires 8px
+padding around the 32px logo / 40px hamburger button, giving a total header
+height of 56px. Desktop spacing (16px) is unchanged.
+
+---
+
+## Stories
+
+### S-1 — Mobile header height is 56px
+
+**Given** I open the app on a mobile viewport (≤ 402px wide)
+**When** the page loads
+**Then** the TopBar `<header>` element is 56px tall (8px top + 40px content + 8px bottom)
+
+_Verification: measure `header.getBoundingClientRect().height` in DevTools or a
+Playwright assertion at a 402px viewport._
+
+### S-2 — Desktop header height is unchanged
+
+**Given** I open the app on a desktop viewport (≥ 768px wide, i.e. `md` breakpoint)
+**When** the page loads
+**Then** the TopBar `<header>` element is 72px tall (16px top + 40px content + 16px bottom)
+
+_Verification: measure `header.getBoundingClientRect().height` at ≥ 768px._
+
+### S-3 — Responsive padding classes are present
+
+**Given** the TopBar component is rendered
+**Then** the `<header>` element's `className` contains both `p-2` and `md:p-4`
+
+_Verification: unit test in `TopBar.test.tsx` — "header element has `p-2` …
+classes"._
+
+### S-4 — Logo and hamburger button are vertically centred in the mobile header
+
+**Given** a 402px viewport
+**When** the page loads
+**Then** the Pipeline logo and the hamburger icon button are vertically centred
+within the 56px header (no visible clipping or misalignment)
+
+_Verification: visual inspection or screenshot comparison against Figma node
+`1989:9052`._

--- a/docs/user-stories/index.md
+++ b/docs/user-stories/index.md
@@ -19,3 +19,4 @@ See [`docs/ISSUE_PROTOCOL.md` §6](../ISSUE_PROTOCOL.md) for conventions.
 | [#478 StakeCard copy fixes (APY p.a. + senior)](https://github.com/eq-lab/pipeline/issues/478) | [478-stake-card-copy.md](./epic-463/478-stake-card-copy.md) | Initial |
 | [#480 ConnectWalletPromoCard decorative graphic size/position (mobile)](https://github.com/eq-lab/pipeline/issues/480) | [480-promo-graphic-size.md](./epic-463/480-promo-graphic-size.md) | Initial |
 | [#481 Welcome heading → content gap (mobile)](https://github.com/eq-lab/pipeline/issues/481) | [481-welcome-heading-gap.md](./epic-463/481-welcome-heading-gap.md) | Initial |
+| [#482 Mobile header height — TopBar padding](https://github.com/eq-lab/pipeline/issues/482) | [482-mobile-header-padding.md](./epic-463/482-mobile-header-padding.md) | Initial |

--- a/packages/frontend/src/components/TopBar.test.tsx
+++ b/packages/frontend/src/components/TopBar.test.tsx
@@ -565,6 +565,20 @@ describe("TopBar — mobile responsive classes", () => {
     vi.clearAllMocks();
   });
 
+  it("header element has `p-2` (8px mobile padding) and `md:p-4` (16px desktop padding) classes", async () => {
+    renderTopBar("/");
+
+    // The <header> element is the landmark with role="banner".
+    await waitFor(() =>
+      expect(screen.getByRole("banner")).toBeInTheDocument(),
+    );
+    const header = screen.getByRole("banner");
+    // Mobile: 8px padding (Figma 1989:9052 — 56px total = 8+40+8).
+    expect(header.className).toContain("p-2");
+    // Desktop: restore 16px padding at md breakpoint.
+    expect(header.className).toContain("md:p-4");
+  });
+
   it("desktop nav wrapper has `hidden md:flex` class (invisible below md breakpoint)", async () => {
     renderTopBar("/");
 

--- a/packages/frontend/src/components/TopBar.tsx
+++ b/packages/frontend/src/components/TopBar.tsx
@@ -136,8 +136,9 @@ export const TopBar = React.forwardRef<HTMLElement, TopBarProps>(
     const composed = [
       // Layout: flex row, three slots, justified between, vertically centred.
       "flex items-center justify-between",
-      // Padding mirrors Figma `p-16` (16px all sides).
-      "p-4",
+      // Padding: 8px on mobile (Figma 1989:9052 = 56px tall = 8px + 40px + 8px),
+      // restored to 16px on desktop (md and above).
+      "p-2 md:p-4",
       "w-full",
       // Surface tokens — no hardcoded colors.
       "bg-[var(--color-pipeline-paper)]",


### PR DESCRIPTION
Closes #482

The TopBar renders 73px tall with 16px padding on mobile; the Figma mobile spec (node 1989:9052) is 56px tall with 8px padding around the 32px logo / 40px menu button. Steps the header padding down to 8px on mobile, desktop unchanged.