### PR TITLE
Fix #492: update home route Sell test for disabled mobile Sell

### DIFF
--- a/packages/frontend/src/routes/-index.test.tsx
+++ b/packages/frontend/src/routes/-index.test.tsx
@@ -218,12 +218,18 @@ describe("Home page — disconnected state", () => {
     const user = userEvent.setup();
     renderHome();
 
-    // Both mobile and desktop blocks render StartHereCard; grab the first Sell.
+    // Both mobile and desktop blocks render StartHereCard.
+    // Since #476, the mobile Sell (index 0, renders first in DOM) is intentionally
+    // disabled + dimmed when the wallet is disconnected (mobileHomeState="empty").
+    // The desktop Sell (index 1) remains enabled and is used for navigation.
     const sellBtns = await screen.findAllByRole("button", { name: "Sell" });
-    // Sell button must not be disabled (disconnected state has no sell-disabled)
-    expect(sellBtns[0]).not.toBeDisabled();
+    expect(sellBtns.length).toBeGreaterThanOrEqual(2);
+    // Mobile instance must be disabled in disconnected state.
+    expect(sellBtns[0]).toBeDisabled();
+    // Desktop instance must be enabled.
+    expect(sellBtns[1]).not.toBeDisabled();
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    await user.click(sellBtns[0]!);
+    await user.click(sellBtns[1]!);
 
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith({


### PR DESCRIPTION
Closes #492

`src/routes/-index.test.tsx` ("clicking Sell navigates to /deposit?direction=withdraw") asserts the pre-#476 behavior: it grabs the first Sell button (the mobile instance, now intentionally disabled+dimmed when disconnected) and expects it enabled. Updates the test to assert the mobile instance is disabled and exercise the desktop instance for the navigation assertion. Restores a green frontend suite on `main`.