### PR TITLE
Auto admin-merge the QA docs PR after green checks

### DIFF
--- a/.claude/skills/manager/SKILL.md
+++ b/.claude/skills/manager/SKILL.md
@@ -182,7 +182,7 @@ Steps:
 
 1. Launch `ux-tester` (prompt above — `model: "opus"`, `EFFORT: medium`, argument is the **epic** number). The ux-tester owns the `qa` issue end-to-end: it claims it (`in-progress`), executes the user-stories docs under `docs/user-stories/epic-<N>/`, verifies against the epic's Figma references, files defects as `bug` sub-issues of the epic, posts the results comment, and finishes with the `qa` issue back to `blocked` — or closed (together with the epic) when all siblings are closed and the pass is green. The manager does **not** touch the `qa` issue's labels.
 2. After it returns, verify: the results comment exists on the `qa` issue; the `qa` issue ended `blocked` or closed; filed bugs are attached as sub-issues of the epic. Repair any gap (e.g. attach a missed bug via `POST .../issues/<epic>/sub_issues`).
-3. If the pass updated docs (e.g. `docs/QUALITY_SCORE.md`): branch, commit `QA pass for epic #<N>`, push, PR ready. Human-merge only.
+3. If the pass updated docs (e.g. `docs/QUALITY_SCORE.md`): branch, commit `QA pass for epic #<N>`, push, PR ready, then **admin-merge** it using the same procedure as the trivial-frontend flow (Flow C, step 2): wait 3 minutes, poll `gh pr view <pr> --json state,mergeable,mergeStateStatus,statusCheckRollup` every 3 minutes (cap 20 minutes); all checks `SUCCESS` → `gh pr merge <pr> --admin --squash --delete-branch`, then sync local `main`. Any check failed / `DIRTY` / cap exceeded → comment on the `qa` issue, leave the PR open for human merge, next task. (QA PRs are docs-only and carry no `Closes #`, so the merge never closes an Issue.)
 4. Loop mode: bugs the pass filed are new `backlog` candidates — continue the loop as usual.
 
 ---
@@ -202,7 +202,7 @@ Steps:
 - The manager is the only label mutator; it claims before acting and verifies the status label after every subagent returns. Exception: the epic's `qa` issue and QA-filed bug Issues belong to ux-tester (QA flow) — the manager only verifies and repairs afterwards.
 - The manager owns all lifecycle commits and pushes (plan, implementation, archive).
 - Never close Issues manually — `Closes #<n>` in the PR body does it on merge. The `qa` issue and its epic are closed by ux-tester when the final pass is green (no PR carries them); the manager closes them only when repairing a gap ux-tester left.
-- Merge policy per `AGENTS.md`: trivial-frontend admin-merge after explicit green checks is the single exception; everything else is human-merge.
+- Merge policy per `AGENTS.md`: the manager admin-merges after explicit green checks in two cases — trivial-frontend PRs (Flow C) and the QA docs PR (QA flow, step 3); everything else is human-merge.
 - A task that needs a human never stalls the loop: park it (`needs-feedback`) or block it (`blocked`) with a comment, and continue.
 
 ## Output

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ When uncertain about frontend vs. backend, label it `backend`. Per-flow specific
 - NEVER commit or push directly to `main`. All changes reach `main` only through a PR from a feature branch.
 - Create a feature branch for every task: `feat/`, `fix/`, `docs/`, `chore/` prefixes.
 - Push the branch, open a PR, and wait for review before merging.
-- **Merge policy.** Backend (Flow A) and frontend (Flow B) PRs are human-merge only. Trivial-frontend (Flow C) PRs are the single exception: the `manager` skill is authorized to admin-merge its own Flow C PRs (`gh pr merge --admin --squash --delete-branch`) — the repo's branch protection requires an approval review, and `--admin` bypasses that gate. CI/CD checks are NOT bypassed; the manager polls until every check is green before merging (see [`manager/SKILL.md`](./.claude/skills/manager/SKILL.md) for the procedure). Outside Flow C, never admin-merge or otherwise bypass branch protection without explicit human direction.
+- **Merge policy.** Backend (Flow A) and frontend (Flow B) PRs are human-merge only. The `manager` skill is authorized to admin-merge in two cases: its own trivial-frontend (Flow C) PRs, and the docs-only QA PR raised at the end of the QA flow. In both, it uses `gh pr merge --admin --squash --delete-branch` — the repo's branch protection requires an approval review, and `--admin` bypasses that gate. CI/CD checks are NOT bypassed; the manager polls until every check is green before merging (see [`manager/SKILL.md`](./.claude/skills/manager/SKILL.md) for the procedure). Outside those two cases, never admin-merge or otherwise bypass branch protection without explicit human direction.
 
 ### Worktrees
 


### PR DESCRIPTION
## What

The QA flow's docs-only PR (the `QA pass for epic #<N>` commit that updates `docs/QUALITY_SCORE.md`) no longer waits for a human merge. The `manager` skill now admin-merges it automatically once CI is green, using the same poll-until-green procedure as the trivial-frontend flow (Flow C).

## Changes

- **`.claude/skills/manager/SKILL.md`** — QA flow step 3 now pushes, marks ready, then admin-merges after green checks (3-min wait, poll every 3 min capped at 20, `gh pr merge --admin --squash --delete-branch`, sync `main`). Failed/DIRTY/timeout → comment and leave open for human merge. Merge-policy rule updated to list two admin-merge cases.
- **`AGENTS.md`** — repo-wide merge policy updated to match (Flow C + QA docs PR).

## Notes

- CI checks are still never bypassed; only the approval-review branch protection is, via `--admin`.
- QA PRs are docs-only and carry no `Closes #`, so the auto-merge closes no issue — the `qa` issue and epic remain owned by ux-tester.