### PR TITLE
fix(stellar): preserve Strkey case across KYC, Crystal, and PnL paths

### DIFF
--- a/packages/api/src/routes/kyc.rs
+++ b/packages/api/src/routes/kyc.rs
@@ -10,7 +10,9 @@ use utoipa::{OpenApi, ToSchema};
 
 use crate::middleware::webhook_auth::validate_webhook;
 use crate::routes::common::{resolve_chain, ChainQuery};
+use crate::routes::vouchers::normalise_wallet;
 use crate::AppState;
+use shared::chains::parse_chain_type;
 
 pub fn router() -> Router<Arc<AppState>> {
     Router::new()
@@ -84,11 +86,26 @@ async fn create_applicant(
 ) -> impl IntoResponse {
     let chain_id = resolve_chain(&state, query.chain_id);
 
-    let profile = match state
-        .kyc_repo
-        .get_lp_profile(chain_id, &req.wallet_address)
-        .await
-    {
+    let chain_kind = match parse_chain_type(chain_id) {
+        Ok(k) => k,
+        Err(e) => {
+            tracing::error!(error = %e, chain_id, "failed to determine chain type");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": "invalid chain type configuration"})),
+            )
+                .into_response();
+        }
+    };
+
+    let wallet = match normalise_wallet(chain_kind, &req.wallet_address) {
+        Ok(w) => w,
+        Err((status, msg)) => {
+            return (status, Json(serde_json::json!({ "error": msg }))).into_response();
+        }
+    };
+
+    let profile = match state.kyc_repo.get_lp_profile(chain_id, &wallet).await {
         Ok(Some(p)) => p,
         Ok(None) => {
             return (
@@ -122,11 +139,11 @@ async fn create_applicant(
             .into_response();
     };
 
-    match sumsub_client.create_applicant(&req.wallet_address).await {
+    match sumsub_client.create_applicant(&wallet).await {
         Ok(resp) => {
             if let Err(e) = state
                 .kyc_repo
-                .set_applicant_id(chain_id, &req.wallet_address, &resp.id)
+                .set_applicant_id(chain_id, &wallet, &resp.id)
                 .await
             {
                 tracing::error!("failed to store applicant_id: {e:?}");
@@ -167,6 +184,25 @@ async fn create_token(
 ) -> impl IntoResponse {
     let chain_id = resolve_chain(&state, query.chain_id);
 
+    let chain_kind = match parse_chain_type(chain_id) {
+        Ok(k) => k,
+        Err(e) => {
+            tracing::error!(error = %e, chain_id, "failed to determine chain type");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": "invalid chain type configuration"})),
+            )
+                .into_response();
+        }
+    };
+
+    let wallet = match normalise_wallet(chain_kind, &req.wallet_address) {
+        Ok(w) => w,
+        Err((status, msg)) => {
+            return (status, Json(serde_json::json!({ "error": msg }))).into_response();
+        }
+    };
+
     let Some(ref sumsub_client) = state.sumsub_client else {
         return (
             StatusCode::SERVICE_UNAVAILABLE,
@@ -182,11 +218,7 @@ async fn create_token(
             .into_response();
     };
 
-    match state
-        .kyc_repo
-        .get_lp_profile(chain_id, &req.wallet_address)
-        .await
-    {
+    match state.kyc_repo.get_lp_profile(chain_id, &wallet).await {
         Ok(Some(_)) => {}
         Ok(None) => {
             return (
@@ -205,10 +237,7 @@ async fn create_token(
         }
     }
 
-    match sumsub_client
-        .generate_access_token(&req.wallet_address)
-        .await
-    {
+    match sumsub_client.generate_access_token(&wallet).await {
         Ok(resp) => {
             let expires_at = chrono::Utc::now()
                 + chrono::Duration::seconds(sumsub_settings.token_ttl_secs as i64);
@@ -257,11 +286,26 @@ async fn get_status(
 ) -> impl IntoResponse {
     let chain_id = resolve_chain(&state, query.chain_id);
 
-    match state
-        .kyc_repo
-        .get_lp_profile(chain_id, &wallet_address)
-        .await
-    {
+    let chain_kind = match parse_chain_type(chain_id) {
+        Ok(k) => k,
+        Err(e) => {
+            tracing::error!(error = %e, chain_id, "failed to determine chain type");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": "invalid chain type configuration"})),
+            )
+                .into_response();
+        }
+    };
+
+    let wallet = match normalise_wallet(chain_kind, &wallet_address) {
+        Ok(w) => w,
+        Err((status, msg)) => {
+            return (status, Json(serde_json::json!({ "error": msg }))).into_response();
+        }
+    };
+
+    match state.kyc_repo.get_lp_profile(chain_id, &wallet).await {
         Ok(Some(profile)) => Json(KycStatusResponse {
             sumsub_kyc_status: profile.sumsub_kyc_status,
             sumsub_review_status: profile.sumsub_review_status,
@@ -324,8 +368,17 @@ async fn webhook_callback(
         return (StatusCode::BAD_REQUEST, "sandbox mode mismatch").into_response();
     }
 
+    // Normalise to match how lp_profiles stores wallets: EVM rows are lowercased
+    // by populate_profiles_from_deposits, Stellar rows keep Strkey case verbatim.
+    // The webhook has no chain context, so detect by prefix.
     let wallet_address = match &payload.external_user_id {
-        Some(id) if !id.is_empty() => id.clone(),
+        Some(id) if !id.is_empty() => {
+            if id.starts_with("0x") {
+                id.to_lowercase()
+            } else {
+                id.clone()
+            }
+        }
         _ => {
             tracing::warn!("webhook missing external_user_id");
             return (StatusCode::BAD_REQUEST, "missing external_user_id").into_response();

--- a/packages/api/src/routes/pnl.rs
+++ b/packages/api/src/routes/pnl.rs
@@ -12,7 +12,9 @@ use serde::{Deserialize, Serialize};
 use utoipa::{OpenApi, ToSchema};
 
 use crate::routes::common::resolve_chain;
+use crate::routes::vouchers::normalise_wallet;
 use crate::AppState;
+use shared::chains::parse_chain_type;
 
 pub fn router() -> Router<Arc<AppState>> {
     Router::new().route("/pnl", get(get_pnl))
@@ -75,8 +77,26 @@ async fn get_pnl(
     State(state): State<Arc<AppState>>,
     Query(query): Query<PnlQuery>,
 ) -> impl IntoResponse {
-    let wallet = query.wallet.to_lowercase();
     let chain_id = resolve_chain(&state, query.chain_id);
+
+    let chain_kind = match parse_chain_type(chain_id) {
+        Ok(k) => k,
+        Err(e) => {
+            tracing::error!(error = %e, chain_id, "failed to determine chain type");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": "invalid chain type configuration"})),
+            )
+                .into_response();
+        }
+    };
+
+    let wallet = match normalise_wallet(chain_kind, &query.wallet) {
+        Ok(w) => w,
+        Err((status, msg)) => {
+            return (status, Json(serde_json::json!({ "error": msg }))).into_response();
+        }
+    };
 
     match compute_pnl(&state, &wallet, chain_id).await {
         Ok(response) => Json(response).into_response(),

--- a/packages/shared/src/position_repo.rs
+++ b/packages/shared/src/position_repo.rs
@@ -222,6 +222,11 @@ impl PositionRepo {
         owner_address: &str,
     ) -> anyhow::Result<Vec<PositionSummary>> {
         let owner = owner_address.to_lowercase();
+        // `vault_address` is returned to the API client. EVM addresses are
+        // case-insensitive, so lowering them is the canonical normalisation.
+        // Stellar Strkeys (C…) carry a CRC16 checksum — lowering corrupts them
+        // into an invalid form that downstream clients can't parse, so preserve
+        // case for Stellar chain IDs (sentinel 99000001 / 99000002).
         let rows = sqlx::query_as::<_, PositionSummary>(
             "SELECT
                  latest.vault_address,
@@ -230,7 +235,7 @@ impl PositionRepo {
                  COALESCE(agg.total_realized_pnl, 0) AS total_realized_pnl
              FROM (
                  SELECT DISTINCT ON (LOWER(contract_address))
-                     LOWER(contract_address) AS vault_address,
+                     (CASE WHEN chain_id IN (99000001, 99000002) THEN contract_address ELSE LOWER(contract_address) END) AS vault_address,
                      (params->>'shares_balance')::numeric AS shares_balance,
                      (params->>'avg_buy_share_price')::numeric AS avg_buy_share_price
                  FROM contract_logs
@@ -242,14 +247,14 @@ impl PositionRepo {
                  ORDER BY LOWER(contract_address), block_number DESC, log_index DESC
              ) latest
              LEFT JOIN (
-                 SELECT LOWER(contract_address) AS vault_address,
+                 SELECT (CASE WHEN chain_id IN (99000001, 99000002) THEN contract_address ELSE LOWER(contract_address) END) AS vault_address,
                         SUM((params->>'realized_pnl')::numeric) AS total_realized_pnl
                  FROM contract_logs
                  WHERE chain_id = $1
                    AND LOWER(params->>'owner') = $2
                    AND event_name IN ('StakingDeposit', 'StakingWithdrawal')
                    AND params ? 'realized_pnl'
-                 GROUP BY LOWER(contract_address)
+                 GROUP BY (CASE WHEN chain_id IN (99000001, 99000002) THEN contract_address ELSE LOWER(contract_address) END)
              ) agg ON agg.vault_address = latest.vault_address",
         )
         .bind(chain_id)

--- a/packages/worker/src/relayer/crystal_check.rs
+++ b/packages/worker/src/relayer/crystal_check.rs
@@ -153,6 +153,8 @@ async fn screen_single_event(
             transfer.id
         )
     })?;
+    // lp_profiles stores EVM addresses lowercased; the raw event field may not be.
+    let sender_lower = sender.to_lowercase();
 
     if transfer.event_name == "DepositRequested" {
         // Deposit: Crystal deposit-type transaction screening
@@ -193,7 +195,10 @@ async fn screen_single_event(
                 tx_risk = tx_risk,
                 "Crystal deposit screening failed — marking sender profile"
             );
-            if let Err(e) = kyc_repo.set_profile_kyt_failed(chain_id, sender).await {
+            if let Err(e) = kyc_repo
+                .set_profile_kyt_failed(chain_id, &sender_lower)
+                .await
+            {
                 tracing::error!(sender = sender, error = %e, "failed to set profile crystal_kyt_status");
             }
         }
@@ -231,7 +236,10 @@ async fn screen_single_event(
                 sender = sender,
                 "Crystal withdrawal address screening failed — marking profile"
             );
-            if let Err(e) = kyc_repo.set_profile_kyt_failed(chain_id, sender).await {
+            if let Err(e) = kyc_repo
+                .set_profile_kyt_failed(chain_id, &sender_lower)
+                .await
+            {
                 tracing::error!(sender = sender, error = %e, "failed to set profile crystal_kyt_status");
             }
         }


### PR DESCRIPTION
EVM addresses are case-insensitive so lowercasing is the canonical normalisation. Stellar Strkeys (G…, C…) carry a CRC16 checksum; lowercasing produces an invalid form. Four sites silently broke for Stellar requests by mixing the two conventions:

- api/routes/kyc.rs (create_applicant / create_token / get_status): bound query.wallet_address verbatim. EVM clients sending checksum hex missed the lp_profiles row. Now dispatches on parse_chain_type and normalises through normalise_wallet (lowercase for EVM, verbatim G… for Stellar). webhook_callback has no chain context, so it detects EVM by the 0x prefix and lowercases only that branch.

- worker/relayer/crystal_check.rs: passed the raw event sender to set_profile_kyt_failed, which compares wallet_address directly. Crystal screening only runs on the EVM relayer path, so binding the EVM-lowercased form is safe; the local sender_lower binding makes this explicit at the two call sites.

- shared/position_repo.rs::get_position_summaries: returned LOWER(contract_address) AS vault_address. The pnl.rs API response propagated that lowercased value, so Stellar UI got an invalid C-Strkey for every staking position. Wrapped the projection in CASE WHEN chain_id IN (99000001, 99000002) THEN contract_address ELSE LOWER(contract_address) END so Stellar preserves case while EVM behaviour is byte-for-byte unchanged. DISTINCT ON / ORDER BY / join keys keep LOWER — injective for Strkeys, so they still dedupe.

- api/routes/pnl.rs: lowercased query.wallet unconditionally; the response then echoed the corrupted Strkey. Now follows the same chain_kind dispatch as kyc.rs and uses normalise_wallet.