### PR TITLE
Make manager admin-merge the QA PR mandatorily

### DIFF
--- a/.claude/skills/manager/SKILL.md
+++ b/.claude/skills/manager/SKILL.md
@@ -182,8 +182,13 @@ Steps:
 
 1. Launch `ux-tester` (prompt above — `model: "opus"`, `EFFORT: medium`, argument is the **epic** number). The ux-tester owns the `qa` issue end-to-end: it claims it (`in-progress`), executes the user-stories docs under `docs/user-stories/epic-<N>/`, verifies against the epic's Figma references, files defects as `bug` sub-issues of the epic, posts the results comment, and finishes with the `qa` issue back to `blocked` — or closed (together with the epic) when all siblings are closed and the pass is green. The manager does **not** touch the `qa` issue's labels.
 2. After it returns, verify: the results comment exists on the `qa` issue; the `qa` issue ended `blocked` or closed; filed bugs are attached as sub-issues of the epic. Repair any gap (e.g. attach a missed bug via `POST .../issues/<epic>/sub_issues`).
-3. If the pass updated docs (e.g. `docs/QUALITY_SCORE.md`): branch, commit `QA pass for epic #<N>`, push, PR ready, then **admin-merge** it using the same procedure as the trivial-frontend flow (Flow C, step 2): wait 3 minutes, poll `gh pr view <pr> --json state,mergeable,mergeStateStatus,statusCheckRollup` every 3 minutes (cap 20 minutes); all checks `SUCCESS` → `gh pr merge <pr> --admin --squash --delete-branch`, then sync local `main`. Any check failed / `DIRTY` / cap exceeded → comment on the `qa` issue, leave the PR open for human merge, next task. (QA PRs are docs-only and carry no `Closes #`, so the merge never closes an Issue.)
-4. Loop mode: bugs the pass filed are new `backlog` candidates — continue the loop as usual.
+3. **Commit and admin-merge the QA PR — mandatory, not conditional.** The ux-tester **never commits**: it updates `docs/QUALITY_SCORE.md` (and the results history) in the working tree and leaves committing to the manager (ux-tester SKILL §"Do not commit"). So a QA pass almost always leaves an **uncommitted change** — confirm with `git status --short`. Whenever any file changed, you **must** carry it through to a merged PR before this task ends:
+   - branch (`chore/qa-epic-<N>`), `git add -A`, commit `QA pass for epic #<N>`, push, `gh pr create` then `gh pr ready` (no `Closes #` — QA PRs are docs-only and close no Issue);
+   - **admin-merge** it using the same procedure as the trivial-frontend flow (Flow C, step 2): wait 3 minutes (`sleep 180`), poll `gh pr view <pr> --json state,mergeable,mergeStateStatus,statusCheckRollup` every 3 minutes (cap 20 minutes); all checks `SUCCESS` → `gh pr merge <pr> --admin --squash --delete-branch`, then sync local `main`.
+   - **Only** on a check failure / `DIRTY` (conflicts) / cap exceeded: comment the reason on the `qa` issue and leave the PR open for human merge. A red or unfinished check is never bypassed.
+
+   This is one of the two PRs the manager merges itself (see Rules). **Do not end the QA task — and in loop mode do not advance to the next candidate — while a QA working-tree change is uncommitted or its PR is left open for any reason other than failing checks.** `git status --short` must be clean before you move on. If the only thing the pass changed is nothing at all (rare — `git status` truly clean), there is no PR to merge; otherwise there always is.
+4. Loop mode: bugs the pass filed are new `backlog` candidates — continue the loop as usual (only after step 3 has merged the QA PR or parked it on a failing check).
 
 ---
 
@@ -202,7 +207,7 @@ Steps:
 - The manager is the only label mutator; it claims before acting and verifies the status label after every subagent returns. Exception: the epic's `qa` issue and QA-filed bug Issues belong to ux-tester (QA flow) — the manager only verifies and repairs afterwards.
 - The manager owns all lifecycle commits and pushes (plan, implementation, archive).
 - Never close Issues manually — `Closes #<n>` in the PR body does it on merge. The `qa` issue and its epic are closed by ux-tester when the final pass is green (no PR carries them); the manager closes them only when repairing a gap ux-tester left.
-- Merge policy per `AGENTS.md`: the manager admin-merges after explicit green checks in two cases — trivial-frontend PRs (Flow C) and the QA docs PR (QA flow, step 3); everything else is human-merge.
+- Merge policy per `AGENTS.md`: the manager admin-merges after explicit green checks in two cases — trivial-frontend PRs (Flow C) and the QA docs PR (QA flow, step 3); everything else is human-merge. The QA docs PR merge is **mandatory**: a QA pass leaves uncommitted artifacts (the ux-tester never commits), and the manager must commit, push, and admin-merge them. Never finish a QA task — or, in loop mode, advance to the next candidate — with a QA working-tree change left uncommitted; the only allowed non-merge outcome is a PR parked on a failing check.
 - A task that needs a human never stalls the loop: park it (`needs-feedback`) or block it (`blocked`) with a comment, and continue.
 
 ## Output


### PR DESCRIPTION
## What

Rewrites the QA flow in the `manager` skill so the manager reliably commits and admin-merges the QA PR.

## Why

The `ux-tester` never commits — it updates `docs/QUALITY_SCORE.md` (and results history) in the working tree and leaves committing to the manager. QA flow step 3 described the admin-merge but read as conditional ("If the pass updated docs…"), so in practice the manager slid into the loop-continuation step (step 4) without committing or merging, leaving the QA artifacts orphaned in the working tree.

## Changes

- **QA flow step 3** — now mandatory: confirm `git status --short`, commit → PR → admin-merge (same poll procedure as trivial-frontend). The only non-merge exit is a failing check / `DIRTY` / cap exceeded (parked for human merge). Forbids ending the task or advancing the loop with a dirty QA working tree.
- **Step 4** — continue the loop only after step 3 merged or parked the PR.
- **Rules / merge policy** — promoted the QA merge to a hard, mandatory rule.