### PR TITLE
Add deep test ids to deposit/withdraw page tree

### DIFF
--- a/packages/frontend/src/routes/deposit.tsx
+++ b/packages/frontend/src/routes/deposit.tsx
@@ -750,7 +750,7 @@ function Deposit() {
     <div className="min-h-screen bg-[var(--color-pipeline-paper)] text-[color:var(--color-pipeline-ink)]">
       <main className="mx-auto flex w-full max-w-lg flex-col gap-6 px-2 py-12 md:px-4">
         {/* Section header */}
-        <DepositHeader title="1:1 Conversion" />
+        <DepositHeader data-testid="deposit-header" title="1:1 Conversion" />
 
         {/* Conversion card */}
         <ConversionCard
@@ -838,10 +838,14 @@ function Deposit() {
             data-testid="connect-wallet-banner"
             className="flex flex-row items-center justify-between gap-4"
           >
-            <p className="font-[family-name:var(--font-body)] text-[length:var(--text-pipeline-body)]">
+            <p
+              data-testid="connect-wallet-banner-text"
+              className="font-[family-name:var(--font-body)] text-[length:var(--text-pipeline-body)]"
+            >
               Connect your wallet first
             </p>
             <Button
+              data-testid="connect-wallet-banner-action"
               variant="primary-dark"
               className="whitespace-nowrap"
               onClick={connect}
@@ -851,25 +855,44 @@ function Deposit() {
           </Card>
         ) : isManagerUnreachable ? (
           <Card variant="danger" data-testid="dm-unreachable-banner">
-            <p className="font-[family-name:var(--font-display)] text-[length:var(--text-pipeline-heading-s)]">
+            <p
+              data-testid="dm-unreachable-banner-title"
+              className="font-[family-name:var(--font-display)] text-[length:var(--text-pipeline-heading-s)]"
+            >
               DepositManager not reachable
             </p>
-            <p className="mt-1 font-[family-name:var(--font-body)] text-[length:var(--text-pipeline-caption)]">
-              Check <code>VITE_DEPOSIT_MANAGER_ADDRESS</code> and RPC
-              connectivity.
+            <p
+              data-testid="dm-unreachable-banner-detail"
+              className="mt-1 font-[family-name:var(--font-body)] text-[length:var(--text-pipeline-caption)]"
+            >
+              Check{" "}
+              <code data-testid="dm-unreachable-banner-env">
+                VITE_DEPOSIT_MANAGER_ADDRESS
+              </code>{" "}
+              and RPC connectivity.
             </p>
           </Card>
         ) : isDeposit && hasBalance === false ? (
           /* Insufficient-balance banner — deposit only. Figma: node 1825-10214. */
           <Card
             variant="yellow"
+            data-testid="low-balance-banner"
             className="flex flex-row items-center justify-between gap-4"
           >
-            <div className="flex flex-col items-start gap-1">
-              <p className="font-[family-name:var(--font-body)] text-[length:var(--text-pipeline-body)]">
+            <div
+              data-testid="low-balance-banner-text"
+              className="flex flex-col items-start gap-1"
+            >
+              <p
+                data-testid="low-balance-banner-title"
+                className="font-[family-name:var(--font-body)] text-[length:var(--text-pipeline-body)]"
+              >
                 Add funds to your USDC balance
               </p>
-              <p className="font-[family-name:var(--font-body)] text-[length:var(--text-pipeline-caption)] text-[color:var(--color-pipeline-ink-muted)]">
+              <p
+                data-testid="low-balance-banner-minimum"
+                className="font-[family-name:var(--font-body)] text-[length:var(--text-pipeline-caption)] text-[color:var(--color-pipeline-ink-muted)]"
+              >
                 Minimum amount —{" "}
                 {minDeposit !== undefined && decimals !== undefined
                   ? `${formatUsdcWhole(minDeposit, decimals)} USDC`
@@ -877,6 +900,7 @@ function Deposit() {
               </p>
             </div>
             <Button
+              data-testid="low-balance-banner-action"
               variant="primary-dark"
               className="whitespace-nowrap"
               onClick={copyAddress}

--- a/packages/ui/src/components/ConversionCard/ConversionCard.tsx
+++ b/packages/ui/src/components/ConversionCard/ConversionCard.tsx
@@ -100,9 +100,8 @@ export const ConversionCard = React.forwardRef<
 ) {
   // Prefix the PLUSD output value with "+" when non-zero (purely visual).
   // Zero values stay un-prefixed to match the Figma "0" placeholder state.
-  const outputValue = output.value && output.value !== "0"
-    ? `+${output.value}`
-    : output.value;
+  const outputValue =
+    output.value && output.value !== "0" ? `+${output.value}` : output.value;
 
   return (
     /* Outer wrapper: two cards stacked with a 2px gap.
@@ -126,7 +125,8 @@ export const ConversionCard = React.forwardRef<
           signPrefix="−" shows the minus sign (outflow) when a non-zero value
           is present; the underlying input value stays positive. */}
       <div
-        className="relative pt-4 pr-4 pb-6 pl-4 bg-[var(--color-pipeline-surface)] rounded-[var(--radius-pipeline-card-lg)]"
+        data-testid="conversion-input-card"
+        className="relative rounded-[var(--radius-pipeline-card-lg)] bg-[var(--color-pipeline-surface)] pt-4 pr-4 pb-6 pl-4"
       >
         <TokenInput {...input} signPrefix="−" />
 
@@ -157,7 +157,11 @@ export const ConversionCard = React.forwardRef<
           nested within the PLUSD card, matching Figma node 1498-100135.
           TokenAmountDisplay's self-styling (border, bg, radius, padding) is
           suppressed via inline styles so it renders flush inside Card B. */}
-      <Card variant="white" className="flex flex-col gap-2">
+      <Card
+        variant="white"
+        data-testid="conversion-output-card"
+        className="flex flex-col gap-2"
+      >
         {/* PLUSD token row — card chrome stripped via inline styles so it
             sits flush inside the Card B wrapper without a nested border. */}
         <TokenAmountDisplay
@@ -172,7 +176,10 @@ export const ConversionCard = React.forwardRef<
         />
 
         {/* Details: Exchange rate + Network fee — nested inside Card B */}
-        <div className="flex flex-col gap-2 pb-2">
+        <div
+          data-testid="conversion-details"
+          className="flex flex-col gap-2 pb-2"
+        >
           <InfoRow label="Exchange rate" value={exchangeRate} />
           <InfoRow label="Network fee" value={networkFee} />
         </div>

--- a/packages/ui/src/components/InfoRow/InfoRow.tsx
+++ b/packages/ui/src/components/InfoRow/InfoRow.tsx
@@ -42,9 +42,16 @@ const valueClasses = [
 export const InfoRow = React.forwardRef<HTMLDivElement, InfoRowProps>(
   function InfoRow({ label, value, className, ...rest }, ref) {
     const composed = [rootClasses, className].filter(Boolean).join(" ");
+    // Derive a stable test id from the label so the two rows rendered inside a
+    // ConversionCard ("Exchange rate" / "Network fee") stay individually
+    // addressable. A caller-supplied data-testid (via ...rest) still wins.
+    const derivedTestId = `info-row-${label
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-|-$/g, "")}`;
 
     return (
-      <div ref={ref} className={composed} {...rest}>
+      <div ref={ref} data-testid={derivedTestId} className={composed} {...rest}>
         <span className={labelClasses}>{label}</span>
         <span className={valueClasses}>{value}</span>
       </div>

--- a/packages/ui/src/components/StepRow/StepRow.tsx
+++ b/packages/ui/src/components/StepRow/StepRow.tsx
@@ -113,9 +113,18 @@ export const StepRow = React.forwardRef<HTMLDivElement, StepRowProps>(
       .join(" ");
 
     return (
-      <div ref={ref} className={composed} {...rest}>
+      <div
+        ref={ref}
+        data-testid={`step-row-${step}`}
+        className={composed}
+        {...rest}
+      >
         {/* Numbered square — always visible, including in success state */}
-        <div className={stepCircleClasses} aria-hidden="true">
+        <div
+          data-testid={`step-row-${step}-badge`}
+          className={stepCircleClasses}
+          aria-hidden="true"
+        >
           <span className={stepNumberClasses}>{step}</span>
         </div>
 
@@ -123,7 +132,7 @@ export const StepRow = React.forwardRef<HTMLDivElement, StepRowProps>(
         <span className={labelClasses}>{label}</span>
 
         {/* Action button / loading spinner wrapper — matches Figma `ButtonCont` */}
-        <div className="shrink-0 p-1">
+        <div data-testid={`step-row-${step}-action`} className="shrink-0 p-1">
           {isSuccess ? (
             /* Success state: wide green pill with check icon — matches Figma node 1497-95272 */
             <div

--- a/packages/ui/src/components/StepsCard/StepsCard.tsx
+++ b/packages/ui/src/components/StepsCard/StepsCard.tsx
@@ -74,7 +74,7 @@ export const StepsCard = React.forwardRef<HTMLDivElement, StepsCardProps>(
           .join(" ")}
         {...rest}
       >
-        <div className="flex flex-col gap-2">
+        <div data-testid="steps-list" className="flex flex-col gap-2">
           {steps.map(
             (
               { label, actionLabel, disabled, onAction, loading, state },

--- a/packages/ui/src/components/TokenAmountDisplay/TokenAmountDisplay.tsx
+++ b/packages/ui/src/components/TokenAmountDisplay/TokenAmountDisplay.tsx
@@ -90,9 +90,17 @@ export const TokenAmountDisplay = React.forwardRef<
   const composed = [cardClasses, className].filter(Boolean).join(" ");
 
   return (
-    <div ref={ref} className={composed} {...rest}>
+    <div
+      ref={ref}
+      data-testid="token-amount-display"
+      className={composed}
+      {...rest}
+    >
       {/* Row: identity (icon + label + balance) + numeric value */}
-      <div className="flex items-center justify-between pr-2">
+      <div
+        data-testid="token-amount-display-row"
+        className="flex items-center justify-between pr-2"
+      >
         {/* Left: coin icon + labels */}
         <div className={identityClasses}>
           <CoinIcon token={token} size="lg" aria-hidden />

--- a/packages/ui/src/components/TokenInput/TokenInput.tsx
+++ b/packages/ui/src/components/TokenInput/TokenInput.tsx
@@ -180,9 +180,12 @@ export const TokenInput = React.forwardRef<HTMLDivElement, TokenInputProps>(
     const showSign = signPrefix !== undefined && !!value && value !== "0";
 
     return (
-      <div ref={ref} className={composed} {...rest}>
+      <div ref={ref} data-testid="token-input" className={composed} {...rest}>
         {/* Top row: identity (icon + label + balance) + numeric input */}
-        <div className="flex items-center justify-between pr-2">
+        <div
+          data-testid="token-input-row"
+          className="flex items-center justify-between pr-2"
+        >
           {/* Left: coin icon + labels */}
           <div className={identityClasses}>
             <CoinIcon token={token} size="lg" aria-hidden />
@@ -220,7 +223,10 @@ export const TokenInput = React.forwardRef<HTMLDivElement, TokenInputProps>(
         </div>
 
         {/* Bottom row: quick-amount chips */}
-        <div className="flex w-full items-center gap-1">
+        <div
+          data-testid="token-input-chips"
+          className="flex w-full items-center gap-1"
+        >
           {quickAmounts.map((item, idx) => (
             <QuickAmountChip
               key={idx}


### PR DESCRIPTION
## What

Extends the deposit/withdraw page test-id coverage down to the 4th DOM level below `<main>`. Building on the page-level ids added earlier (`deposit-conversion-card`, `deposit-steps-card`, amount inputs, banners), this tags the container divs rendered **inside** the shared `packages/ui` components so any structural region is individually addressable.

`<main>` itself is intentionally left without an id.

## Ids added (depth from `<main>`)

| Depth | Element | `data-testid` |
|---|---|---|
| 2 | Card A wrapper | `conversion-input-card` |
| 2 | Card B | `conversion-output-card` |
| 3 | TokenInput root | `token-input` |
| 4 | TokenInput top row | `token-input-row` |
| 4 | TokenInput chips row | `token-input-chips` |
| 3 | TokenAmountDisplay root | `token-amount-display` |
| 4 | TokenAmountDisplay row | `token-amount-display-row` |
| 3 | Details block | `conversion-details` |
| 4 | InfoRow ×2 | `info-row-exchange-rate` / `info-row-network-fee` |
| 2 | Steps list | `steps-list` |
| 3 | StepRow ×3 | `step-row-{n}` |
| 4 | Step badge / action | `step-row-{n}-badge` / `step-row-{n}-action` |

## How

- Hardcoded on each component's container div, placed **before** the `...rest` spread so a caller-supplied `data-testid` still wins.
- Repeated components get unique ids derived from existing props: `InfoRow` from its `label`, `StepRow` from its `step` number.
- These are shared components, so the same ids also render on the stake page / Storybook — harmless, as they're separate routes.

## Verification

- eslint + prettier + frontend typecheck: clean. Docs-lint: 0 errors.
- Targeted tests (deposit + ConversionCard + stake): 118 passed.
- Full frontend suite: 903 passed. The 21 failures in `AccountDropdown.test.tsx` / `useStellarWithdrawalQueue.test.tsx` are pre-existing on `main` (local clipboard/timing flakes), unrelated to this change.