### PR TITLE
Fix Stellar SAC address resolution (read-only simulation + name())

### DIFF
--- a/packages/frontend/src/wallet/stellar/chain.ts
+++ b/packages/frontend/src/wallet/stellar/chain.ts
@@ -67,6 +67,21 @@ export const blendNetwork = {
   passphrase: kitNetwork as string,
 } as const;
 
+/**
+ * Source account for read-only contract simulations.
+ *
+ * Soroban `simulateTransaction` needs a structurally valid source account on
+ * the envelope, but for read-only (view) calls it is never charged or
+ * authenticated, so any valid account works. This is the canonical "null"
+ * account — the all-zero ed25519 public key.
+ *
+ * IMPORTANT: do NOT pass a contract ID (`C…`) here. `new Account()` only
+ * accepts a classic ed25519 public key (`G…`) and throws `accountId is
+ * invalid` for a contract address.
+ */
+export const READ_SIMULATION_SOURCE =
+  "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+
 // ── Pipeline protocol contract IDs ─────────────────────────────────────────────
 
 /**

--- a/packages/frontend/src/wallet/stellar/contracts/depositManager.test.ts
+++ b/packages/frontend/src/wallet/stellar/contracts/depositManager.test.ts
@@ -119,6 +119,8 @@ vi.mock("@stellar/stellar-sdk", () => {
 vi.mock("../chain", () => ({
   sorobanRpcUrl: "https://soroban-testnet.stellar.org",
   networkPassphrase: "Test SDF Network ; September 2015",
+  READ_SIMULATION_SOURCE:
+    "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
 }));
 
 // ── Constants ─────────────────────────────────────────────────────────────────

--- a/packages/frontend/src/wallet/stellar/contracts/depositManager.ts
+++ b/packages/frontend/src/wallet/stellar/contracts/depositManager.ts
@@ -29,7 +29,11 @@ import {
   scValToNative,
   rpc as SorobanRpc,
 } from "@stellar/stellar-sdk";
-import { sorobanRpcUrl, networkPassphrase } from "../chain";
+import {
+  sorobanRpcUrl,
+  networkPassphrase,
+  READ_SIMULATION_SOURCE,
+} from "../chain";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -51,7 +55,6 @@ export interface DepositRequest {
 export class DepositManagerClient {
   private readonly contract: Contract;
   private readonly server: SorobanRpc.Server;
-  private readonly contractId: string;
 
   constructor(contractId: string) {
     if (!contractId) {
@@ -60,7 +63,6 @@ export class DepositManagerClient {
           "Set VITE_STELLAR_DEPOSIT_MANAGER_ID in your .env.",
       );
     }
-    this.contractId = contractId;
     this.contract = new Contract(contractId);
     this.server = new SorobanRpc.Server(sorobanRpcUrl, {
       allowHttp: sorobanRpcUrl.startsWith("http://"),
@@ -75,9 +77,10 @@ export class DepositManagerClient {
    * require auth.
    */
   private async simulateReadCall(operation: xdr.Operation): Promise<xdr.ScVal> {
-    // Use a dummy Account (zero sequence) as source for the simulation envelope.
-    // Soroban RPC accepts this for read-only (view) calls.
-    const dummyAccount = new Account(this.contractId, "0");
+    // Read-only simulations require a structurally valid classic source
+    // account (`G…`) on the envelope — NOT the contract ID. Soroban RPC
+    // never charges or authenticates it for view calls.
+    const dummyAccount = new Account(READ_SIMULATION_SOURCE, "0");
 
     const tx = new TransactionBuilder(dummyAccount, {
       fee: BASE_FEE,

--- a/packages/frontend/src/wallet/stellar/contracts/withdrawalQueue.ts
+++ b/packages/frontend/src/wallet/stellar/contracts/withdrawalQueue.ts
@@ -27,7 +27,11 @@ import {
   scValToNative,
   rpc as SorobanRpc,
 } from "@stellar/stellar-sdk";
-import { sorobanRpcUrl, networkPassphrase } from "../chain";
+import {
+  sorobanRpcUrl,
+  networkPassphrase,
+  READ_SIMULATION_SOURCE,
+} from "../chain";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -47,7 +51,6 @@ export interface WithdrawalRequest {
 export class WithdrawalQueueClient {
   private readonly contract: Contract;
   private readonly server: SorobanRpc.Server;
-  private readonly contractId: string;
 
   constructor(contractId: string) {
     if (!contractId) {
@@ -56,7 +59,6 @@ export class WithdrawalQueueClient {
           "Set VITE_STELLAR_WITHDRAWAL_QUEUE_ID in your .env.",
       );
     }
-    this.contractId = contractId;
     this.contract = new Contract(contractId);
     this.server = new SorobanRpc.Server(sorobanRpcUrl, {
       allowHttp: sorobanRpcUrl.startsWith("http://"),
@@ -66,7 +68,9 @@ export class WithdrawalQueueClient {
   // ── Internal simulate helper ───────────────────────────────────────────────
 
   private async simulateReadCall(operation: xdr.Operation): Promise<xdr.ScVal> {
-    const dummyAccount = new Account(this.contractId, "0");
+    // Read-only simulations require a structurally valid classic source
+    // account (`G…`) on the envelope — NOT the contract ID.
+    const dummyAccount = new Account(READ_SIMULATION_SOURCE, "0");
 
     const tx = new TransactionBuilder(dummyAccount, {
       fee: BASE_FEE,

--- a/packages/frontend/src/wallet/stellar/useStellarDepositManagerAddresses.test.tsx
+++ b/packages/frontend/src/wallet/stellar/useStellarDepositManagerAddresses.test.tsx
@@ -8,30 +8,35 @@
  *   2. Mock keys both set → returns mock values; no RPC call.
  *   3. Only one mock key set → falls through to real query path (disabled
  *      in these tests because RPC is mocked away).
- *   4. Happy path: simulated asset()+share() return SAC IDs; SAC asset()
+ *   4. Happy path: simulated asset()+share() return SAC IDs; SAC name()
  *      calls return "CODE:ISSUER" strings; hook returns full addresses.
  *   5. Simulation error → surfaces on `error`.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import React from "react";
-import { renderHook } from "@testing-library/react";
+import { renderHook, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useStellarDepositManagerAddresses } from "./useStellarDepositManagerAddresses";
 
 // ── Hoisted mocks ─────────────────────────────────────────────────────────────
 
-const { mockSimulateTransaction, mockGetAccount, mockIsSimulationError } =
-  vi.hoisted(() => ({
-    mockSimulateTransaction: vi.fn(),
-    mockGetAccount: vi.fn(),
-    mockIsSimulationError: vi.fn().mockReturnValue(false),
-  }));
+const {
+  mockSimulateTransaction,
+  mockGetAccount,
+  mockIsSimulationError,
+  mockContractCall,
+} = vi.hoisted(() => ({
+  mockSimulateTransaction: vi.fn(),
+  mockGetAccount: vi.fn(),
+  mockIsSimulationError: vi.fn().mockReturnValue(false),
+  mockContractCall: vi.fn((method: string) => ({ _method: method })),
+}));
 
 vi.mock("@stellar/stellar-sdk", () => {
   class MockContract {
     call(method: string) {
-      return { _method: method };
+      return mockContractCall(method);
     }
   }
   class MockServer {
@@ -41,6 +46,12 @@ vi.mock("@stellar/stellar-sdk", () => {
     simulateTransaction(tx: unknown) {
       return mockSimulateTransaction(tx);
     }
+  }
+  class MockAccount {
+    constructor(
+      public _id: string,
+      public _seq: string,
+    ) {}
   }
   class MockTransactionBuilder {
     addOperation() {
@@ -56,6 +67,7 @@ vi.mock("@stellar/stellar-sdk", () => {
 
   return {
     Contract: MockContract,
+    Account: MockAccount,
     rpc: {
       Server: MockServer,
       Api: { isSimulationError: mockIsSimulationError },
@@ -84,6 +96,8 @@ vi.mock("./chain", () => ({
   },
   sorobanRpcUrl: "https://soroban-testnet.stellar.org",
   networkPassphrase: "Test SDF Network ; September 2015",
+  READ_SIMULATION_SOURCE:
+    "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
 }));
 
 // ── Constants ─────────────────────────────────────────────────────────────────
@@ -177,5 +191,69 @@ describe("useStellarDepositManagerAddresses — partial mock (one key)", () => {
     // Not in mock-path (hasMock = false); query disabled because mockGetAccount
     // would reject — but we just verify we're not in the mock fast-path.
     expect(result.current.isLoading).toBeDefined();
+  });
+});
+
+// ── Tests: real RPC path ──────────────────────────────────────────────────────
+
+describe("useStellarDepositManagerAddresses — real RPC path", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockDepositManagerId.value = DM_ID;
+    mockSimulateTransaction.mockReset();
+    mockContractCall.mockClear();
+    mockIsSimulationError.mockReturnValue(false);
+  });
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("resolves SAC ids and classic assets via DepositManager asset()/share() + SAC name()", async () => {
+    // Four sequential view calls: DM.asset(), DM.share(), USDC.name(), PLUSD.name().
+    // The SAC classic identity comes from name() ("CODE:ISSUER"), not asset().
+    mockSimulateTransaction
+      .mockReturnValueOnce({ result: { retval: { _value: USDC_ID } } })
+      .mockReturnValueOnce({ result: { retval: { _value: PLUSD_ID } } })
+      .mockReturnValueOnce({
+        result: { retval: { _value: `USDC:${PROTOCOL_ISSUER}` } },
+      })
+      .mockReturnValueOnce({
+        result: { retval: { _value: `PLUSD:${PROTOCOL_ISSUER}` } },
+      });
+
+    const { result } = renderHook(() => useStellarDepositManagerAddresses(), {
+      wrapper: makeWrapper().wrapper,
+    });
+
+    await waitFor(() => expect(result.current.addresses).toBeDefined());
+
+    expect(result.current.addresses?.usdc).toBe(USDC_ID);
+    expect(result.current.addresses?.plusd).toBe(PLUSD_ID);
+    expect(result.current.addresses?.usdcAsset).toEqual({
+      code: "USDC",
+      issuer: PROTOCOL_ISSUER,
+    });
+    expect(result.current.addresses?.plusdAsset).toEqual({
+      code: "PLUSD",
+      issuer: PROTOCOL_ISSUER,
+    });
+    expect(result.current.error).toBeNull();
+    // DepositManager exposes the SAC ids via asset()/share()...
+    expect(mockContractCall).toHaveBeenCalledWith("asset");
+    expect(mockContractCall).toHaveBeenCalledWith("share");
+    // ...while each SAC's classic "CODE:ISSUER" identity comes from name().
+    expect(mockContractCall).toHaveBeenCalledWith("name");
+  });
+
+  it("surfaces a simulation error on `error`", async () => {
+    mockIsSimulationError.mockReturnValue(true);
+    mockSimulateTransaction.mockReturnValue({ error: "boom" });
+
+    const { result } = renderHook(() => useStellarDepositManagerAddresses(), {
+      wrapper: makeWrapper().wrapper,
+    });
+
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(result.current.addresses).toBeUndefined();
   });
 });

--- a/packages/frontend/src/wallet/stellar/useStellarDepositManagerAddresses.ts
+++ b/packages/frontend/src/wallet/stellar/useStellarDepositManagerAddresses.ts
@@ -25,7 +25,7 @@
  * Caching: results are cached forever (addresses are static per deployment).
  *
  * IMPORTANT: The protocol USDC issuer (`GC5SUAXM…`) is derived from the SAC's
- * `asset()` return value — it is NOT the Circle issuer in `chain.ts`
+ * `name()` return value — it is NOT the Circle issuer in `chain.ts`
  * (`usdcIssuer`). Do not substitute one for the other.
  */
 
@@ -40,7 +40,12 @@ import {
 } from "@stellar/stellar-sdk";
 import { readMock, useMock } from "../evm/mock";
 import { STELLAR_MOCK_KEYS, parseStellarContractId } from "./mock";
-import { depositManagerId, sorobanRpcUrl, networkPassphrase } from "./chain";
+import {
+  depositManagerId,
+  sorobanRpcUrl,
+  networkPassphrase,
+  READ_SIMULATION_SOURCE,
+} from "./chain";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -82,8 +87,9 @@ async function callView(
 ): Promise<unknown> {
   const contract = new Contract(contractId);
   const op = contract.call(method);
-  // Use a dummy Account (zero sequence) for read-only simulation envelopes.
-  const dummyAccount = new Account(contractId, "0");
+  // Read-only simulations need a structurally valid classic source account
+  // (`G…`) on the envelope — NOT the contract ID. See READ_SIMULATION_SOURCE.
+  const dummyAccount = new Account(READ_SIMULATION_SOURCE, "0");
 
   const tx = new TransactionBuilder(dummyAccount, {
     fee: BASE_FEE,
@@ -110,7 +116,7 @@ async function callView(
 
 /**
  * Fetches the SAC metadata (`asset()` and `share()`) from the DepositManager
- * contract and then reads each SAC's `asset()` to get the classic
+ * contract and then reads each SAC's `name()` to get the classic
  * `"CODE:ISSUER"` string.
  */
 async function fetchAddresses(
@@ -132,16 +138,18 @@ async function fetchAddresses(
     "share",
   )) as string;
 
-  // Each SAC's `asset()` view returns the classic asset string: `"CODE:ISSUER"`.
+  // Each SAC's `name()` view returns the classic asset string: `"CODE:ISSUER"`.
+  // (Stellar Asset Contracts expose the classic identity via `name()`; they
+  // have no `asset()` view — calling it errors with `Error(Value, InvalidInput)`.)
   const usdcSacAssetStr = (await callView(
     server,
     usdcContractId,
-    "asset",
+    "name",
   )) as string;
   const plusdSacAssetStr = (await callView(
     server,
     plusdContractId,
-    "asset",
+    "name",
   )) as string;
 
   return {


### PR DESCRIPTION
## Problem

On the Stellar deposit/withdraw page, the PLUSD (and USDC) trustline status was never determined: the on-chain address resolver (`useStellarDepositManagerAddresses`) always failed on the real RPC path, leaving `addresses` `undefined`. Because `needsTrustline` is gated on `!!addresses?.plusdAsset`, it defaulted to `false` and the UI showed trustlines as **already enabled** — a false positive even for accounts with no PLUSD trustline.

The PLUSD asset the protocol expects is derived on-chain: `DepositManager.share()` → SAC `CAC7JMGR…` → classic **`PLUSD:GC5SUAXM…`**.

## Root causes (both verified against testnet)

1. **Wrong simulation source account.** Read-only view simulations built their envelope source from the *contract* ID: `new Account(contractId, "0")`. `@stellar/stellar-sdk` only accepts a classic `G…` ed25519 key and throws `accountId is invalid` for a `C…` address — so every simulation threw before reaching the RPC. The same defect was in the `DepositManagerClient` and `WithdrawalQueueClient` read helpers.
2. **Wrong view method.** The resolver read each SAC's classic `"CODE:ISSUER"` identity via `asset()`. SACs don't implement `asset()` (it errors `Error(Value, InvalidInput)`); the classic identity is exposed via **`name()`**.

## Changes

- Add `READ_SIMULATION_SOURCE` (canonical all-zero `G…` null account) to `chain.ts`; use it as the simulation source in the resolver and both contract clients. Drop the now-unused `contractId` fields.
- Read SAC classic identity via `name()` instead of `asset()` (the `DepositManager.asset()`/`share()` reads that return the SAC ids are unchanged).
- Add real-RPC-path regression tests (happy path + simulation error) covering the previously-untested branch that hid both bugs.

## Verification

- `tsc -b` clean; ESLint + Prettier clean.
- New resolver tests pass; full frontend suite shows no new failures (the 3 unrelated failing files — `AccountDropdown`, `-stake` #615, `useStellarWithdrawalQueue` — fail identically on `main`).
- Manually confirmed against testnet that with the null-account source + `name()`, `DepositManager.share()` → `CAC7JMGR…` and its `name()` → `PLUSD:GC5SUAXM…`.