### PR TITLE
Fix EmptyState comment leaking Tailwind class syntax to v4 scanner

### DIFF
--- a/packages/ui/src/components/EmptyState/EmptyState.tsx
+++ b/packages/ui/src/components/EmptyState/EmptyState.tsx
@@ -57,8 +57,9 @@ const rootClasses = [
 ].join(" ");
 
 // Caption row — body size, muted ink, centred. Matches Figma node 1497:94665
-// (`leading-[var(--font/line-height/body,22px)]`,
-//  `text-[color:var(--content-test/secondary,…)]`).
+// (Figma tokens "font/line-height/body" 22px and "content-test/secondary").
+// NB: don't write Tailwind class syntax in comments — the v4 scanner picks it
+// up and emits invalid CSS for slash-containing var() names.
 const captionClasses = [
   "text-[length:var(--text-pipeline-body)]",
   "leading-[var(--text-pipeline-body--line-height)]",


### PR DESCRIPTION
## Summary

The comment above `captionClasses` in `EmptyState.tsx` spelled out literal Tailwind arbitrary-value class syntax to document the Figma tokens. Tailwind v4's scanner reads source comments too and treated the slash-containing `var()` names as candidate utilities, emitting invalid CSS.

This reworks the comment into prose (and adds a note explaining why) so the scanner no longer picks it up. Comment-only change — no runtime/logic impact.

## Test plan
- [x] No code paths changed; comment-only edit.