### PR TITLE
Configure Stellar frontend for Futurenet

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -192,10 +192,11 @@ VITE_WITHDRAWAL_QUEUE_ADDRESS=0x0000000000000000000000000000000000000000  # set 
 VITE_STAKED_PLUSD_ADDRESS=0x0000000000000000000000000000000000000000  # set to StakedPLUSD vault address on Hoodi
 VITE_WALLETCONNECT_PROJECT_ID=replace-me                                 # provision at https://cloud.reown.com
 
-# Stellar
-VITE_STELLAR_NETWORK=testnet                                             # "testnet" (default) or "mainnet"
+# Stellar (configured for Futurenet)
+VITE_STELLAR_NETWORK_PASSPHRASE=Test SDF Future Network ; October 2022    # network passphrase (testnet: "Test SDF Network ; September 2015")
 VITE_STELLAR_CHAIN_ID=99000001                                           # backend chain_id for Stellar voucher/API dispatch
-VITE_STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org             # Stellar Horizon base URL
-# VITE_STELLAR_DEPOSIT_MANAGER_ID=CARFA2QETOZVKHSG4BCEEXMJHTYR2Z75VR7WQNX4MWZ33RQMKRKATIVI  # Pipeline DepositManager Soroban contract ID (testnet 2026-06-10)
-# VITE_STELLAR_WITHDRAWAL_QUEUE_ID=CC3TWGFXP2XUZJXGLVTM2G4K2PF2YTC6BKDRPZIUPSVETNYAO57GU3Q7  # Pipeline WithdrawalQueue Soroban contract ID (redeployed testnet 2026-06-16)
-# VITE_STELLAR_STAKED_PLUSD_ID=CDO4X3HCPR44UGXJ5PE35JBB4SYVDRQETXXOPQZLB7THN6FOTBTRKLW5      # Pipeline StakedPLUSD FungibleVault Soroban contract ID (testnet 2026-06-18)
+VITE_STELLAR_HORIZON_URL=https://horizon-futurenet.stellar.org           # Stellar Horizon base URL
+VITE_STELLAR_RPC_URL=https://rpc-futurenet.stellar.org                   # Soroban RPC URL (distinct from Horizon)
+VITE_STELLAR_DEPOSIT_MANAGER_ID=CCYQKUAZ7BF22OMXNPF7RJ2D3PDUNV66S3O2L54UYHDYQ4CLMTJHLNWU    # Pipeline DepositManager Soroban contract ID (futurenet 2026-06-19)
+VITE_STELLAR_WITHDRAWAL_QUEUE_ID=CBNZF5QAFJSYDZKU7G7VTV2G3NQ4BM54FI72O2SXVZTXURHGZ262L4KH   # Pipeline WithdrawalQueue Soroban contract ID (futurenet 2026-06-19)
+VITE_STELLAR_STAKED_PLUSD_ID=CDSWAVNSVURETMQ7VPMF3XXADDUZLJNJQ4YBUTV65QZEBF5RVOPGW5M4       # Pipeline StakedPLUSD FungibleVault Soroban contract ID (futurenet 2026-06-19)

--- a/packages/frontend/src/api/useStellarDepositVoucher.ts
+++ b/packages/frontend/src/api/useStellarDepositVoucher.ts
@@ -7,7 +7,7 @@
  * hex-decoding the `signature` field (ed25519, 64 bytes → 0x-prefixed hex).
  *
  * The hook polls
- * `GET /v1/deposits/{request_id}/voucher?wallet=<G…>&chain_id=<stellarChainId>`
+ * `GET /v1/deposits/{request_id}/voucher?wallet=<G…>&chain_id=<chain_id>`
  * every 3 s until the verifier signature is available.
  *
  * Mock layer

--- a/packages/frontend/src/api/useStellarWithdrawalVoucher.ts
+++ b/packages/frontend/src/api/useStellarWithdrawalVoucher.ts
@@ -7,7 +7,7 @@
  * hex-decoding the `signature` field (ed25519, 64 bytes → 0x-prefixed hex).
  *
  * The hook polls
- * `GET /v1/withdrawals/{request_id}/voucher?wallet=<G…>&chain_id=<stellarChainId>`
+ * `GET /v1/withdrawals/{request_id}/voucher?wallet=<G…>&chain_id=<chain_id>`
  * every 3 s until the verifier signature is available.
  *
  * Mock layer

