### PR TITLE
QA pass for epic #522 (Activity page)

### DIFF
--- a/docs/QUALITY_SCORE.md
+++ b/docs/QUALITY_SCORE.md
@@ -4,6 +4,18 @@ MVP quality bars. All targets must be met before mainnet launch.
 
 ## UX Testing Log
 
+### 2026-06-16 — Epic #522 (Activity page) — first QA pass via `qa` issue #525
+
+- **Scope:** First QA pass on `qa` #525. All 3 user-stories docs under `docs/user-stories/epic-522/` executed: `523` (mobile with-data, 5 stories), `524` (mobile empty state, 3 stories), `530` (header icon centering, 1 story). Human-invoked directly; `qa` #525 claimed from `blocked`.
+- **Environment:** `http://localhost:5173/transactions` (yarn front:dev, vite). Chrome DevTools MCP, mobile (`matchMedia('(min-width:768px)')`=false; Chrome ~500px window floor) + desktop 1440. State seeded via `pipeline.mock.wallet.*` + `pipeline.mock.api.GET./v1/requests` localStorage keys (mirrors `/test` scenarios history-mixed / single-Buy / disconnected). Zero error-level console messages.
+- **Coverage:** 3 docs / 9 stories — **8 PASS / 1 FAIL / 0 blocked.**
+- **Figma frames compared:** `1993-9592` (mobile with-data) + child `1993-9808` (heading) → header mismatch; `1497-94912` (desktop) → matches; `1993-9958` (mobile empty) → matches.
+- **Bugs filed:** **#576** (medium, `trivial`, sub-issue of #522) — mobile arrow-clock hero circle renders when it should be hidden.
+- **Score: 8/10**
+  - Strong functional + visual coverage: all four request types (Deposit/Withdraw/Stake/Unstake) render correct icons, labels, timestamps, and amount formatting (`+100.00 USDC`, `+999.50 sPLUSD`, two-line stake/unstake) with no horizontal overflow at mobile width; Buy default, no "All" tab (accepted deviation from Figma per doc). Empty state correct for all three causes (disconnected, connected-zero, tab-filter-empty) — single consistent illustration + caption, top-anchored on mobile, vertically centered on desktop. Single semantic `<h2>` at all viewports. #530 verified: arrow-clock glyph optically centered (offset 0/0, mask-size contain).
+  - **#576 (FAIL — #523 Story 1):** at mobile width the 72×72 arrow-clock hero circle still renders above the "Activity" heading (`display:flex`, 72×72) — the `inline-flex` base on `HeroIcon` beats the `hidden md:block` override passed by `ActivityHeader`, so the responsive mobile hide never applies. Mobile Figma `1993-9592` has no hero circle there. Same class of regression as the closed #547. Desktop header is correct.
+  - **Outcome:** not green. `qa` #525 returned to `blocked`; epic #522 cannot close until #576 is fixed and a follow-up pass is green. Deducted 2 points for the one medium mobile-fidelity defect on the primary new surface; everything else passes.
+
 ### 2026-06-10 — Epic #498 (Deposit/withdraw page) — final QA pass (re-run) via `qa` issue #499
 
 - **Scope:** Re-run of the final QA pass after the only first-pass failure (#547) was fixed and merged to `main` (`ca5e34d`). Targeted the previously-failing doc `501-deposit-header-mobile` (incl. its new Story 4 #547 regression guard) plus the `CoinIcon` surfaces the fix touches; the other 6 docs were first-pass green with no intervening merged changes to their surfaces. All 8 non-`qa` sub-issues (#501–#507, #520, #547) closed.


### PR DESCRIPTION
Records the Activity-page QA pass result in docs/QUALITY_SCORE.md.

Pass filed bug #576 (mobile Activity header hero circle renders at mobile width). Epic #522 stays open until #576 is fixed and a follow-up pass is green.

Refs #525