### PR TITLE
Add test ids to deposit/withdraw page elements

### DIFF
--- a/packages/frontend/src/routes/deposit.tsx
+++ b/packages/frontend/src/routes/deposit.tsx
@@ -754,11 +754,15 @@ function Deposit() {
 
         {/* Conversion card */}
         <ConversionCard
+          data-testid={
+            isDeposit ? "deposit-conversion-card" : "withdraw-conversion-card"
+          }
           input={
             isDeposit
               ? {
                   token: "usdc",
                   tokenLabel: "USDC",
+                  inputTestId: "deposit-amount-input",
                   balanceLabel: formattedBalance
                     ? formattedBalance.replace(/^\$/, "")
                     : "—",
@@ -786,6 +790,7 @@ function Deposit() {
               : {
                   token: "plusd",
                   tokenLabel: "PLUSD",
+                  inputTestId: "withdraw-amount-input",
                   balanceLabel: formattedBalance
                     ? formattedBalance.replace(/^\$/, "")
                     : "—",
@@ -883,6 +888,7 @@ function Deposit() {
         ) : isDeposit ? (
           /* Deposit three-step card */
           <StepsCard
+            data-testid="deposit-steps-card"
             steps={[
               {
                 label: "Allow Pipeline to use USDC",
@@ -925,6 +931,7 @@ function Deposit() {
         ) : (
           /* Withdraw three-step card */
           <StepsCard
+            data-testid="withdraw-steps-card"
             steps={[
               {
                 label: "Allow Pipeline to use PLUSD",

--- a/packages/ui/src/components/TokenInput/TokenInput.tsx
+++ b/packages/ui/src/components/TokenInput/TokenInput.tsx
@@ -81,6 +81,13 @@ export interface TokenInputProps extends Omit<
    * back via `onValueChange`. Only shown when `value` is non-empty and not "0".
    */
   signPrefix?: string;
+  /**
+   * Optional `data-testid` applied directly to the inner numeric `<input>`
+   * element (not the wrapper). The component's own `...rest` spread targets
+   * the wrapper `<div>`, so this prop is the supported way to give tests a
+   * stable handle on the field itself.
+   */
+  inputTestId?: string;
 }
 
 // Outer panel — subtle gray fill, 1px hairline border, 8px radius, uniform 8px padding.
@@ -161,6 +168,7 @@ export const TokenInput = React.forwardRef<HTMLDivElement, TokenInputProps>(
       onValueChange,
       disabled,
       signPrefix,
+      inputTestId,
       className,
       ...rest
     },
@@ -197,6 +205,7 @@ export const TokenInput = React.forwardRef<HTMLDivElement, TokenInputProps>(
               className={inputClasses}
               placeholder={placeholderValue}
               aria-label={`${tokenLabel} amount`}
+              data-testid={inputTestId}
               // Sizing: wide enough for typical amounts, collapses naturally
               size={8}
               // Controlled mode: when `value` is provided the input is


### PR DESCRIPTION
## What

Adds stable `data-testid` hooks to the shared deposit/withdraw page (`/deposit?direction=…`) for testing and for pointing at specific elements.

Implements gaps #1 (direction-scoped amount input) and #3 (region containers) from the discussion. Other interactive elements (swap toggle, step action buttons, success badges) already carry accessible `role`/`aria-label`s and are queried via `getByRole`/`getByLabelText`, so they were left untouched.

## Ids added

| Element | Test id |
|---|---|
| Amount input | `deposit-amount-input` / `withdraw-amount-input` |
| Conversion card region | `deposit-conversion-card` / `withdraw-conversion-card` |
| Steps card region | `deposit-steps-card` / `withdraw-steps-card` |

## How

- **`packages/ui` — `TokenInput`**: new optional `inputTestId` prop applied directly to the inner `<input>`. The component's `...rest` spread targets the wrapper `<div>`, so a dedicated prop is needed to reach the field itself.
- **`ConversionCard` / `StepsCard`**: already forward `data-testid` via their existing `...rest` spread — no component change needed, just call-site props.
- **`packages/frontend` — `deposit.tsx`**: passes the direction-scoped ids at the call sites.

Additive only; no behavior change.

## Verification

- `deposit.tsx` route tests: 76 passed.
- Lint (eslint + prettier) and frontend typecheck: clean.
- Docs lint (`scripts/lint-docs.ts`): 0 errors.
- Pre-existing failures in `AccountDropdown.test.tsx` and `useStellarWithdrawalQueue.test.tsx` were confirmed to fail identically on `main` (local clipboard/timing flakes) and are unrelated to this change.