--- a/packages/frontend/src/lib/env.ts
+++ b/packages/frontend/src/lib/env.ts
@@ -95,10 +95,20 @@ export const ENV = Object.freeze({
   ),
 
   /**
-   * Stellar network identifier. Accepts `"testnet"` (default) or `"mainnet"`.
-   * Maps to the StellarWalletsKit `Networks` enum value at runtime.
+   * Stellar network passphrase — identifies the network for wallet signing and
+   * Horizon/Soroban calls. The StellarWalletsKit `Networks` enum values ARE the
+   * passphrase strings, so this value is consumed directly as the kit network.
+   * Defaults to the Stellar testnet passphrase.
+   *
+   * Examples:
+   *   - testnet:   "Test SDF Network ; September 2015"
+   *   - futurenet: "Test SDF Future Network ; October 2022"
+   *   - mainnet:   "Public Global Stellar Network ; September 2015"
    */
-  STELLAR_NETWORK: readString("VITE_STELLAR_NETWORK", "testnet"),
+  STELLAR_NETWORK_PASSPHRASE: readString(
+    "VITE_STELLAR_NETWORK_PASSPHRASE",
+    "Test SDF Network ; September 2015",
+  ),
 
   /**
    * Backend chain id for Stellar API calls. Defaults to the repo's Stellar

--- a/packages/frontend/src/wallet/stellar/chain.ts
+++ b/packages/frontend/src/wallet/stellar/chain.ts
@@ -12,20 +12,14 @@ import { Networks } from "@creit.tech/stellar-wallets-kit";
 import { ENV } from "@/lib/env";
 
 /**
- * Map the human-readable `VITE_STELLAR_NETWORK` value to the kit's `Networks`
- * enum. Falls back to `TESTNET` for any unrecognised value so the app stays
- * functional during development without requiring an explicit env override.
+ * Network passphrase for the configured Stellar network, taken directly from
+ * `VITE_STELLAR_NETWORK_PASSPHRASE`. The StellarWalletsKit `Networks` enum
+ * values ARE the passphrase strings (e.g. `TESTNET = "Test SDF Network ;
+ * September 2015"`), so the env passphrase doubles as the kit network value —
+ * no hardcoded network-name mapping required, which lets any network (testnet,
+ * futurenet, mainnet, standalone) be configured purely via env.
  */
-function resolveKitNetwork(network: string): Networks {
-  if (network === "mainnet") return Networks.PUBLIC;
-  return Networks.TESTNET;
-}
-
-/** Kit `Networks` enum value for the configured network. */
-export const kitNetwork: Networks = resolveKitNetwork(ENV.STELLAR_NETWORK);
-
-/** Backend chain id used by API routes that dispatch EVM vs Stellar behavior. */
-export const stellarChainId: number = ENV.STELLAR_CHAIN_ID;
+export const kitNetwork: Networks = ENV.STELLAR_NETWORK_PASSPHRASE as Networks;
 
 /**
  * Network passphrase string. In v2.x the kit `Networks` enum values ARE the


### PR DESCRIPTION
## What

Configures the Stellar frontend to run against **Futurenet**, and makes the network passphrase env-driven instead of hardcoded.

## Changes

- **Passphrase is now env-driven (`chain.ts`).** Removed `resolveKitNetwork()`, which mapped a `VITE_STELLAR_NETWORK` name to a hardcoded `Networks` enum value (only handled `mainnet`/`testnet` — anything else, including `futurenet`, silently fell back to the **testnet** passphrase). `kitNetwork` now reads `VITE_STELLAR_NETWORK_PASSPHRASE` directly. Since the kit's `Networks` enum values *are* the passphrase strings, this value flows unchanged to wallet signing and Horizon/Soroban calls — so any network (testnet/futurenet/mainnet/standalone) is configurable purely via env, no code change.
- **`env.ts`:** replaced the `STELLAR_NETWORK` key with `STELLAR_NETWORK_PASSPHRASE` (defaults to the testnet passphrase).
- **`.env.example`:** points at the Futurenet deployment — passphrase, Horizon (`horizon-futurenet`), Soroban RPC (`rpc-futurenet`, newly added — was previously relying on the code default), and the DepositManager / WithdrawalQueue / StakedPLUSD contract IDs.
- **Removed the dead `stellarChainId` export** from `chain.ts` — nothing imported it; the voucher hooks read `ENV.STELLAR_CHAIN_ID` directly.

`VITE_STELLAR_CHAIN_ID` is intentionally **unchanged** (stays `99000001`) — it only drives the backend voucher-dispatch `chain_id` and must keep matching the API/worker `CHAIN_<id>` config.

## Scope notes

- Frontend-only. The backend (indexer/relayer/API/price-poller) still needs its own Futurenet `CHAIN_<id>_STELLAR_*` config and a couple of sentinel-handling code changes (passphrase auto-default + `position_repo.rs` address-casing) — not in this PR.
- The actual running values live in the gitignored `.env` (updated locally); `.env.example` carries them for the record.

## Verification

- `tsc --noEmit` — passes
- ESLint on changed files — clean
- `npx tsx scripts/lint-docs.ts` — 0 errors
- Stellar wallet + voucher tests — no new failures (13 pre-existing failures in `useStellarWithdrawalQueue`/`useStellarStakedPlusd` are identical with and without this change — timing/declined-signature tests unrelated to network config).
