### PR TITLE
Fix #547: mobile /deposit coin icon hidden below md

### DIFF
--- a/docs/user-stories/epic-498/501-deposit-header-mobile.md
+++ b/docs/user-stories/epic-498/501-deposit-header-mobile.md
@@ -48,3 +48,32 @@ Figma (mobile): node 1993:7911 | Figma (desktop): node 1498:100130
 
 - There is exactly one `<h2>` element containing the deposit heading text at every
   viewport width (no duplicate headings introduced by the responsive implementation).
+
+---
+
+## Story 4 — CoinIcon inline style does not defeat responsive hide (Issue #547 regression)
+
+**As a** mobile user on the `/deposit` page,
+**I want** the PLUSD coin icon to remain hidden below 768 px even after future
+refactors of `CoinIcon`,
+**so that** the mobile layout matches the Figma spec and is not silently broken by
+changes to the component's default display property.
+
+### Acceptance criteria
+
+- `CoinIcon` does **not** set `display` via an inline `style` attribute.  Inline
+  styles override Tailwind utility classes (including `hidden`) regardless of
+  specificity order, so this must remain absent.
+- `CoinIcon` renders with a `block` CSS class by default so standalone usage
+  (without explicit `className`) still shows the icon as a block element.
+- When `DepositHeader` renders `<CoinIcon className="hidden md:block" …>`, the
+  `hidden` class is present on the `<img>` element in the DOM.
+- At a viewport narrower than 768 px the coin icon computes `display:none`
+  (i.e. `getComputedStyle(icon).display === "none"`).
+- At 768 px and wider the coin icon computes `display:block`.
+
+### Automated regression (CoinIcon.test.tsx — Group 5)
+
+The regression is guarded by the "CoinIcon — responsive display (Issue #547
+regression)" describe block in
+`packages/frontend/src/components/CoinIcon.test.tsx`.

--- a/packages/frontend/src/components/CoinIcon.test.tsx
+++ b/packages/frontend/src/components/CoinIcon.test.tsx
@@ -141,3 +141,42 @@ describe("CoinIcon — accessibility", () => {
     expect(img?.getAttribute("aria-label")).toBe("USDC coin");
   });
 });
+
+// ── Group 5: Responsive display — Issue #547 regression ──────────────────────
+//
+// Regression guard: CoinIcon must NOT hard-code `display:block` in an inline
+// style.  Inline styles win over Tailwind utility classes, so callers could
+// never use `className="hidden md:block"` to hide the icon on mobile.
+// The fix moves `display` into the className ("block" default) so callers can
+// override it with responsive utilities.
+
+describe("CoinIcon — responsive display (Issue #547 regression)", () => {
+  it("renders with class 'block' by default (no inline display style)", () => {
+    const { container } = render(<CoinIcon token="plusd" size="lg" />);
+    const img = container.querySelector("img");
+    expect(img).not.toBeNull();
+    // Must have the default "block" class
+    expect(img?.classList.contains("block")).toBe(true);
+    // Must NOT set display via inline style (would defeat responsive hiding)
+    expect(img?.style.display).toBe("");
+  });
+
+  it("merges caller className with default 'block' — hidden md:block is present", () => {
+    const { container } = render(
+      <CoinIcon token="plusd" size="lg" className="hidden md:block" />,
+    );
+    const img = container.querySelector("img");
+    expect(img).not.toBeNull();
+    // Both the default 'block' and the caller's classes must appear
+    expect(img?.classList.contains("block")).toBe(true);
+    expect(img?.classList.contains("hidden")).toBe(true);
+    // Still no inline display override
+    expect(img?.style.display).toBe("");
+  });
+
+  it("preserves flexShrink:0 in the inline style", () => {
+    const { container } = render(<CoinIcon token="plusd" size="lg" />);
+    const img = container.querySelector("img");
+    expect(img?.style.flexShrink).toBe("0");
+  });
+});

--- a/packages/ui/src/components/CoinIcon/CoinIcon.tsx
+++ b/packages/ui/src/components/CoinIcon/CoinIcon.tsx
@@ -47,6 +47,7 @@ export const CoinIcon = React.forwardRef<HTMLImageElement, CoinIconProps>(
     {
       token,
       size = "md",
+      className,
       "aria-label": ariaLabel,
       "aria-hidden": ariaHidden,
       ...rest
@@ -64,6 +65,14 @@ export const CoinIcon = React.forwardRef<HTMLImageElement, CoinIconProps>(
     // Decorative by default; becomes meaningful when caller supplies aria-label.
     const isHidden = ariaLabel == null ? true : (ariaHidden ?? false);
 
+    // "block" is the default display; callers can override it with responsive
+    // Tailwind utilities (e.g. className="hidden md:block") because class-based
+    // rules share the same specificity and the caller's classes appear later in
+    // the stylesheet.  We deliberately do NOT put display in the inline style —
+    // inline styles have higher specificity than utility classes, which would
+    // prevent responsive hiding from working (Issue #547).
+    const composedClassName = ["block", className].filter(Boolean).join(" ");
+
     return (
       <img
         ref={ref}
@@ -74,7 +83,8 @@ export const CoinIcon = React.forwardRef<HTMLImageElement, CoinIconProps>(
         aria-hidden={isHidden || undefined}
         aria-label={ariaLabel}
         role={ariaLabel != null ? "img" : undefined}
-        style={{ display: "block", flexShrink: 0 }}
+        className={composedClassName}
+        style={{ flexShrink: 0 }}
         {...rest}
       />
     );


### PR DESCRIPTION
Closes #547

Mobile `/deposit` still renders the PLUSD coin icon above the "1:1 Conversion" heading — the inline `display:block` on `CoinIcon` defeats the Tailwind `hidden md:block` from `DepositHeader`.

Trivial-frontend flow.