### PR TITLE
Fix #505: StepsCard mobile wraps labels and uses 32px buttons

### DIFF
--- a/docs/user-stories/epic-498/505-stepscard-mobile.md
+++ b/docs/user-stories/epic-498/505-stepscard-mobile.md
@@ -1,0 +1,66 @@
+# User Stories: #505 — StepsCard mobile: step labels truncate with ellipsis and buttons are 48px tall; Figma wraps labels and uses 32px buttons
+
+Epic: [#498 — Deposit/withdraw page](https://github.com/eq-lab/pipeline/issues/498)
+Issue: [#505](https://github.com/eq-lab/pipeline/issues/505)
+Figma: [node 1993:7964 in frame 1993-7701](https://www.figma.com/design/A43rjYYjSwdTmiwwf5cx5n/Pipeline?node-id=1993-7701&m=dev)
+
+On mobile (402×874 viewport) the 3-step card's step labels must wrap to two lines when the
+text is too wide, matching the Figma spec. The action buttons (Approve / Confirm / Claim)
+must be 32 px tall (h-8), not the default 48 px (h-12) used for the primary-dark variant.
+
+---
+
+## Story 1: Long step label wraps to two lines on mobile (no ellipsis)
+
+**Persona:** A mobile user (viewport 402×874) on the `/deposit` page in the `connected-allowance-zero` scenario.
+
+**Pre-conditions:** App running; wallet connected with USDC balance ≥ minDeposit; deposit state requires both Approve and Confirm steps.
+
+**Steps:**
+
+1. Open `/deposit` at 402 px wide.
+2. Scroll to the StepsCard (3-step card near the bottom of the deposit form).
+3. Read the label of Step 1.
+
+**Expected outcomes:**
+
+- Step 1 label "Allow Pipeline to use USDC" is fully visible, wrapping to a second line if necessary — no ellipsis (`…`) is shown.
+- Step 2 label "Confirm USDC transaction" (or equivalent) is similarly fully readable without truncation.
+- No label is clipped at the right edge.
+
+---
+
+## Story 2: Action buttons in StepsCard are 32px tall on mobile
+
+**Persona:** A mobile user (viewport 402×874) on the `/deposit` page.
+
+**Pre-conditions:** App running; wallet connected; at least one step is in the idle (active) state so its action button is visible.
+
+**Steps:**
+
+1. Open `/deposit` at 402 px wide.
+2. Locate the StepsCard.
+3. Inspect the rendered height of the action button (e.g. "Approve").
+
+**Expected outcomes:**
+
+- The action button renders at 32 px tall (matching Figma node 1993:7964).
+- The button is not 48 px tall (the primary-dark default).
+- Button width remains 88 px.
+
+---
+
+## Story 3: Step number badge and button align to the top of a wrapping label
+
+**Persona:** A mobile user on the `/deposit` page with a long step label that wraps.
+
+**Pre-conditions:** Same as Story 1 — long label causes a two-line wrap.
+
+**Steps:**
+
+1. Open `/deposit` at 402 px wide.
+2. Observe the vertical alignment of the numbered badge (e.g. "1") and the action button relative to the label.
+
+**Expected outcomes:**
+
+- Both the numbered badge and the action button are top-aligned with the first line of the step label, not vertically centered relative to the full label height.

--- a/docs/user-stories/index.md
+++ b/docs/user-stories/index.md
@@ -10,14 +10,6 @@ fidelity is verified by the QA agent's Figma comparison, not by story execution.
 
 ---
 
-## Epic #498 — Deposit/withdraw page
-
-| Issue | Doc | Status |
-|-------|-----|--------|
-| [#502 Deposit suggestion bar: Min chip reads "$1,000.00 (Min)" and chip row overflows on mobile](https://github.com/eq-lab/pipeline/issues/502) | [502-deposit-min-chip.md](./epic-498/502-deposit-min-chip.md) | Initial |
-
----
-
 ## Epic #463 — Home page
 
 | Issue                                                                                                                    | Doc                                                                                               | Status                          |
@@ -35,6 +27,8 @@ fidelity is verified by the QA agent's Figma comparison, not by story execution.
 
 ## Epic #498 — Deposit/withdraw page
 
-| Issue                                                                                                                                    | Doc                                                           | Status  |
-| ---------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- | ------- |
-| [#503 Below-min deposit banner: serif title, wrapped Copy Address, wrong subtitle format](https://github.com/eq-lab/pipeline/issues/503) | [503-below-min-banner.md](./epic-498/503-below-min-banner.md) | Initial |
+| Issue                                                                                                                                                                          | Doc                                                           | Status  |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------- | ------- |
+| [#502 Deposit suggestion bar: Min chip reads "$1,000.00 (Min)" and chip row overflows on mobile](https://github.com/eq-lab/pipeline/issues/502)                                | [502-deposit-min-chip.md](./epic-498/502-deposit-min-chip.md) | Initial |
+| [#503 Below-min deposit banner: serif title, wrapped Copy Address, wrong subtitle format](https://github.com/eq-lab/pipeline/issues/503)                                       | [503-below-min-banner.md](./epic-498/503-below-min-banner.md) | Initial |
+| [#505 StepsCard mobile: step labels truncate with ellipsis and buttons are 48px tall; Figma wraps labels and uses 32px buttons](https://github.com/eq-lab/pipeline/issues/505) | [505-stepscard-mobile.md](./epic-498/505-stepscard-mobile.md) | Initial |

--- a/packages/frontend/src/routes/-deposit.test.tsx
+++ b/packages/frontend/src/routes/-deposit.test.tsx
@@ -1029,8 +1029,8 @@ describe("Deposit page — three-step flow", () => {
         .find((b) => b.getAttribute("aria-busy") === "true");
       // Walk up to the StepRow root div (the container that gets opacity-30).
       // StepRow structure: div.rootClasses > ... > div.shrink-0 > Button
-      const rowRoot = busyBtn?.closest(".flex.items-center.gap-3");
-      expect(rowRoot).toBeDefined();
+      const rowRoot = busyBtn?.closest(".flex.items-start.gap-3");
+      expect(rowRoot).not.toBeNull();
       expect(rowRoot?.className).not.toContain("opacity-30");
     });
   });

--- a/packages/ui/src/components/StepRow/StepRow.stories.tsx
+++ b/packages/ui/src/components/StepRow/StepRow.stories.tsx
@@ -199,3 +199,51 @@ export const Pair: Story = {
     </div>
   ),
 };
+
+/* -------------------------------------------------------------------------- */
+/*  Mobile — 402px viewport with long labels that wrap (Issue #505)           */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Verifies fix for Issue #505: long step labels must wrap to two lines at
+ * 402px mobile width instead of truncating with ellipsis.
+ * Action buttons must render at 32px (h-8) not 48px.
+ */
+export const MobileLongLabels: Story = {
+  name: "Mobile 402px — long labels wrap (Issue #505)",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Fix #505 regression test: at 402 px mobile width, " +
+          '"Allow Pipeline to use USDC" and "Confirm USDC transaction" must ' +
+          "wrap to two lines (no ellipsis). Action buttons must be 32 px tall.",
+      },
+    },
+  },
+  render: () => (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 8,
+        padding: 16,
+        background: "var(--color-pipeline-paper)",
+        width: 370, // card interior at 402px viewport with 8px page margins × 2
+      }}
+    >
+      <StepRow
+        step={1}
+        label="Allow Pipeline to use USDC"
+        actionLabel="Approve"
+        disabled
+      />
+      <StepRow
+        step={2}
+        label="Confirm USDC transaction"
+        actionLabel="Confirm"
+        disabled
+      />
+    </div>
+  ),
+};

