### PR TITLE
Never close epic issues — keep them open permanently

### DIFF
--- a/.claude/skills/manager/SKILL.md
+++ b/.claude/skills/manager/SKILL.md
@@ -73,7 +73,7 @@ The manager works **only on sub-issues of an epic** (`epic`-labelled Issue, nati
    - no `blocked` label;
    - unassigned or assigned to `@me`;
    - matches the session filter (`frontend` / `backend` / `trivial`); `qa` and `docs` sub-issues are picked only by `all` (no filter).
-   **Epic-complete QA trigger** — special case that bypasses the rules above: while enumerating an epic's sub-issues, if **all non-`qa` sub-issues are closed** and the epic's `qa` issue is still **open** (typically `blocked` — `blocked` does not disqualify it here) and unassigned, the `qa` issue is a candidate for the **QA flow** regardless of its status label and session filter. This is the final QA pass that lets the epic close.
+   **Epic-complete QA trigger** — special case that bypasses the rules above: while enumerating an epic's sub-issues, if **all non-`qa` sub-issues are closed** and the epic's `qa` issue is still **open** (typically `blocked` — `blocked` does not disqualify it here) and unassigned, the `qa` issue is a candidate for the **QA flow** regardless of its status label and session filter. This is the epic's final QA pass.
 3. Order: `priority` first, then by issue number ascending.
 4. Proceed with the chosen Issue immediately — no confirmation pause.
 5. No candidates and nothing to resume → the loop is done. Report and stop.
@@ -176,11 +176,11 @@ No planning, no gates, no testing. Quality bar: lint clean, build clean, tests g
 Entry — either of:
 
 - **Human-requested**: a `qa` sub-issue in `backlog` (ISSUE_PROTOCOL §5.3). The manager never flips a `qa` issue to `backlog` itself.
-- **Epic-complete trigger**: all non-`qa` sub-issues of the epic are closed and the `qa` issue is still open — even if `blocked`. The epic cannot close without a green final pass, so the manager runs it without waiting for a human.
+- **Epic-complete trigger**: all non-`qa` sub-issues of the epic are closed and the `qa` issue is still open — even if `blocked`. This is the epic's final QA pass, so the manager runs it without waiting for a human. (The epic itself is never closed — see Rules.)
 
 Steps:
 
-1. Launch `ux-tester` (prompt above — `model: "opus"`, `EFFORT: medium`, argument is the **epic** number). The ux-tester owns the `qa` issue end-to-end: it claims it (`in-progress`), executes the user-stories docs under `docs/user-stories/epic-<N>/`, verifies against the epic's Figma references, files defects as `bug` sub-issues of the epic, posts the results comment, and finishes with the `qa` issue back to `blocked` — or closed (together with the epic) when all siblings are closed and the pass is green. The manager does **not** touch the `qa` issue's labels.
+1. Launch `ux-tester` (prompt above — `model: "opus"`, `EFFORT: medium`, argument is the **epic** number). The ux-tester owns the `qa` issue end-to-end: it claims it (`in-progress`), executes the user-stories docs under `docs/user-stories/epic-<N>/`, verifies against the epic's Figma references, files defects as `bug` sub-issues of the epic, posts the results comment, and finishes with the `qa` issue back to `blocked` — or closed (the epic stays open) when all siblings are closed and the pass is green. The manager does **not** touch the `qa` issue's labels.
 2. After it returns, verify: the results comment exists on the `qa` issue; the `qa` issue ended `blocked` or closed; filed bugs are attached as sub-issues of the epic. Repair any gap (e.g. attach a missed bug via `POST .../issues/<epic>/sub_issues`).
 3. **Commit and admin-merge the QA PR — mandatory, not conditional.** The ux-tester **never commits**: it updates `docs/QUALITY_SCORE.md` (and the results history) in the working tree and leaves committing to the manager (ux-tester SKILL §"Do not commit"). So a QA pass almost always leaves an **uncommitted change** — confirm with `git status --short`. Whenever any file changed, you **must** carry it through to a merged PR before this task ends:
    - branch (`chore/qa-epic-<N>`), `git add -A`, commit `QA pass for epic #<N>`, push, `gh pr create` then `gh pr ready` (no `Closes #` — QA PRs are docs-only and close no Issue);
@@ -206,7 +206,7 @@ Steps:
 - The manager does **not** write code, tests, plans, specs, or reviews itself — it delegates.
 - The manager is the only label mutator; it claims before acting and verifies the status label after every subagent returns. Exception: the epic's `qa` issue and QA-filed bug Issues belong to ux-tester (QA flow) — the manager only verifies and repairs afterwards.
 - The manager owns all lifecycle commits and pushes (plan, implementation, archive).
-- Never close Issues manually — `Closes #<n>` in the PR body does it on merge. The `qa` issue and its epic are closed by ux-tester when the final pass is green (no PR carries them); the manager closes them only when repairing a gap ux-tester left.
+- Never close Issues manually — `Closes #<n>` in the PR body does it on merge. The `qa` issue is closed by ux-tester when the final pass is green (no PR carries it); the manager only repairs a gap ux-tester left. **Epics are never closed by any agent — they stay open permanently, even once every sub-issue is closed and the final pass is green.**
 - Merge policy per `AGENTS.md`: the manager admin-merges after explicit green checks in two cases — trivial-frontend PRs (Flow C) and the QA docs PR (QA flow, step 3); everything else is human-merge. The QA docs PR merge is **mandatory**: a QA pass leaves uncommitted artifacts (the ux-tester never commits), and the manager must commit, push, and admin-merge them. Never finish a QA task — or, in loop mode, advance to the next candidate — with a QA working-tree change left uncommitted; the only allowed non-merge outcome is a PR parked on a failing check.
 - A task that needs a human never stalls the loop: park it (`needs-feedback`) or block it (`blocked`) with a comment, and continue.
 

--- a/.claude/skills/ux-tester/SKILL.md
+++ b/.claude/skills/ux-tester/SKILL.md
@@ -159,7 +159,7 @@ Severity guidance:
      gh issue edit <qa> --remove-label in-progress --add-label blocked --remove-assignee @me
      ```
 
-   - **If all sibling sub-issues are closed and this pass is fully green:** close the `qa` issue, then the epic.
+   - **If all sibling sub-issues are closed and this pass is fully green:** close the `qa` issue. **Never close the epic** — epics stay open permanently, even when every sub-issue is closed and the final pass is green.
 3. Update `docs/QUALITY_SCORE.md` (see below). Do **not** commit — the manager/human commits testing artifacts.
 
 ## Quality Score Updates
@@ -191,7 +191,7 @@ When setup is required, prefer existing scripts/fixtures from the repo over manu
 
 ## Rules
 
-- **Label edits are limited to the epic's `qa` issue** (claim → results → `blocked`/close) and the status labels of bugs you create. Never relabel the epic itself or its other sub-issues — the manager owns those transitions.
+- **Label edits are limited to the epic's `qa` issue** (claim → results → `blocked`/close) and the status labels of bugs you create. Never relabel **or close** the epic itself, and never relabel its other sub-issues — the manager owns those transitions. Epics stay open permanently.
 - Do **not** implement fixes. Testing and filing only.
 - Do **not** commit. The manager/human commits testing artifacts (`docs/QUALITY_SCORE.md`) — your results comment on the `qa` issue is the durable record.
 - Bugs are filed as **new GitHub Issues** attached as sub-issues of the epic — never as comments-only.

--- a/docs/ISSUE_PROTOCOL.md
+++ b/docs/ISSUE_PROTOCOL.md
@@ -21,7 +21,7 @@ All dev work is grouped under an epic. An epic describes one business feature.
 - **Structure:** all work issues (`implementation`, `bug`, `docs`, `qa`) are attached as **native GitHub sub-issues** of the epic. GitHub renders the progress automatically.
 - **A `qa` sub-issue is created together with the epic** (see `qa` below).
 - Epics carry no status label — their state is the aggregate of their sub-issues.
-- **Done when:** all sub-issues are closed and the final QA pass is green. The `qa` sub-issue closes last, then the epic.
+- **Done when:** all sub-issues are closed and the final QA pass is green; the `qa` sub-issue closes last. **The epic itself is never closed — it stays open permanently as the feature's record, even once every sub-issue is closed.**
 
 ### `implementation` — code work
 
@@ -43,7 +43,7 @@ All dev work is grouped under an epic. An epic describes one business feature.
 
 ### `qa` — testing pass
 
-One `qa` issue per epic, created together with the epic as its sub-issue. Manual testing does **not** happen after each task — a **human requests a pass** by flipping the `qa` issue to `backlog`, and it happens when an agent picks the issue up. Exception: the **final pass** — when all non-`qa` sibling sub-issues are closed and the `qa` issue is still open (even `blocked`), an agent may run the pass without a human request, since the epic cannot close without it (§5.3).
+One `qa` issue per epic, created together with the epic as its sub-issue. Manual testing does **not** happen after each task — a **human requests a pass** by flipping the `qa` issue to `backlog`, and it happens when an agent picks the issue up. Exception: the **final pass** — when all non-`qa` sibling sub-issues are closed and the `qa` issue is still open (even `blocked`), an agent may run the pass without a human request, since it is the epic's final QA pass (§5.3).
 
 - **Body:** points to the epic's user-stories directory (`docs/user-stories/epic-<N>/`, see §6). The QA agent discovers the stories to run from that directory; verification history lives in the results comments.
 - **Lifecycle:**
@@ -51,7 +51,7 @@ One `qa` issue per epic, created together with the epic as its sub-issue. Manual
   2. A human flips it to `backlog` when they want a testing pass. Agents never make this transition (§5.3).
   3. A QA agent claims it (`in-progress`), executes every user-stories doc in the epic's directory (at minimum those not yet verified per the latest results comment), files found defects as `bug` sub-issues of the same epic, and posts a results comment (stories run, pass/fail per story, bugs filed).
   4. After posting results → back to `blocked` (the next pass is again human-requested).
-  5. When all sibling sub-issues are closed and the latest pass is green → close the `qa` issue, then the epic.
+  5. When all sibling sub-issues are closed and the latest pass is green → close the `qa` issue. The epic is **never** closed — it stays open permanently.
 
 ## 3. Labels
 
@@ -131,7 +131,7 @@ gh issue edit <number> --add-assignee @me --remove-label backlog --add-label in-
 
 Mid-epic QA passes are **requested by humans**, not triggered by agents. Implementing agents only commit user-stories docs in their PRs (§6) — they never edit, comment on, or relabel the epic's `qa` issue. When a human wants a testing pass, they flip the `qa` issue `blocked` → `backlog`; the QA agent that claims it discovers the stories to run from `docs/user-stories/epic-<N>/`.
 
-**Final-pass exception:** when **all non-`qa` sub-issues of an epic are closed** and the `qa` issue is still open, an orchestrating agent may start the pass directly — claiming the `qa` issue from `blocked` or `backlog` — because the epic can only close after a green final pass.
+**Final-pass exception:** when **all non-`qa` sub-issues of an epic are closed** and the `qa` issue is still open, an orchestrating agent may start the pass directly — claiming the `qa` issue from `blocked` or `backlog` — because it is the epic's final QA pass.
 
 ### 5.4 Discovering work
 


### PR DESCRIPTION
## What

Epics now stay **open permanently** as the feature's record. The `qa` issue still closes on a final green pass; only the subsequent "close the epic" step is removed.

## Why

Per request: epic issues should never be closed and should remain open forever.

## Changes

- **`.claude/skills/ux-tester/SKILL.md`** (the actual closer) — final-pass step closes the `qa` issue but **never** the epic; permissions line forbids relabeling or closing the epic.
- **`.claude/skills/manager/SKILL.md`** — Rules state epics are never closed by any agent; reworded the "epic cannot close without a final pass" spots to "the epic's final QA pass."
- **`docs/ISSUE_PROTOCOL.md`** — canonical contract updated to match (epic §2 "Done when", qa lifecycle step 5, §5.3 final-pass exception) so the protocol and both skills agree.

Historical `docs/QUALITY_SCORE.md` log entries are left as-is — they record passes under the old rule.