### PR TITLE
Fix Stellar deposit balance source to match wallet header

### DIFF
--- a/docs/exec-plans/known-bugs.md
+++ b/docs/exec-plans/known-bugs.md
@@ -31,6 +31,13 @@ Bugs discovered during development that are not yet fixed. Log here, don't fix i
 - **Root cause:** Asset was originally extracted as a rasterised PNG and placed into an SVG wrapper (same historical pattern as `coin-usdc.svg`). Not caught by #246 scope, which was USDC-only.
 - **Workaround:** None applied. Replace with a proper vector SVG export from Figma (same procedure as #246 Step 1–2).
 
+### BUG-3: `useStellarWithdrawalQueue.test.tsx` — 8 failing tests
+- **Date:** 2026-06-17
+- **Location:** `packages/frontend/src/wallet/stellar/useStellarWithdrawalQueue.test.tsx`
+- **Symptom:** `npx vitest run src/wallet/stellar/useStellarWithdrawalQueue.test.tsx` reports 8 failures (16 pass). Example: the "declined signature sets error" case expects `error.message` to match `/Declined/` but receives `"WithdrawalQueue not configured"`. Reproduces on a clean `main` checkout, so unrelated to any in-flight change.
+- **Root cause:** Not investigated. The mocked test setup appears to leave the WithdrawalQueue contract unconfigured, so the hook short-circuits with a "not configured" error before reaching the signature-decline / submission paths the tests assert on.
+- **Workaround:** None applied.
+
 ---
 
 ## Resolved

--- a/packages/frontend/src/wallet/useDepositFlow.ts
+++ b/packages/frontend/src/wallet/useDepositFlow.ts
@@ -45,6 +45,7 @@ import {
   useStellarWallet,
   useStellarDepositManagerAddresses,
   useStellarSacToken,
+  useStellarToken,
   SAC_DECIMALS,
   sacDisplayToRaw,
   useStellarRequestDeposit,
@@ -261,12 +262,12 @@ export function useDepositFlow(
   const { addresses: stellarAddresses, isLoading: stellarManagerLoading } =
     useStellarDepositManagerAddresses();
 
-  // USDC SAC — deposit input on Stellar
-  const usdcSac = useStellarSacToken({
-    assetCode: "USDC",
-    assetIssuer: stellarAddresses?.usdcAsset.issuer ?? "",
-    contractId: stellarAddresses?.usdc ?? "",
-  });
+  // USDC balance — deposit input on Stellar.
+  // Use the same source as the TopBar wallet pill (`useStellarToken`) so the
+  // deposit page's balance check can never disagree with the balance shown in
+  // the header. (The SAC hook reads a separate mock key / issuer and would
+  // diverge — surfacing a false "Add funds" banner when the user holds USDC.)
+  const usdcToken = useStellarToken();
   // PLUSD SAC — withdraw input on Stellar
   const plusdSac = useStellarSacToken({
     assetCode: "PLUSD",
@@ -489,8 +490,8 @@ export function useDepositFlow(
   // ── Stellar derived state ──────────────────────────────────────────────────
   // Balance: convert Horizon decimal string to bigint at 7 dp
   const stellarUsdcBalanceRaw: bigint | undefined =
-    isStellarConnected && usdcSac.balance !== undefined
-      ? sacDisplayToRaw(usdcSac.balance)
+    isStellarConnected && usdcToken.balance !== undefined
+      ? sacDisplayToRaw(usdcToken.balance)
       : undefined;
   const stellarPlusdBalanceRaw: bigint | undefined =
     isStellarConnected && plusdSac.balance !== undefined
@@ -1132,7 +1133,7 @@ export function useDepositFlow(
     isManagerUnreachable: false,
     isManagerLoading: stellarManagerLoading,
     refetchBalance: isDeposit
-      ? usdcSac.refetchBalance
+      ? usdcToken.refetchBalance
       : plusdSac.refetchBalance,
     onQuickAmount: onStellarQuickAmount,
   };


### PR DESCRIPTION
## Problem

On `/deposit?direction=deposit` with a Stellar wallet connected holding USDC (e.g. 20 USDC), the page shows the **"Add funds to your USDC balance — Minimum amount — 1 USDC"** banner even though the wallet header correctly displays the held balance and it's well above the 1 USDC minimum.

## Root cause

The deposit page and the wallet header read the Stellar USDC balance from **two different sources**:

| | Hook | Mock key | Issuer matched |
|---|---|---|---|
| Header pill (correct) | `useStellarToken()` (`TopBar.tsx`) | `…stellar.balance.usdc` | `usdcIssuer` from `chain.ts` |
| Deposit flow (wrong) | `useStellarSacToken()` (`useDepositFlow.ts`) | `…stellar.balance.sac.usdc` | `stellarAddresses.usdcAsset.issuer` |

When only the classic balance is populated, the SAC hook falls through to a live Horizon query that returns `"0"`, so `stellarUsdcBalanceRaw = 0n < STELLAR_MIN_DEPOSIT`, `hasBalance === false`, and `deposit.tsx` renders the low-balance banner. (The two hooks also match different issuers, so the same divergence can occur against real data if those issuers differ.)

## Fix

Point the deposit flow's USDC deposit balance at the **same `useStellarToken` hook the header uses**, so the deposit-page balance check can never disagree with the header. `useStellarSacToken` is retained for the PLUSD withdraw balance (no header equivalent) and trustline operations — it was only ever used as a balance source for the USDC deposit side.

## Verification

- `npx tsc --noEmit` — clean
- `npx vitest run src/wallet` — 387 pass; the 8 failures are pre-existing in `useStellarWithdrawalQueue.test.tsx` (reproduce on `main`, logged as BUG-3 in `known-bugs.md`)
- ESLint clean on the changed file

Relates to the Stellar deposit/withdraw epic (#498).