### PR TITLE
Use single on-chain protocol USDC (drop Circle issuer)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -195,6 +195,5 @@ VITE_WALLETCONNECT_PROJECT_ID=replace-me                                 # provi
 VITE_STELLAR_NETWORK=testnet                                             # "testnet" (default) or "mainnet"
 VITE_STELLAR_CHAIN_ID=99000001                                           # backend chain_id for Stellar voucher/API dispatch
 VITE_STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org             # Stellar Horizon base URL
-VITE_STELLAR_USDC_ISSUER=GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5  # Circle USDC issuer (testnet)
 # VITE_STELLAR_DEPOSIT_MANAGER_ID=CARFA2QETOZVKHSG4BCEEXMJHTYR2Z75VR7WQNX4MWZ33RQMKRKATIVI  # Pipeline DepositManager Soroban contract ID (testnet 2026-06-10)
 # VITE_STELLAR_WITHDRAWAL_QUEUE_ID=CC3TWGFXP2XUZJXGLVTM2G4K2PF2YTC6BKDRPZIUPSVETNYAO57GU3Q7  # Pipeline WithdrawalQueue Soroban contract ID (redeployed testnet 2026-06-16)

--- a/packages/frontend/src/lib/env.ts
+++ b/packages/frontend/src/lib/env.ts
@@ -116,16 +116,6 @@ export const ENV = Object.freeze({
   ),
 
   /**
-   * Stellar USDC issuer address. Defaults to Circle's official testnet issuer.
-   * The mainnet issuer (`GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN`)
-   * must be set via env when `VITE_STELLAR_NETWORK=mainnet`.
-   */
-  STELLAR_USDC_ISSUER: readString(
-    "VITE_STELLAR_USDC_ISSUER",
-    "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
-  ),
-
-  /**
    * Soroban RPC URL — distinct from Horizon. Contract invocations (Blend
    * deposit/withdraw) go through the Soroban RPC (simulate → assemble → send),
    * NOT Horizon. Defaults to the public Stellar testnet Soroban RPC.
@@ -148,8 +138,8 @@ export const ENV = Object.freeze({
   ),
 
   /**
-   * Blend testnet USDC reserve — a Soroban token contract (NOT the classic
-   * USDC asset that `STELLAR_USDC_ISSUER` refers to). This is the `address`
+   * Blend testnet USDC reserve — a Soroban token contract (NOT the protocol
+   * USDC asset derived on-chain from the DepositManager). This is the `address`
    * passed in a Blend supply/withdraw request when depositing USDC.
    */
   STELLAR_BLEND_USDC_ID: readString(

--- a/packages/frontend/src/wallet/stellar/chain.ts
+++ b/packages/frontend/src/wallet/stellar/chain.ts
@@ -67,6 +67,21 @@ export const blendNetwork = {
   passphrase: kitNetwork as string,
 } as const;
 
+/**
+ * Source account for read-only contract simulations.
+ *
+ * Soroban `simulateTransaction` needs a structurally valid source account on
+ * the envelope, but for read-only (view) calls it is never charged or
+ * authenticated, so any valid account works. This is the canonical "null"
+ * account — the all-zero ed25519 public key.
+ *
+ * IMPORTANT: do NOT pass a contract ID (`C…`) here. `new Account()` only
+ * accepts a classic ed25519 public key (`G…`) and throws `accountId is
+ * invalid` for a contract address.
+ */
+export const READ_SIMULATION_SOURCE =
+  "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+
 // ── Pipeline protocol contract IDs ─────────────────────────────────────────────
 
 /**

--- a/packages/frontend/src/wallet/stellar/chain.ts
+++ b/packages/frontend/src/wallet/stellar/chain.ts
@@ -37,9 +37,6 @@ export const networkPassphrase: string = kitNetwork;
 /** Stellar Horizon base URL for the configured network. */
 export const horizonUrl: string = ENV.STELLAR_HORIZON_URL;
 
-/** Circle USDC issuer address on the configured Stellar network. */
-export const usdcIssuer: string = ENV.STELLAR_USDC_ISSUER;
-
 // ── Soroban / Blend constants ──────────────────────────────────────────────────
 
 /**

--- a/packages/frontend/src/wallet/stellar/contracts/depositManager.test.ts
+++ b/packages/frontend/src/wallet/stellar/contracts/depositManager.test.ts
@@ -119,6 +119,8 @@ vi.mock("@stellar/stellar-sdk", () => {
 vi.mock("../chain", () => ({
   sorobanRpcUrl: "https://soroban-testnet.stellar.org",
   networkPassphrase: "Test SDF Network ; September 2015",
+  READ_SIMULATION_SOURCE:
+    "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
 }));
 
 // ── Constants ─────────────────────────────────────────────────────────────────

--- a/packages/frontend/src/wallet/stellar/contracts/depositManager.ts
+++ b/packages/frontend/src/wallet/stellar/contracts/depositManager.ts
@@ -29,7 +29,11 @@ import {
   scValToNative,
   rpc as SorobanRpc,
 } from "@stellar/stellar-sdk";
-import { sorobanRpcUrl, networkPassphrase } from "../chain";
+import {
+  sorobanRpcUrl,
+  networkPassphrase,
+  READ_SIMULATION_SOURCE,
+} from "../chain";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -51,7 +55,6 @@ export interface DepositRequest {
 export class DepositManagerClient {
   private readonly contract: Contract;
   private readonly server: SorobanRpc.Server;
-  private readonly contractId: string;
 
   constructor(contractId: string) {
     if (!contractId) {
@@ -60,7 +63,6 @@ export class DepositManagerClient {
           "Set VITE_STELLAR_DEPOSIT_MANAGER_ID in your .env.",
       );
     }
-    this.contractId = contractId;
     this.contract = new Contract(contractId);
     this.server = new SorobanRpc.Server(sorobanRpcUrl, {
       allowHttp: sorobanRpcUrl.startsWith("http://"),
@@ -75,9 +77,10 @@ export class DepositManagerClient {
    * require auth.
    */
   private async simulateReadCall(operation: xdr.Operation): Promise<xdr.ScVal> {
-    // Use a dummy Account (zero sequence) as source for the simulation envelope.
-    // Soroban RPC accepts this for read-only (view) calls.
-    const dummyAccount = new Account(this.contractId, "0");
+    // Read-only simulations require a structurally valid classic source
+    // account (`G…`) on the envelope — NOT the contract ID. Soroban RPC
+    // never charges or authenticates it for view calls.
+    const dummyAccount = new Account(READ_SIMULATION_SOURCE, "0");
 
     const tx = new TransactionBuilder(dummyAccount, {
       fee: BASE_FEE,

--- a/packages/frontend/src/wallet/stellar/contracts/withdrawalQueue.ts
+++ b/packages/frontend/src/wallet/stellar/contracts/withdrawalQueue.ts
@@ -27,7 +27,11 @@ import {
   scValToNative,
   rpc as SorobanRpc,
 } from "@stellar/stellar-sdk";
-import { sorobanRpcUrl, networkPassphrase } from "../chain";
+import {
+  sorobanRpcUrl,
+  networkPassphrase,
+  READ_SIMULATION_SOURCE,
+} from "../chain";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -47,7 +51,6 @@ export interface WithdrawalRequest {
 export class WithdrawalQueueClient {
   private readonly contract: Contract;
   private readonly server: SorobanRpc.Server;
-  private readonly contractId: string;
 
   constructor(contractId: string) {
     if (!contractId) {
@@ -56,7 +59,6 @@ export class WithdrawalQueueClient {
           "Set VITE_STELLAR_WITHDRAWAL_QUEUE_ID in your .env.",
       );
     }
-    this.contractId = contractId;
     this.contract = new Contract(contractId);
     this.server = new SorobanRpc.Server(sorobanRpcUrl, {
       allowHttp: sorobanRpcUrl.startsWith("http://"),
@@ -66,7 +68,9 @@ export class WithdrawalQueueClient {
   // ── Internal simulate helper ───────────────────────────────────────────────
 
   private async simulateReadCall(operation: xdr.Operation): Promise<xdr.ScVal> {
-    const dummyAccount = new Account(this.contractId, "0");
+    // Read-only simulations require a structurally valid classic source
+    // account (`G…`) on the envelope — NOT the contract ID.
+    const dummyAccount = new Account(READ_SIMULATION_SOURCE, "0");
 
     const tx = new TransactionBuilder(dummyAccount, {
       fee: BASE_FEE,

--- a/packages/frontend/src/wallet/stellar/useStellarDepositManagerAddresses.test.tsx
+++ b/packages/frontend/src/wallet/stellar/useStellarDepositManagerAddresses.test.tsx
@@ -8,30 +8,35 @@
  *   2. Mock keys both set → returns mock values; no RPC call.
  *   3. Only one mock key set → falls through to real query path (disabled
  *      in these tests because RPC is mocked away).
- *   4. Happy path: simulated asset()+share() return SAC IDs; SAC asset()
+ *   4. Happy path: simulated asset()+share() return SAC IDs; SAC name()
  *      calls return "CODE:ISSUER" strings; hook returns full addresses.
  *   5. Simulation error → surfaces on `error`.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import React from "react";
-import { renderHook } from "@testing-library/react";
+import { renderHook, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useStellarDepositManagerAddresses } from "./useStellarDepositManagerAddresses";
 
 // ── Hoisted mocks ─────────────────────────────────────────────────────────────
 
-const { mockSimulateTransaction, mockGetAccount, mockIsSimulationError } =
-  vi.hoisted(() => ({
-    mockSimulateTransaction: vi.fn(),
-    mockGetAccount: vi.fn(),
-    mockIsSimulationError: vi.fn().mockReturnValue(false),
-  }));
+const {
+  mockSimulateTransaction,
+  mockGetAccount,
+  mockIsSimulationError,
+  mockContractCall,
+} = vi.hoisted(() => ({
+  mockSimulateTransaction: vi.fn(),
+  mockGetAccount: vi.fn(),
+  mockIsSimulationError: vi.fn().mockReturnValue(false),
+  mockContractCall: vi.fn((method: string) => ({ _method: method })),
+}));
 
 vi.mock("@stellar/stellar-sdk", () => {
   class MockContract {
     call(method: string) {
-      return { _method: method };
+      return mockContractCall(method);
     }
   }
   class MockServer {
@@ -41,6 +46,12 @@ vi.mock("@stellar/stellar-sdk", () => {
     simulateTransaction(tx: unknown) {
       return mockSimulateTransaction(tx);
     }
+  }
+  class MockAccount {
+    constructor(
+      public _id: string,
+      public _seq: string,
+    ) {}
   }
   class MockTransactionBuilder {
     addOperation() {
@@ -56,6 +67,7 @@ vi.mock("@stellar/stellar-sdk", () => {
 
   return {
     Contract: MockContract,
+    Account: MockAccount,
     rpc: {
       Server: MockServer,
       Api: { isSimulationError: mockIsSimulationError },
@@ -84,6 +96,8 @@ vi.mock("./chain", () => ({
   },
   sorobanRpcUrl: "https://soroban-testnet.stellar.org",
   networkPassphrase: "Test SDF Network ; September 2015",
+  READ_SIMULATION_SOURCE:
+    "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
 }));
 
 // ── Constants ─────────────────────────────────────────────────────────────────
@@ -177,5 +191,69 @@ describe("useStellarDepositManagerAddresses — partial mock (one key)", () => {
     // Not in mock-path (hasMock = false); query disabled because mockGetAccount
     // would reject — but we just verify we're not in the mock fast-path.
     expect(result.current.isLoading).toBeDefined();
+  });
+});
+
+// ── Tests: real RPC path ──────────────────────────────────────────────────────
+
+describe("useStellarDepositManagerAddresses — real RPC path", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockDepositManagerId.value = DM_ID;
+    mockSimulateTransaction.mockReset();
+    mockContractCall.mockClear();
+    mockIsSimulationError.mockReturnValue(false);
+  });
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("resolves SAC ids and classic assets via DepositManager asset()/share() + SAC name()", async () => {
+    // Four sequential view calls: DM.asset(), DM.share(), USDC.name(), PLUSD.name().
+    // The SAC classic identity comes from name() ("CODE:ISSUER"), not asset().
+    mockSimulateTransaction
+      .mockReturnValueOnce({ result: { retval: { _value: USDC_ID } } })
+      .mockReturnValueOnce({ result: { retval: { _value: PLUSD_ID } } })
+      .mockReturnValueOnce({
+        result: { retval: { _value: `USDC:${PROTOCOL_ISSUER}` } },
+      })
+      .mockReturnValueOnce({
+        result: { retval: { _value: `PLUSD:${PROTOCOL_ISSUER}` } },
+      });
+
+    const { result } = renderHook(() => useStellarDepositManagerAddresses(), {
+      wrapper: makeWrapper().wrapper,
+    });
+
+    await waitFor(() => expect(result.current.addresses).toBeDefined());
+
+    expect(result.current.addresses?.usdc).toBe(USDC_ID);
+    expect(result.current.addresses?.plusd).toBe(PLUSD_ID);
+    expect(result.current.addresses?.usdcAsset).toEqual({
+      code: "USDC",
+      issuer: PROTOCOL_ISSUER,
+    });
+    expect(result.current.addresses?.plusdAsset).toEqual({
+      code: "PLUSD",
+      issuer: PROTOCOL_ISSUER,
+    });
+    expect(result.current.error).toBeNull();
+    // DepositManager exposes the SAC ids via asset()/share()...
+    expect(mockContractCall).toHaveBeenCalledWith("asset");
+    expect(mockContractCall).toHaveBeenCalledWith("share");
+    // ...while each SAC's classic "CODE:ISSUER" identity comes from name().
+    expect(mockContractCall).toHaveBeenCalledWith("name");
+  });
+
+  it("surfaces a simulation error on `error`", async () => {
+    mockIsSimulationError.mockReturnValue(true);
+    mockSimulateTransaction.mockReturnValue({ error: "boom" });
+
+    const { result } = renderHook(() => useStellarDepositManagerAddresses(), {
+      wrapper: makeWrapper().wrapper,
+    });
+
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(result.current.addresses).toBeUndefined();
   });
 });

--- a/packages/frontend/src/wallet/stellar/useStellarDepositManagerAddresses.ts
+++ b/packages/frontend/src/wallet/stellar/useStellarDepositManagerAddresses.ts
@@ -25,8 +25,8 @@
  * Caching: results are cached forever (addresses are static per deployment).
  *
  * IMPORTANT: The protocol USDC issuer (`GC5SUAXM…`) is derived from the SAC's
- * `name()` return value — it is NOT the Circle issuer in `chain.ts`
- * (`usdcIssuer`). Do not substitute one for the other.
+ * `name()` return value. This is the single source of truth for the USDC asset
+ * across the app — balance reads, trustline checks, and transfers all use it.
  */
 
 import { useQuery } from "@tanstack/react-query";

--- a/packages/frontend/src/wallet/stellar/useStellarDepositManagerAddresses.ts
+++ b/packages/frontend/src/wallet/stellar/useStellarDepositManagerAddresses.ts
@@ -25,7 +25,7 @@
  * Caching: results are cached forever (addresses are static per deployment).
  *
  * IMPORTANT: The protocol USDC issuer (`GC5SUAXM…`) is derived from the SAC's
- * `asset()` return value — it is NOT the Circle issuer in `chain.ts`
+ * `name()` return value — it is NOT the Circle issuer in `chain.ts`
  * (`usdcIssuer`). Do not substitute one for the other.
  */
 
@@ -40,7 +40,12 @@ import {
 } from "@stellar/stellar-sdk";
 import { readMock, useMock } from "../evm/mock";
 import { STELLAR_MOCK_KEYS, parseStellarContractId } from "./mock";
-import { depositManagerId, sorobanRpcUrl, networkPassphrase } from "./chain";
+import {
+  depositManagerId,
+  sorobanRpcUrl,
+  networkPassphrase,
+  READ_SIMULATION_SOURCE,
+} from "./chain";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -82,8 +87,9 @@ async function callView(
 ): Promise<unknown> {
   const contract = new Contract(contractId);
   const op = contract.call(method);
-  // Use a dummy Account (zero sequence) for read-only simulation envelopes.
-  const dummyAccount = new Account(contractId, "0");
+  // Read-only simulations need a structurally valid classic source account
+  // (`G…`) on the envelope — NOT the contract ID. See READ_SIMULATION_SOURCE.
+  const dummyAccount = new Account(READ_SIMULATION_SOURCE, "0");
 
   const tx = new TransactionBuilder(dummyAccount, {
     fee: BASE_FEE,
@@ -110,7 +116,7 @@ async function callView(
 
 /**
  * Fetches the SAC metadata (`asset()` and `share()`) from the DepositManager
- * contract and then reads each SAC's `asset()` to get the classic
+ * contract and then reads each SAC's `name()` to get the classic
  * `"CODE:ISSUER"` string.
  */
 async function fetchAddresses(
@@ -132,16 +138,18 @@ async function fetchAddresses(
     "share",
   )) as string;
 
-  // Each SAC's `asset()` view returns the classic asset string: `"CODE:ISSUER"`.
+  // Each SAC's `name()` view returns the classic asset string: `"CODE:ISSUER"`.
+  // (Stellar Asset Contracts expose the classic identity via `name()`; they
+  // have no `asset()` view — calling it errors with `Error(Value, InvalidInput)`.)
   const usdcSacAssetStr = (await callView(
     server,
     usdcContractId,
-    "asset",
+    "name",
   )) as string;
   const plusdSacAssetStr = (await callView(
     server,
     plusdContractId,
-    "asset",
+    "name",
   )) as string;
 
   return {

--- a/packages/frontend/src/wallet/stellar/useStellarToken.test.tsx
+++ b/packages/frontend/src/wallet/stellar/useStellarToken.test.tsx
@@ -10,8 +10,12 @@
  *   5. Unfunded account (404) — loadAccount rejects with NotFoundError → "0".
  *   6. Hard error — loadAccount rejects with generic error → surfaces on `error`.
  *   7. Disconnected — query disabled; balance undefined; loadAccount never called.
- *   8. Mock key — hook returns mock value; loadAccount never called.
- *   9. refetchBalance is a function.
+ *   8. Issuer not resolved — query idle until the on-chain USDC issuer loads.
+ *   9. Mock key — hook returns mock value; loadAccount never called.
+ *  10. refetchBalance is a function.
+ *
+ * The protocol USDC issuer is derived on-chain via
+ * `useStellarDepositManagerAddresses` (mocked here), not from env.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import React from "react";
@@ -63,7 +67,34 @@ const { USDC_ISSUER, HORIZON_URL } = vi.hoisted(() => ({
 
 vi.mock("./chain", () => ({
   horizonUrl: HORIZON_URL,
-  usdcIssuer: USDC_ISSUER,
+}));
+
+// ── Mock ./useStellarDepositManagerAddresses ──────────────────────────────────
+// The protocol USDC issuer is now derived on-chain. `mockAddresses.value` is
+// the resolver's `addresses` — set to `undefined` to simulate the not-yet-
+// resolved state (query stays idle).
+
+const mockAddresses = vi.hoisted(() => ({
+  value: {
+    usdc: "CCWX3TKH3K5SQDPOBGQTGOGE6Q5VEZWCOYJ2HDVV5U6GNN5U4WOEB3C7",
+    plusd: "CAC7JMGRFZBL4IS4WBO5R3AMTK3C53FEOQZSU2WL5C4TWCRFAYWFSIBN",
+    usdcAsset: {
+      code: "USDC",
+      issuer: "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+    },
+    plusdAsset: {
+      code: "PLUSD",
+      issuer: "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+    },
+  } as object | undefined,
+}));
+
+vi.mock("./useStellarDepositManagerAddresses", () => ({
+  useStellarDepositManagerAddresses: () => ({
+    addresses: mockAddresses.value,
+    isLoading: false,
+    error: null,
+  }),
 }));
 
 // ── Mock ./mock ───────────────────────────────────────────────────────────────
@@ -311,6 +342,37 @@ describe("useStellarToken — disconnected", () => {
     expect(result.current.formattedBalance).toBeUndefined();
     expect(result.current.isLoading).toBe(false);
     expect(result.current.error).toBeNull();
+    expect(mockLoadAccount).not.toHaveBeenCalled();
+  });
+});
+
+// ── Tests: protocol issuer not yet resolved ───────────────────────────────────
+
+describe("useStellarToken — issuer not resolved", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockStellarWallet.address = STELLAR_ADDR;
+    mockStellarWallet.isConnected = true;
+    mockLoadAccount.mockClear();
+    mockAddresses.value = undefined; // resolver still loading
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    mockAddresses.value = {
+      usdc: "CCWX3TKH3K5SQDPOBGQTGOGE6Q5VEZWCOYJ2HDVV5U6GNN5U4WOEB3C7",
+      plusd: "CAC7JMGRFZBL4IS4WBO5R3AMTK3C53FEOQZSU2WL5C4TWCRFAYWFSIBN",
+      usdcAsset: { code: "USDC", issuer: USDC_ISSUER },
+      plusdAsset: { code: "PLUSD", issuer: USDC_ISSUER },
+    };
+  });
+
+  it("stays idle (no Horizon call) until the protocol USDC issuer resolves", () => {
+    const { result } = renderHook(() => useStellarToken(), {
+      wrapper: makeWrapper().wrapper,
+    });
+
+    expect(result.current.balance).toBeUndefined();
     expect(mockLoadAccount).not.toHaveBeenCalled();
   });
 });

--- a/packages/frontend/src/wallet/stellar/useStellarToken.ts
+++ b/packages/frontend/src/wallet/stellar/useStellarToken.ts
@@ -25,15 +25,19 @@
  * Unfunded account (404 from Horizon): treated the same as no-trustline →
  * `balance === "0"`, `error === null`. The account simply holds nothing yet.
  *
- * USDC is matched by BOTH `asset_code === "USDC"` AND
- * `asset_issuer === usdcIssuer` to avoid picking up a same-code asset from a
- * different (fake) issuer.
+ * USDC is matched by BOTH `asset_code === "USDC"` AND `asset_issuer ===` the
+ * protocol issuer. That issuer is the single on-chain source of truth derived
+ * from the DepositManager (`useStellarDepositManagerAddresses().usdcAsset`) —
+ * the same USDC the deposit/withdraw flow transfers and checks trustlines
+ * against. The query stays idle until that issuer resolves, so the balance can
+ * never reflect a different (e.g. Circle) USDC than the protocol uses.
  */
 import { useQuery } from "@tanstack/react-query";
 import { Horizon } from "@stellar/stellar-sdk";
-import { horizonUrl, usdcIssuer } from "./chain";
+import { horizonUrl } from "./chain";
 import { useMock, readMock } from "../evm/mock";
 import { useStellarWallet } from "./useStellarWallet";
+import { useStellarDepositManagerAddresses } from "./useStellarDepositManagerAddresses";
 import { STELLAR_MOCK_KEYS } from "./mock";
 
 // ── Parse helpers ──────────────────────────────────────────────────────────────
@@ -94,6 +98,11 @@ export interface UseStellarTokenResult {
 export function useStellarToken(): UseStellarTokenResult {
   const { address, isConnected } = useStellarWallet();
 
+  // Protocol USDC issuer — single source of truth, derived on-chain from the
+  // DepositManager. Undefined until the resolver loads.
+  const { addresses } = useStellarDepositManagerAddresses();
+  const usdcIssuer = addresses?.usdcAsset.issuer;
+
   // ── Mock read (reactive) ──────────────────────────────────────────────────
   const mockBalance = useMock(STELLAR_MOCK_KEYS.balanceUsdc, parseString);
 
@@ -138,8 +147,11 @@ export function useStellarToken(): UseStellarTokenResult {
   };
 
   // ── useQuery ──────────────────────────────────────────────────────────────
-  // Disabled when mock is present, wallet is disconnected, or address missing.
-  const shouldRunQuery = mockBalance === undefined && isConnected && !!address;
+  // Disabled when mock is present, wallet is disconnected, address missing, or
+  // the protocol USDC issuer has not resolved yet (avoids a premature $0.00
+  // flash and matching against an undefined issuer).
+  const shouldRunQuery =
+    mockBalance === undefined && isConnected && !!address && !!usdcIssuer;
 
   const query = useQuery({
     queryKey: ["stellarUsdcBalance", address, usdcIssuer, horizonUrl],


### PR DESCRIPTION
> **Stacked on #628** (`fix/stellar-sac-address-resolver`). Review/merge #628 first; GitHub will retarget this PR to `main` once #628 merges. The diff below is only this change.

## Problem

The Stellar app used **two different USDC assets**:

| Concern | Issuer | Source |
|---|---|---|
| Balance (wallet header + deposit/withdraw page) | `GBBD47IF…` (Circle) | `VITE_STELLAR_USDC_ISSUER` |
| Trustline check + actual deposit/withdraw transfer | `GC5SUAXM…` (protocol, SAC `CCWX3TKH…`) | on-chain `DepositManager.asset()` |

So the "$X USDC" you saw was your **Circle** USDC, but the flow deposits the **protocol** USDC (`GC5SUAXM…`) — a different asset. You could see a non-zero balance you can't actually deposit.

## Fix — one USDC, the protocol asset

- `useStellarToken` now derives the matching issuer from `useStellarDepositManagerAddresses().usdcAsset` (on-chain, single source of truth), and stays idle until it resolves (no premature `$0.00` flash, no matching against an undefined issuer).
- Removed the redundant Circle USDC config entirely: `chain.ts` `usdcIssuer`, `env.ts` `STELLAR_USDC_ISSUER`, and the `VITE_STELLAR_USDC_ISSUER` lines in `.env` / `.env.example`.
- Updated `useStellarToken` tests to mock the resolver as the issuer source and added coverage for the not-yet-resolved gate.

Now balance, trustline, and transfer all reference the same on-chain protocol USDC. With your account (no `USDC:GC5SUAXM…` trustline), the balance correctly reads `$0.00`.

## Verification

- `tsc -b`, ESLint, Prettier all clean.
- `useStellarToken` / `-deposit` / `TopBar` suites pass (122 tests).
- Full frontend suite: no new failures (the 3 unrelated failing files — `AccountDropdown`, `-stake` #615, `useStellarWithdrawalQueue` — fail identically on `main`).