### PR TITLE
Fix #503: below-min deposit banner matches Figma

### DIFF
--- a/docs/user-stories/epic-498/503-below-min-banner.md
+++ b/docs/user-stories/epic-498/503-below-min-banner.md
@@ -1,0 +1,84 @@
+# User Stories: #503 — Below-min deposit banner visual fixes
+
+Epic: [#498 — Deposit/withdraw page](https://github.com/eq-lab/pipeline/issues/498)
+Issue: [#503](https://github.com/eq-lab/pipeline/issues/503)
+
+Viewport: 402×874 (mobile). Mock scenario: `connected-below-min` (USDC balance below minimum deposit).
+
+---
+
+## Story 1: Banner title uses sans-serif body style
+
+**Persona:** A connected LP whose USDC balance is below the minimum deposit threshold, viewing the deposit page on mobile.
+
+**Pre-conditions:**
+
+- App is running at `/deposit`.
+- Wallet is connected with a USDC balance below the minimum deposit amount.
+- Viewport width is 402px.
+
+**Steps:**
+
+1. Load `/deposit` in a 402px-wide viewport with a below-min USDC balance.
+2. Observe the yellow banner that replaces the steps card.
+3. Read the banner title text.
+
+**Expected outcomes:**
+
+- The banner title "Add funds to your USDC balance" is rendered in the body sans-serif typeface (Graphik LC), not in Besley serif.
+- The title uses the body text size (16px/22px), not the heading-s size (20px/30px).
+
+---
+
+## Story 2: Banner subtitle shows whole-number minimum without currency symbol
+
+**Persona:** Same LP as Story 1.
+
+**Pre-conditions:** Same as Story 1.
+
+**Steps:**
+
+1. Load `/deposit` in a 402px-wide viewport with a below-min USDC balance.
+2. Read the banner subtitle text.
+
+**Expected outcomes:**
+
+- The subtitle reads "Minimum amount — 1,000 USDC" (no `$` prefix, no decimal places).
+- The minimum value is formatted with a thousands separator (comma).
+
+---
+
+## Story 3: "Copy Address" button stays on a single line
+
+**Persona:** Same LP as Story 1.
+
+**Pre-conditions:** Same as Story 1.
+
+**Steps:**
+
+1. Load `/deposit` in a 402px-wide viewport with a below-min USDC balance.
+2. Observe the "Copy Address" button in the banner.
+
+**Expected outcomes:**
+
+- The button label "Copy Address" renders on a single line without wrapping.
+- The overall banner height is approximately 92px (matching the Figma design), not 150px.
+
+---
+
+## Story 4: "Copy Address" button copies the wallet address
+
+**Persona:** Same LP as Story 1.
+
+**Pre-conditions:** Same as Story 1.
+
+**Steps:**
+
+1. Load `/deposit` in a 402px-wide viewport with a below-min USDC balance.
+2. Click or tap the "Copy Address" button.
+3. Observe the button label change.
+
+**Expected outcomes:**
+
+- After clicking, the button label temporarily changes to "Copied".
+- The wallet address is written to the clipboard.

--- a/docs/user-stories/index.md
+++ b/docs/user-stories/index.md
@@ -12,13 +12,21 @@ fidelity is verified by the QA agent's Figma comparison, not by story execution.
 
 ## Epic #463 — Home page
 
-| Issue | Doc | Status |
-|-------|-----|--------|
-| [#247 RecentActivityCard connected state shows recent requests](https://github.com/eq-lab/pipeline/issues/247) | [247-recent-activity-connected.md](./epic-463/247-recent-activity-connected.md) | Migrated from `docs/STORIES.md` |
+| Issue                                                                                                                    | Doc                                                                                               | Status                          |
+| ------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------- | ------------------------------- |
+| [#247 RecentActivityCard connected state shows recent requests](https://github.com/eq-lab/pipeline/issues/247)           | [247-recent-activity-connected.md](./epic-463/247-recent-activity-connected.md)                   | Migrated from `docs/STORIES.md` |
 | [#250 Home Connect-Wallet section: wired Connect + Portfolio placeholder](https://github.com/eq-lab/pipeline/issues/250) | [250-home-connect-portfolio-placeholder.md](./epic-463/250-home-connect-portfolio-placeholder.md) | Migrated from `docs/STORIES.md` |
-| [#372 Home: Recent activity "View All" button affordance](https://github.com/eq-lab/pipeline/issues/372) | [372-recent-activity-view-all.md](./epic-463/372-recent-activity-view-all.md) | Migrated from `docs/STORIES.md` |
-| [#389 Home Portfolio chart: stacked-bars + hover tooltip](https://github.com/eq-lab/pipeline/issues/389) | [389-portfolio-stacked-bars-chart.md](./epic-463/389-portfolio-stacked-bars-chart.md) | Migrated from `docs/STORIES.md` |
-| [#465 Mobile home base layout + wallet-not-connected state](https://github.com/eq-lab/pipeline/issues/465) | [465-mobile-home-base.md](./epic-463/465-mobile-home-base.md) | Initial |
-| [#466 Mobile home page balance states (0/0, has PLUSD, has sPLUSD)](https://github.com/eq-lab/pipeline/issues/466) | [466-mobile-home-balance-states.md](./epic-463/466-mobile-home-balance-states.md) | Initial |
-| [#476 StartHereCard Sell button dimmed style](https://github.com/eq-lab/pipeline/issues/476) | [476-sell-button-dimmed.md](./epic-463/476-sell-button-dimmed.md) | Initial |
-| [#478 StakeCard copy fixes (APY p.a. + senior)](https://github.com/eq-lab/pipeline/issues/478) | [478-stake-card-copy.md](./epic-463/478-stake-card-copy.md) | Initial |
+| [#372 Home: Recent activity "View All" button affordance](https://github.com/eq-lab/pipeline/issues/372)                 | [372-recent-activity-view-all.md](./epic-463/372-recent-activity-view-all.md)                     | Migrated from `docs/STORIES.md` |
+| [#389 Home Portfolio chart: stacked-bars + hover tooltip](https://github.com/eq-lab/pipeline/issues/389)                 | [389-portfolio-stacked-bars-chart.md](./epic-463/389-portfolio-stacked-bars-chart.md)             | Migrated from `docs/STORIES.md` |
+| [#465 Mobile home base layout + wallet-not-connected state](https://github.com/eq-lab/pipeline/issues/465)               | [465-mobile-home-base.md](./epic-463/465-mobile-home-base.md)                                     | Initial                         |
+| [#466 Mobile home page balance states (0/0, has PLUSD, has sPLUSD)](https://github.com/eq-lab/pipeline/issues/466)       | [466-mobile-home-balance-states.md](./epic-463/466-mobile-home-balance-states.md)                 | Initial                         |
+| [#476 StartHereCard Sell button dimmed style](https://github.com/eq-lab/pipeline/issues/476)                             | [476-sell-button-dimmed.md](./epic-463/476-sell-button-dimmed.md)                                 | Initial                         |
+| [#478 StakeCard copy fixes (APY p.a. + senior)](https://github.com/eq-lab/pipeline/issues/478)                           | [478-stake-card-copy.md](./epic-463/478-stake-card-copy.md)                                       | Initial                         |
+
+---
+
+## Epic #498 — Deposit/withdraw page
+
+| Issue                                                                                                                                    | Doc                                                           | Status  |
+| ---------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- | ------- |
+| [#503 Below-min deposit banner: serif title, wrapped Copy Address, wrong subtitle format](https://github.com/eq-lab/pipeline/issues/503) | [503-below-min-banner.md](./epic-498/503-below-min-banner.md) | Initial |

--- a/packages/frontend/src/lib/format.ts
+++ b/packages/frontend/src/lib/format.ts
@@ -15,6 +15,13 @@ const tokenFormatter = new Intl.NumberFormat("en-US", {
   maximumFractionDigits: 2,
 });
 
+// Whole-number Intl formatter (no fraction digits) — used for amounts where
+// cents are irrelevant, e.g. the below-min banner subtitle ("1,000 USDC").
+const tokenFormatterWhole = new Intl.NumberFormat("en-US", {
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 0,
+});
+
 /**
  * Formats a raw bigint (or decimal bigint string) into a human-readable
  * decimal string with exactly two fraction digits.
@@ -33,6 +40,23 @@ export function formatTokenAmount(
   const value = typeof raw === "string" ? BigInt(raw) : raw;
   const float = parseFloat(formatUnits(value, decimals));
   return tokenFormatter.format(float);
+}
+
+/**
+ * Same as `formatTokenAmount` but rounds to a whole number (no fraction
+ * digits). Used where the design omits cents, e.g. "1,000 USDC".
+ *
+ * Examples:
+ *   formatTokenAmountWhole(1_000_000_000n, 6)  → "1,000"
+ *   formatTokenAmountWhole(1_500_000n, 6)       → "2"   (rounds half-up)
+ */
+export function formatTokenAmountWhole(
+  raw: bigint | string,
+  decimals: number,
+): string {
+  const value = typeof raw === "string" ? BigInt(raw) : raw;
+  const float = parseFloat(formatUnits(value, decimals));
+  return tokenFormatterWhole.format(float);
 }
 
 /**

--- a/packages/frontend/src/lib/usdc.ts
+++ b/packages/frontend/src/lib/usdc.ts
@@ -13,7 +13,7 @@
  * `src/wallet/**`, so we consume them through the wallet module boundary.
  */
 import { parseUnits } from "@/wallet";
-import { formatTokenAmount } from "./format";
+import { formatTokenAmount, formatTokenAmountWhole } from "./format";
 
 /**
  * Parses a raw decimal string (e.g. `"1000"`, `"1000.50"`) into a bigint
@@ -57,8 +57,7 @@ export function formatUsdc(
 
 /**
  * Same as `formatUsdc` but prefixes the result with `"$"`.
- * Used for quick-amount chip labels (`"$1,000.00 (Min)"`) and the low-balance
- * banner subtitle (`"Minimum amount — $1,000.00 USDC"`).
+ * Used for quick-amount chip labels (`"$1,000.00 (Min)"`).
  *
  * Returns `"—"` when `decimals` is `undefined`.
  */
@@ -68,4 +67,19 @@ export function formatUsdcCurrency(
 ): string {
   if (decimals === undefined) return "—";
   return `$${formatUsdc(value, decimals)}`;
+}
+
+/**
+ * Formats a raw bigint as a whole-number string (no `$`, no fraction digits).
+ * Used where the design omits cents, e.g. the below-min banner subtitle
+ * (`"Minimum amount — 1,000 USDC"`).
+ *
+ * Returns `"—"` when `decimals` is `undefined`.
+ */
+export function formatUsdcWhole(
+  value: bigint,
+  decimals: number | undefined,
+): string {
+  if (decimals === undefined) return "—";
+  return formatTokenAmountWhole(value, decimals);
 }

--- a/packages/frontend/src/routes/-deposit.test.tsx
+++ b/packages/frontend/src/routes/-deposit.test.tsx
@@ -610,8 +610,7 @@ describe("Deposit page — insufficient balance banner", () => {
     await waitFor(() => {
       expect(
         screen.getByText(
-          (content) =>
-            content.includes("$1,000.00") && content.includes("USDC"),
+          (content) => content.includes("1,000") && content.includes("USDC"),
         ),
       ).toBeInTheDocument();
     });

--- a/packages/frontend/src/routes/deposit.tsx
+++ b/packages/frontend/src/routes/deposit.tsx
@@ -20,7 +20,12 @@ import {
 } from "@/wallet";
 import { useRequests, useDepositVoucher, useWithdrawalVoucher } from "@/api";
 import { ENV } from "@/lib/env";
-import { parseUsdc, formatUsdc, formatUsdcCurrency } from "@/lib/usdc";
+import {
+  parseUsdc,
+  formatUsdc,
+  formatUsdcCurrency,
+  formatUsdcWhole,
+} from "@/lib/usdc";
 import { useToast } from "@/lib/toast";
 
 /**
@@ -830,18 +835,19 @@ function Deposit() {
             className="flex flex-row items-center justify-between gap-4"
           >
             <div className="flex flex-col items-start gap-1">
-              <p className="font-[family-name:var(--font-display)] text-[length:var(--text-pipeline-heading-s)]">
+              <p className="font-[family-name:var(--font-body)] text-[length:var(--text-pipeline-body)]">
                 Add funds to your USDC balance
               </p>
               <p className="font-[family-name:var(--font-body)] text-[length:var(--text-pipeline-caption)] text-[color:var(--color-pipeline-ink-muted)]">
                 Minimum amount —{" "}
                 {minDeposit !== undefined && decimals !== undefined
-                  ? `${formatUsdcCurrency(minDeposit, decimals)} USDC`
+                  ? `${formatUsdcWhole(minDeposit, decimals)} USDC`
                   : "—"}
               </p>
             </div>
             <Button
               variant="primary-dark"
+              className="whitespace-nowrap"
               onClick={copyAddress}
               disabled={!address}
             >


### PR DESCRIPTION
Closes #503

Below-min deposit banner: fix serif title, wrapped Copy Address button, and "$1,000.00 USDC" subtitle to match Figma.