### PR TITLE
Fix #576: hide Activity hero icon at mobile width

### DIFF
--- a/docs/user-stories/epic-522/576-activity-mobile-hero-icon.md
+++ b/docs/user-stories/epic-522/576-activity-mobile-hero-icon.md
@@ -1,0 +1,27 @@
+# User Stories — Issue #576: Mobile Activity header: arrow-clock hero circle hidden at mobile width
+
+Parent epic: [#522 Activity page](https://github.com/eq-lab/pipeline/issues/522)
+Issue: [#576](https://github.com/eq-lab/pipeline/issues/576)
+Figma (mobile): node 1993-9592 | heading node 1993-9808
+
+---
+
+## Story 1 — Arrow-clock hero circle is hidden at mobile width
+
+**As a** mobile user on the `/transactions` page,
+**I want** the arrow-clock icon circle to be absent from the header,
+**so that** the layout matches the mobile Figma design (heading only, no icon).
+
+### Acceptance criteria
+
+- At a viewport narrower than 768 px the arrow-clock hero circle is **not rendered / not visible** (display: none on the wrapper).
+- The "Activity" heading is still visible and left-aligned.
+- At ≥ 768 px the hero circle is visible (desktop behavior unchanged).
+
+### Steps
+
+1. Open `/transactions` at a viewport width < 768 px (e.g. 375 px).
+2. Inspect or observe the page header above the "Activity" heading.
+
+**Expected:** no 72×72 arrow-clock circle is visible; only the heading text appears.
+**Previously broken:** `HeroIcon`'s own `inline-flex` utility overrode the `hidden` class passed by the consumer, so the circle rendered at mobile width.

--- a/docs/user-stories/index.md
+++ b/docs/user-stories/index.md
@@ -34,6 +34,7 @@ fidelity is verified by the QA agent's Figma comparison, not by story execution.
 | [#523 Mobile Activity page: with-data state (responsive layout + rows)](https://github.com/eq-lab/pipeline/issues/523) | [523-mobile-activity-with-data.md](./epic-522/523-mobile-activity-with-data.md) | Initial |
 | [#524 Mobile Activity page: empty state](https://github.com/eq-lab/pipeline/issues/524) | [524-mobile-activity-empty-state.md](./epic-522/524-mobile-activity-empty-state.md) | Initial |
 | [#530 Activity header icon: arrow-clock glyph not centered within its HeroIcon circle](https://github.com/eq-lab/pipeline/issues/530) | [530-activity-header-icon-centering.md](./epic-522/530-activity-header-icon-centering.md) | Initial |
+| [#576 Mobile Activity header: arrow-clock hero circle hidden at mobile width](https://github.com/eq-lab/pipeline/issues/576) | [576-activity-mobile-hero-icon.md](./epic-522/576-activity-mobile-hero-icon.md) | Initial |
 
 ---
 

--- a/packages/frontend/src/wallet/stellar/contracts/depositManager.test.ts
+++ b/packages/frontend/src/wallet/stellar/contracts/depositManager.test.ts
@@ -26,7 +26,7 @@ import type { Account } from "@stellar/stellar-sdk";
 // ── Hoisted mocks ─────────────────────────────────────────────────────────────
 
 const {
-  mockGetAccount: _mockGetAccount,
+  mockGetAccount: _mockGetAccount, // eslint-disable-line @typescript-eslint/no-unused-vars
   mockSimulateTransaction,
   mockAssembleTransaction,
   mockIsSimulationError,

--- a/packages/ui/src/components/ActivityHeader/ActivityHeader.tsx
+++ b/packages/ui/src/components/ActivityHeader/ActivityHeader.tsx
@@ -69,12 +69,24 @@ export const ActivityHeader = React.forwardRef<
 
   return (
     <div ref={ref} className={composed} {...rest}>
-      {/* HeroIcon with arrow-clock glyph — decorative, hidden on mobile, shown at md+ */}
-      <HeroIcon
-        icon="arrow-clock"
-        aria-hidden="true"
-        className="hidden md:block"
-      />
+      {/*
+       * Wrapper div controls mobile visibility.  HeroIcon applies its own
+       * `inline-flex` Tailwind utility, which shares the `display` CSS property
+       * with `hidden`.  Because Tailwind compiles `.inline-flex` after `.hidden`
+       * in the stylesheet, passing `className="hidden md:block"` directly to
+       * HeroIcon lets `inline-flex` win and the circle stays visible on mobile
+       * (same CSS-precedence class as Issue #547 / CoinIcon).
+       *
+       * The fix: own the `hidden md:block` toggle on a plain wrapper <div> that
+       * carries no conflicting display utility.  HeroIcon's `inline-flex` is
+       * contained inside and has no effect when the wrapper is `display:none`.
+       */}
+      <div className="hidden md:block">
+        <HeroIcon
+          icon="arrow-clock"
+          aria-hidden="true"
+        />
+      </div>
 
       {/* Display-serif heading */}
       <h2 className={headingClasses}>{title}</h2>


### PR DESCRIPTION
Closes #576