### PR TITLE
Fix #502: deposit suggestion bar Min chip text and mobile overflow

### DIFF
--- a/docs/user-stories/epic-498/502-deposit-min-chip.md
+++ b/docs/user-stories/epic-498/502-deposit-min-chip.md
@@ -1,0 +1,83 @@
+# User Stories: #502 — Deposit suggestion bar: Min chip reads "$1,000.00 (Min)" and chip row overflows the card on mobile
+
+Epic: [#498 — Deposit/withdraw page](https://github.com/eq-lab/pipeline/issues/498)
+Issue: [#502](https://github.com/eq-lab/pipeline/issues/502)
+Figma: [node 1993:7915 in frame 1993-7701](https://www.figma.com/design/A43rjYYjSwdTmiwwf5cx5n/Pipeline?node-id=1993-7701&m=dev)
+
+The Min chip in the suggestion bar of the deposit conversion card must display whole-dollar
+amounts without the `.00` suffix (e.g. `$1,000 (Min)` not `$1,000.00 (Min)`), matching
+the Figma spec. Dropping the two decimal digits recovers ~25 px so all four chips
+(`$1,000 (Min)`, `$5,000`, `$10,000`, `Max`) fit inside the card on a 402 px mobile viewport
+without overflow.
+
+---
+
+## Story 1: Min chip shows no decimal places for a whole-dollar minimum deposit (mobile)
+
+**Persona:** A mobile user (viewport 402×874) on the `/deposit` page.
+
+**Pre-conditions:** App running; wallet connected with USDC balance ≥ minDeposit; minDeposit is an exact whole-dollar amount (e.g. 1,000 USDC at 6 decimals).
+
+**Steps:**
+
+1. Open `/deposit` at 402 px wide.
+2. Locate the suggestion-bar chip row inside the USDC input card.
+3. Read the label on the first chip.
+
+**Expected outcomes:**
+
+- The first chip reads `$1,000 (Min)` — no `.00` suffix.
+- All four chips (`$1,000 (Min)`, `$5,000`, `$10,000`, `Max`) are fully visible within the gray container; none are clipped at the right edge of the 402 px viewport.
+
+---
+
+## Story 2: Clicking the Min chip fills the input with the correct amount
+
+**Persona:** A user on the deposit page with minDeposit = 1,000 USDC.
+
+**Pre-conditions:** App running; wallet connected; minDeposit = 1,000 USDC (1,000,000,000 raw at 6 decimals).
+
+**Steps:**
+
+1. Open `/deposit`.
+2. Click the `$1,000 (Min)` chip.
+3. Observe the numeric input field value.
+
+**Expected outcomes:**
+
+- The numeric input is populated with the formatted minDeposit value (`1000.00`).
+- The chip label itself is `$1,000 (Min)` (no decimal places in the chip label).
+
+---
+
+## Story 3: Min chip label reflects a non-standard whole-dollar minimum (e.g. $250)
+
+**Persona:** A user on a deployment where minDeposit = 250 USDC.
+
+**Pre-conditions:** App running; minDeposit mock set to 250,000,000 (250 USDC at 6 decimals).
+
+**Steps:**
+
+1. Open `/deposit`.
+2. Observe the first chip label.
+
+**Expected outcomes:**
+
+- The chip reads `$250 (Min)` — not `$250.00 (Min)`.
+
+---
+
+## Story 4: Min chip label retains cents when minimum has a fractional component
+
+**Persona:** A user on a deployment where minDeposit has a non-zero fractional part (e.g. 1,000.50 USDC).
+
+**Pre-conditions:** App running; minDeposit mock set to 1,000,500,000 (1,000.50 USDC at 6 decimals).
+
+**Steps:**
+
+1. Open `/deposit`.
+2. Observe the first chip label.
+
+**Expected outcomes:**
+
+- The chip reads `$1,000.50 (Min)` — fractional cents are retained when the amount is not a whole number.

--- a/docs/user-stories/index.md
+++ b/docs/user-stories/index.md
@@ -10,6 +10,14 @@ fidelity is verified by the QA agent's Figma comparison, not by story execution.
 
 ---
 
+## Epic #498 — Deposit/withdraw page
+
+| Issue | Doc | Status |
+|-------|-----|--------|
+| [#502 Deposit suggestion bar: Min chip reads "$1,000.00 (Min)" and chip row overflows on mobile](https://github.com/eq-lab/pipeline/issues/502) | [502-deposit-min-chip.md](./epic-498/502-deposit-min-chip.md) | Initial |
+
+---
+
 ## Epic #463 — Home page
 
 | Issue | Doc | Status |

--- a/packages/frontend/src/lib/usdc.ts
+++ b/packages/frontend/src/lib/usdc.ts
@@ -57,8 +57,8 @@ export function formatUsdc(
 
 /**
  * Same as `formatUsdc` but prefixes the result with `"$"`.
- * Used for quick-amount chip labels (`"$1,000.00 (Min)"`) and the low-balance
- * banner subtitle (`"Minimum amount — $1,000.00 USDC"`).
+ * Used for the low-balance banner subtitle
+ * (`"Minimum amount — $1,000.00 USDC"`).
  *
  * Returns `"—"` when `decimals` is `undefined`.
  */
@@ -67,5 +67,36 @@ export function formatUsdcCurrency(
   decimals: number | undefined,
 ): string {
   if (decimals === undefined) return "—";
+  return `$${formatUsdc(value, decimals)}`;
+}
+
+// Intl formatter with no fractional digits — used for chip labels where
+// whole-dollar amounts like "$1,000" are preferred over "$1,000.00".
+const compactCurrencyFormatter = new Intl.NumberFormat("en-US", {
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 0,
+});
+
+/**
+ * Same as `formatUsdcCurrency` but omits the fractional part when the value
+ * is a whole number of dollars (i.e. no cents).
+ * Used for quick-amount chip labels (`"$1,000 (Min)"` instead of `"$1,000.00 (Min)"`).
+ *
+ * When cents are non-zero the result still shows two decimal places.
+ *
+ * Returns `"—"` when `decimals` is `undefined`.
+ */
+export function formatUsdcCurrencyCompact(
+  value: bigint,
+  decimals: number | undefined,
+): string {
+  if (decimals === undefined) return "—";
+  // Compute the number of sub-units per dollar (10^decimals).
+  const scale = BigInt(10 ** decimals);
+  // If the value is an exact multiple of the scale there are no fractional cents.
+  if (value % scale === 0n) {
+    const dollars = Number(value / scale);
+    return `$${compactCurrencyFormatter.format(dollars)}`;
+  }
   return `$${formatUsdc(value, decimals)}`;
 }

--- a/packages/frontend/src/routes/-deposit.test.tsx
+++ b/packages/frontend/src/routes/-deposit.test.tsx
@@ -681,7 +681,7 @@ describe("Deposit page — quick-amount chips", () => {
     renderDeposit();
 
     const minChip = await screen.findByRole("button", {
-      name: /\$1,000\.00 \(Min\)/,
+      name: /\$1,000 \(Min\)/,
     });
     await user.click(minChip);
 
@@ -886,7 +886,7 @@ describe("Deposit page — Min chip label reflects live minDeposit", () => {
     renderDeposit();
     await waitFor(() => {
       expect(
-        screen.getByRole("button", { name: /\$250\.00 \(Min\)/ }),
+        screen.getByRole("button", { name: /\$250 \(Min\)/ }),
       ).toBeInTheDocument();
     });
   });

--- a/packages/frontend/src/routes/deposit.tsx
+++ b/packages/frontend/src/routes/deposit.tsx
@@ -20,7 +20,12 @@ import {
 } from "@/wallet";
 import { useRequests, useDepositVoucher, useWithdrawalVoucher } from "@/api";
 import { ENV } from "@/lib/env";
-import { parseUsdc, formatUsdc, formatUsdcCurrency } from "@/lib/usdc";
+import {
+  parseUsdc,
+  formatUsdc,
+  formatUsdcCurrency,
+  formatUsdcCurrencyCompact,
+} from "@/lib/usdc";
 import { useToast } from "@/lib/toast";
 
 /**
@@ -760,7 +765,7 @@ function Deposit() {
                     {
                       label:
                         minDeposit !== undefined && decimals !== undefined
-                          ? `${formatUsdcCurrency(minDeposit, decimals)} (Min)`
+                          ? `${formatUsdcCurrencyCompact(minDeposit, decimals)} (Min)`
                           : "Min",
                       disabled: isAmountLocked,
                     },

--- a/packages/ui/src/components/QuickAmountChip/QuickAmountChip.tsx
+++ b/packages/ui/src/components/QuickAmountChip/QuickAmountChip.tsx
@@ -24,7 +24,7 @@ import React from "react";
  */
 
 export interface QuickAmountChipProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  /** Label text, e.g. "$1,000 (Min)", "$5,000", "Max". */
+  /** Label text, e.g. "$1,000 (Min)", "$5,000", "Max". Whole-dollar amounts omit the ".00" suffix. */
   label: string;
   /** Whether this chip is currently selected. */
   selected?: boolean;


### PR DESCRIPTION
Closes #502

Deposit suggestion bar: fix the Min chip reading "$1,000.00 (Min)" and the chip row overflowing the card on mobile.