### PR TITLE
Set Stellar deposit minimum to 1 USDC

### DIFF
--- a/docs/user-stories/epic-498/552-stellar-deposit-withdraw-wiring.md
+++ b/docs/user-stories/epic-498/552-stellar-deposit-withdraw-wiring.md
@@ -46,8 +46,8 @@ wallet is connected
 **Given** the user is on the Stellar tab with a connected wallet and mock keys:
 
 ```js
-localStorage.setItem("pipeline.mock.wallet.stellar.balance.plusd", "500");
-// 500 PLUSD — below the $1,000 minimum
+localStorage.setItem("pipeline.mock.wallet.stellar.balance.usdc", "0.5");
+// 0.5 USDC — below the 1 USDC Stellar minimum
 ```
 
 **When** they navigate to `/deposit?direction=deposit`
@@ -55,7 +55,7 @@ localStorage.setItem("pipeline.mock.wallet.stellar.balance.plusd", "500");
 **Then:**
 
 - The "Add funds to your USDC balance" low-balance banner is visible
-- The banner subtitle references "1,000 USDC" (minimum deposit)
+- The banner subtitle references "1 USDC" (minimum deposit)
 - No StepsCard is rendered
 - The amount input is visible but the step buttons are absent
 
@@ -79,7 +79,7 @@ localStorage.setItem("pipeline.mock.wallet.stellar.balance.usdc", "5000");
 - Step 2 label reads **"Confirm USDC transfer"** and is disabled
 - Step 3 label reads **"Claim your PLUSD"** and is disabled
 
-**When** the user enters an amount ≥ $1,000 and clicks **Approve**
+**When** the user enters an amount ≥ 1 USDC and clicks **Approve**
 
 **Then:**
 
@@ -107,7 +107,7 @@ localStorage.setItem(
 **Then:**
 
 - Step 1 shows the success badge ("Approve complete") immediately
-- Step 2 (**Confirm**) is the active enabled step when an amount ≥ $1,000 is entered
+- Step 2 (**Confirm**) is the active enabled step when an amount ≥ 1 USDC is entered
 
 ---
 

--- a/docs/user-stories/epic-498/598-stellar-min-deposit-one.md
+++ b/docs/user-stories/epic-498/598-stellar-min-deposit-one.md
@@ -1,0 +1,57 @@
+# User story: #598 — Stellar deposit minimum is 1 USDC
+
+**Epic:** #498 — Deposit/withdraw page
+**Issue:** https://github.com/eq-lab/pipeline/issues/598
+**Status:** Initial
+
+---
+
+## Overview
+
+The Stellar DepositManager contract does not expose a minimum-deposit getter.
+Until a contract or API value exists, the frontend applies a Stellar-specific
+minimum of 1 USDC. EVM behavior is unchanged and still uses the EVM
+DepositManager `minDeposit()` value.
+
+---
+
+## Story 1 — Stellar Min chip uses 1 USDC
+
+**Given** the user is on the Stellar tab with a connected wallet and at least
+1 USDC available
+
+**When** they navigate to `/deposit?direction=deposit`
+
+**Then:**
+
+- The quick amount row shows a Min chip for 1 USDC
+- Clicking the Min chip enters `1.00` in the amount input
+- Step actions use the Stellar flow, not the EVM `minDeposit()` value
+
+---
+
+## Story 2 — Stellar deposit is blocked below 1 USDC
+
+**Given** the user is on the Stellar tab with `0.5` USDC available
+
+**When** they navigate to `/deposit?direction=deposit`
+
+**Then:**
+
+- The low-balance banner is visible
+- The minimum text reads `1 USDC`
+- No deposit step action is available
+
+---
+
+## Story 3 — EVM minimum remains contract-driven
+
+**Given** the user switches back to the EVM network
+
+**When** they navigate to `/deposit?direction=deposit`
+
+**Then:**
+
+- The Min chip and low-balance threshold come from the EVM
+  `DepositManager.minDeposit()` read
+- The Stellar 1 USDC frontend constant is not used for EVM

--- a/docs/user-stories/index.md
+++ b/docs/user-stories/index.md
@@ -78,3 +78,4 @@ fidelity is verified by the QA agent's Figma comparison, not by story execution.
 | [#550 [FE] [Stellar] Deposit flow: request_deposit → voucher → claim_request hooks](https://github.com/eq-lab/pipeline/issues/550) | [550-stellar-deposit-hooks.md](./epic-498/550-stellar-deposit-hooks.md) | Initial |
 | [#551 [FE] [Stellar] Withdraw flow: request_withdrawal → voucher → claim_request hooks](https://github.com/eq-lab/pipeline/issues/551) | [551-stellar-withdraw-hooks.md](./epic-498/551-stellar-withdraw-hooks.md) | Initial |
 | [#552 [FE] [Stellar] Deposit/withdraw page: chain-aware wiring (steps, trustline, XLM fee, all states)](https://github.com/eq-lab/pipeline/issues/552) | [552-stellar-deposit-withdraw-wiring.md](./epic-498/552-stellar-deposit-withdraw-wiring.md) | Initial |
+| [#598 [FE] Set Stellar deposit minimum to 1 USDC](https://github.com/eq-lab/pipeline/issues/598) | [598-stellar-min-deposit-one.md](./epic-498/598-stellar-min-deposit-one.md) | Initial |

--- a/packages/frontend/src/wallet/useDepositFlow.ts
+++ b/packages/frontend/src/wallet/useDepositFlow.ts
@@ -159,10 +159,11 @@ export interface FlowState {
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000" as const;
 /**
  * Frontend minimum deposit for Stellar in tokens at 7 decimals.
- * $1,000 at 7 dp = 1_000 × 10^7 = 10_000_000_000n.
- * Soroban enforces no on-chain minimum; we keep the $1,000 frontend rule.
+ * $1 at 7 dp = 1 × 10^7 = 10_000_000n.
+ * Soroban exposes no on-chain minimum getter; keep this Stellar-specific
+ * frontend rule until the contract or API provides a network value.
  */
-const STELLAR_MIN_DEPOSIT = 1_000n * 10n ** BigInt(SAC_DECIMALS);
+const STELLAR_MIN_DEPOSIT = 1n * 10n ** BigInt(SAC_DECIMALS);
 
 // ── Format helper ─────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Change the Stellar-specific frontend minimum deposit from 1,000 USDC to 1 USDC.
- Keep EVM minDeposit behavior contract-driven.
- Add issue #598 user stories and update Stellar wiring stories.

## Verification

- npx tsx scripts/lint-docs.ts
- yarn workspace @pipeline/frontend lint
- yarn workspace @pipeline/frontend build
- git diff --check

Closes #598