--- a/packages/ui/src/components/StepRow/StepRow.tsx
+++ b/packages/ui/src/components/StepRow/StepRow.tsx
@@ -48,7 +48,9 @@ export interface StepRowProps extends React.HTMLAttributes<HTMLDivElement> {
 }
 
 const rootClasses = [
-  "flex items-center gap-3",
+  // items-start so the step badge and action button align to the top of the
+  // label when it wraps to two lines on mobile (402px viewport).
+  "flex items-start gap-3",
   "w-full",
   "transition-opacity duration-150",
 ].join(" ");
@@ -77,7 +79,9 @@ const labelClasses = [
   "leading-[var(--text-pipeline-body--line-height)]",
   "font-[var(--font-weight-regular)]",
   "text-[color:var(--color-pipeline-ink)]",
-  "truncate",
+  // Allow labels to wrap on mobile so long step descriptions
+  // (e.g. "Allow Pipeline to use USDC") remain fully readable.
+  // Previously `truncate` clipped them at 402px mobile width.
 ].join(" ");
 
 export const StepRow = React.forwardRef<HTMLDivElement, StepRowProps>(
@@ -159,8 +163,10 @@ export const StepRow = React.forwardRef<HTMLDivElement, StepRowProps>(
               disabled={disabled || loading}
               onClick={onAction}
               /* Override default 48px height to the 32px height used in the
-                 step card (Figma button height: min-h-[32px] w-[88px]). */
-              className="h-8 w-22 min-w-0 text-[length:var(--text-pipeline-body)]"
+                 step card (Figma button height: 32px × 88px).
+                 Uses !h-8 (important modifier) so the override reliably beats
+                 the h-12 from the primary-dark variant class in Tailwind v4. */
+              className="!h-8 w-22 min-w-0 text-[length:var(--text-pipeline-body)]"
               aria-busy={loading}
             >
               {loading ? (


### PR DESCRIPTION
Closes #505

StepsCard mobile: step labels wrap instead of truncating with ellipsis; buttons are 32px tall per Figma (currently 48px).