### PR TITLE
Show done state for completed deposits + 'Make another deposit' reset

### DIFF
--- a/packages/frontend/src/routes/-deposit.test.tsx
+++ b/packages/frontend/src/routes/-deposit.test.tsx
@@ -1200,7 +1200,7 @@ describe("Deposit page — three-step flow", () => {
         .find((b) => b.getAttribute("aria-busy") === "true");
       // Walk up to the StepRow root div (the container that gets opacity-30).
       // StepRow structure: div.rootClasses > ... > div.shrink-0 > Button
-      const rowRoot = busyBtn?.closest(".flex.items-start.gap-3");
+      const rowRoot = busyBtn?.closest(".flex.items-center.gap-3");
       expect(rowRoot).not.toBeNull();
       expect(rowRoot?.className).not.toContain("opacity-30");
     });
@@ -1270,6 +1270,117 @@ describe("Deposit page — three-step flow", () => {
       },
       { timeout: 2000 },
     );
+  });
+});
+
+describe("Deposit page — completed (claimed) deposit terminal state", () => {
+  beforeEach(() => {
+    mockDirection = "deposit";
+    localStorage.clear();
+    mockWriteContract.mockClear();
+    mockRefetch.mockClear();
+    mockRequestsData = undefined;
+    mockRequestsLoading = false;
+    mockVoucherData = undefined;
+    mockVoucherStatus = "idle";
+    mockWithdrawVoucherData = undefined;
+    mockWithdrawVoucherStatus = "idle";
+    // High allowance + balance so that, absent an active request, Confirm would
+    // be enabled — this is what makes the regression observable.
+    seedBaseMocks({ allowance: "10000000000" });
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  const COMPLETED_DEPOSIT = {
+    type: "Deposit" as const,
+    request_id: "42",
+    amount: "2000000000",
+    status: "Completed" as const,
+    created_at: new Date().toISOString(),
+  };
+
+  // Regression: a deposit that has settled to `Completed` (e.g. on reload after
+  // claiming) must NOT collapse the flow back to its initial form. Previously
+  // the active-request filter kept only Pending* statuses, so a Completed
+  // request dropped out and Confirm re-enabled (and Claim flickered during the
+  // API's PendingClaim lag). The Completed request must drive a terminal done
+  // state instead.
+  it("renders the done state (no active Confirm/Claim) when the latest deposit is Completed", async () => {
+    mockRequestsData = { requests: [COMPLETED_DEPOSIT] };
+
+    renderDeposit();
+
+    await waitFor(() => {
+      // Steps render as success pills — no actionable Confirm/Claim buttons.
+      expect(screen.queryByRole("button", { name: "Confirm" })).toBeNull();
+      expect(screen.queryByRole("button", { name: "Claim" })).toBeNull();
+      expect(screen.getByLabelText("Confirm complete")).toHaveAttribute(
+        "data-state",
+        "success",
+      );
+      expect(screen.getByLabelText("Claim complete")).toHaveAttribute(
+        "data-state",
+        "success",
+      );
+    });
+    // Reset affordance is offered.
+    expect(screen.getByTestId("make-another-deposit")).toBeInTheDocument();
+  });
+
+  it("locks the amount input to the completed deposit amount", async () => {
+    mockRequestsData = { requests: [COMPLETED_DEPOSIT] };
+
+    renderDeposit();
+
+    await waitFor(() => {
+      const input = screen.getByRole("textbox", {
+        name: /USDC amount/i,
+      }) as HTMLInputElement;
+      // 2000000000 raw at 6 dp = 2000.00.
+      expect(input.value).toBe("2000.00");
+      expect(input).toBeDisabled();
+    });
+  });
+
+  it("'Make another deposit' resets the form and restores an actionable flow", async () => {
+    mockRequestsData = { requests: [COMPLETED_DEPOSIT] };
+
+    const user = userEvent.setup();
+    renderDeposit();
+
+    const resetBtn = await screen.findByTestId("make-another-deposit");
+    await user.click(resetBtn);
+
+    await waitFor(() => {
+      // Done state dismissed — reset button gone, Confirm available again.
+      expect(screen.queryByTestId("make-another-deposit")).toBeNull();
+      expect(
+        screen.getByRole("button", { name: "Confirm" }),
+      ).toBeInTheDocument();
+      // Input cleared so the user can enter a fresh amount.
+      const input = screen.getByRole("textbox", {
+        name: /USDC amount/i,
+      }) as HTMLInputElement;
+      expect(input.value).toBe("");
+      expect(input).not.toBeDisabled();
+    });
+  });
+
+  it("still shows the done state even when the post-deposit balance is below the minimum", async () => {
+    // After depositing, the USDC balance can drop below the minimum. The done
+    // state must take precedence over the low-balance banner.
+    seedBaseMocks({ balance: BALANCE_500_RAW, allowance: "10000000000" });
+    mockRequestsData = { requests: [COMPLETED_DEPOSIT] };
+
+    renderDeposit();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("make-another-deposit")).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("low-balance-banner")).toBeNull();
   });
 });
 
@@ -2967,6 +3078,56 @@ describe("Deposit page — Stellar PLUSD unauthorized trustline guard", () => {
       expect(
         screen.getByRole("button", { name: "Claim" }),
       ).not.toBeDisabled();
+    });
+  });
+});
+
+describe("Deposit page — Stellar completed (claimed) deposit terminal state", () => {
+  beforeEach(() => {
+    mockDirection = "deposit";
+    localStorage.clear();
+    mockWriteContract.mockClear();
+    mockRefetch.mockClear();
+    mockRequestsData = undefined;
+    mockRequestsLoading = false;
+    mockVoucherData = undefined;
+    mockVoucherStatus = "idle";
+    mockWithdrawVoucherData = undefined;
+    mockWithdrawVoucherStatus = "idle";
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  // Regression for the reported bug: on Stellar, after claiming a deposit the
+  // request settles to `Completed`. The flow must show the done state rather
+  // than re-enabling Confirm (or, during the API's PendingClaim lag, Claim).
+  it("shows the done state with a reset affordance when the latest deposit is Completed", async () => {
+    seedStellarMocks({
+      usdcBalance: "5000",
+      sacPlusdBalance: SAC_1000_PLUS, // PLUSD trustline present
+      sacUsdcBalance: SAC_1000_PLUS, // USDC trustline present
+    });
+    mockRequestsData = {
+      requests: [
+        {
+          type: "Deposit",
+          request_id: "42",
+          amount: "20000000000", // 2000 USDC at 7 dp
+          status: "Completed",
+          created_at: new Date().toISOString(),
+        },
+      ],
+    };
+
+    renderDepositStellar();
+
+    await waitFor(() => {
+      // No actionable Confirm/Claim — the steps are success pills.
+      expect(screen.queryByRole("button", { name: "Confirm" })).toBeNull();
+      expect(screen.queryByRole("button", { name: "Claim" })).toBeNull();
+      expect(screen.getByTestId("make-another-deposit")).toBeInTheDocument();
     });
   });
 });

--- a/packages/frontend/src/routes/deposit.tsx
+++ b/packages/frontend/src/routes/deposit.tsx
@@ -100,6 +100,11 @@ function Deposit() {
   // ── Local state ───────────────────────────────────────────────────────
   const [amountInput, setAmountInput] = useState("");
   const [copied, setCopied] = useState(false);
+  // `request_id` of a completed deposit the user dismissed via "Make another
+  // deposit". Suppresses the done state so a fresh deposit can be entered.
+  const [dismissedDepositId, setDismissedDepositId] = useState<
+    string | undefined
+  >(undefined);
 
   // ── Parse amount (needs decimals — use 6 as default until flow loads) ──
   // The flow's decimals are used for proper parsing, but we need amountBig
@@ -112,7 +117,18 @@ function Deposit() {
   const amountBig = parseUsdc(amountInput, lastDecimals);
 
   // ── Flow adapter ──────────────────────────────────────────────────────
-  const flow = useDepositFlow(direction, amountBig, setAmountInput);
+  const flow = useDepositFlow(
+    direction,
+    amountBig,
+    setAmountInput,
+    dismissedDepositId,
+  );
+
+  // ── "Make another deposit" — dismiss the completed deposit, reset the form ─
+  const onMakeAnotherDeposit = useCallback(() => {
+    setDismissedDepositId(flow.depositCompletedRequestId);
+    setAmountInput("");
+  }, [flow.depositCompletedRequestId]);
 
   // ── Connect modal (shared single instance via ConnectModalProvider) ───
   const { open: openConnectModal } = useConnectModal();
@@ -474,7 +490,8 @@ function Deposit() {
         ) : flow.isDataPending /* Chain data / requests API still loading — render nothing until resolved. */ ? null : isStellar &&
           isDeposit &&
           usdcTrustline?.needsTrustline &&
-          flow.hasBalance === false ? (
+          flow.hasBalance === false &&
+          !flow.isDepositCompleted ? (
           /* No USDC trustline (Stellar deposit, no USDC balance) — must be
              established before the account can hold or deposit USDC. Takes the
              place of the low-balance banner; same layout, but the action adds
@@ -511,7 +528,9 @@ function Deposit() {
               {usdcTrustline?.enabling ? "Adding…" : "Add trustline"}
             </Button>
           </Card>
-        ) : isDeposit && flow.hasBalance === false ? (
+        ) : isDeposit &&
+          flow.hasBalance === false &&
+          !flow.isDepositCompleted ? (
           /* Insufficient-balance banner — deposit only. Figma: node 1825-10214. */
           <Card
             variant="yellow"
@@ -629,6 +648,21 @@ function Deposit() {
             ]}
           />
         )}
+
+        {/* "Make another deposit" — shown once the latest deposit is claimed
+            (Completed). Resets the form so a fresh deposit can be started. */}
+        {flow.isConnected &&
+          !flow.isDataPending &&
+          flow.isDepositCompleted && (
+            <Button
+              data-testid="make-another-deposit"
+              variant="primary-dark"
+              className="w-full"
+              onClick={onMakeAnotherDeposit}
+            >
+              Make another deposit
+            </Button>
+          )}
       </main>
     </div>
   );

--- a/packages/frontend/src/wallet/useDepositFlow.ts
+++ b/packages/frontend/src/wallet/useDepositFlow.ts
@@ -160,6 +160,17 @@ export interface FlowState {
   requestIsConfirmed: boolean;
   isPendingVerification: boolean;
 
+  // ── Completed (claimed) deposit terminal state ────────────────────────
+  /**
+   * True (deposit direction only) when the latest deposit request has settled
+   * to `Completed` and has not been dismissed. Drives the "done" layout: all
+   * steps success, no active Confirm/Claim, input locked to the completed
+   * amount, and a "Make another deposit" reset affordance.
+   */
+  isDepositCompleted: boolean;
+  /** `request_id` of the completed deposit currently shown as done (for dismissal). */
+  depositCompletedRequestId: string | undefined;
+
   // ── Steps ──────────────────────────────────────────────────────────────
   step1: StepInfo;
   step2: StepInfo;
@@ -230,11 +241,15 @@ function parseRequestId(value: string | undefined): bigint | undefined {
  * @param direction - Current direction ("deposit" | "withdraw").
  * @param amountBig - Parsed amount from the text input (bigint at active decimals).
  * @param setAmountInput - Input setter (for quick-amount handlers).
+ * @param dismissedDepositRequestId - `request_id` of a `Completed` deposit the
+ *   user has dismissed via "Make another deposit". When it matches the latest
+ *   completed deposit, the done state is suppressed so a fresh deposit can start.
  */
 export function useDepositFlow(
   direction: Direction,
   amountBig: bigint,
   setAmountInput: (v: string) => void,
+  dismissedDepositRequestId?: string,
 ): FlowState {
   const { kind } = useWalletView();
   const isStellar = kind === "stellar";
@@ -357,6 +372,27 @@ export function useDepositFlow(
   const evmDepositRequestIsConfirmed =
     evmDepositActiveRequest !== null ||
     (evmRequestDeposit.isSuccess && evmDepositRequestId !== undefined);
+
+  // Most-recent claimed deposit. The active-request filter above keeps only
+  // `PendingVerification`/`PendingClaim`, so a claimed request settles to
+  // `Completed` and drops out of that set. We track it separately to drive the
+  // terminal "done" state instead of collapsing back to the initial form (which
+  // re-enabled Confirm and, during the API's PendingClaim lag, Claim).
+  const evmDepositCompletedRequest =
+    requestsData?.requests
+      .filter((r) => r.type === "Deposit" && r.status === "Completed")
+      .sort(
+        (a, b) =>
+          new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+      )[0] ?? null;
+
+  // Terminal done state: the latest deposit is `Completed` (no newer Pending*
+  // request) and the user has not dismissed it via "Make another deposit".
+  const evmDepositIsCompleted =
+    evmDepositActiveRequest === null &&
+    evmDepositCompletedRequest !== null &&
+    evmDepositCompletedRequest.request_id !== dismissedDepositRequestId;
+
   const evmWithdrawRequestIsConfirmed =
     evmWithdrawActiveRequest !== null ||
     (evmRequestWithdrawal.isSuccess && evmWithdrawRequestId !== undefined);
@@ -408,6 +444,24 @@ export function useDepositFlow(
         (a, b) =>
           new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
       )[0] ?? null;
+
+  // Most-recent claimed deposit (settled to `Completed`). Tracked separately so
+  // the flow can show a terminal "done" state instead of collapsing back to the
+  // initial form once the claimed request drops out of the active set.
+  const stellarDepositCompletedRequest =
+    requestsData?.requests
+      .filter((r) => r.type === "Deposit" && r.status === "Completed")
+      .sort(
+        (a, b) =>
+          new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+      )[0] ?? null;
+
+  // Terminal done state: the latest deposit is `Completed` (no newer Pending*
+  // request) and the user has not dismissed it via "Make another deposit".
+  const stellarDepositIsCompleted =
+    stellarDepositActiveRequest === null &&
+    stellarDepositCompletedRequest !== null &&
+    stellarDepositCompletedRequest.request_id !== dismissedDepositRequestId;
 
   // Stellar request IDs — keep one canonical id source so voucher fetch,
   // on-chain polling, and claim submission cannot drift apart.
@@ -680,7 +734,8 @@ export function useDepositFlow(
       evmDepositMeetsMin &&
       !evmDepositNeedsApproval &&
       !evmRequestDeposit.isPending &&
-      !evmDepositRequestIsConfirmed;
+      !evmDepositRequestIsConfirmed &&
+      !evmDepositIsCompleted;
     const canEvmClaimDeposit =
       isEvmConnected &&
       evmDepositRequestId !== undefined &&
@@ -715,17 +770,21 @@ export function useDepositFlow(
       : canEvmConfirmWithdraw;
     const canEvmClaim = isDeposit ? canEvmClaimDeposit : canEvmClaimWithdraw;
 
-    // Step states
+    // Step states. When the deposit is completed (claimed) every step reads as
+    // success — the StepsCard then renders success pills instead of actionable
+    // buttons.
     const evmDepositStep1State: StepState =
+      evmDepositIsCompleted ||
       (!evmDepositNeedsApproval && amountBig > 0n && isEvmConnected) ||
       evmDepositRequestIsConfirmed
         ? "success"
         : "idle";
     const evmDepositStep2State: StepState =
-      evmDepositIsPendingClaim || evmClaim.isSuccess ? "success" : "idle";
-    const evmDepositStep3State: StepState = evmClaim.isSuccess
-      ? "success"
-      : "idle";
+      evmDepositIsCompleted || evmDepositIsPendingClaim || evmClaim.isSuccess
+        ? "success"
+        : "idle";
+    const evmDepositStep3State: StepState =
+      evmDepositIsCompleted || evmClaim.isSuccess ? "success" : "idle";
 
     const evmWithdrawStep1State: StepState =
       (evmHasSufficientWithdrawAllowance && isEvmConnected) ||
@@ -797,14 +856,25 @@ export function useDepositFlow(
       hasBalance: evmHasBalance,
       meetsMin: evmMeetsMin,
       isDataPending: evmIsDataPending,
-      isAmountLocked: evmActiveRequest !== null,
+      isAmountLocked:
+        evmActiveRequest !== null || (isDeposit && evmDepositIsCompleted),
       lockedAmountRaw:
         evmActiveRequest !== null && evmDecimals !== undefined
           ? BigInt(evmActiveRequest.amount)
-          : undefined,
+          : isDeposit &&
+              evmDepositIsCompleted &&
+              evmDepositCompletedRequest !== null &&
+              evmDecimals !== undefined
+            ? BigInt(evmDepositCompletedRequest.amount)
+            : undefined,
       requestId: evmRequestId,
       requestIsConfirmed: evmRequestIsConfirmed,
       isPendingVerification: evmIsPendingVerification,
+      isDepositCompleted: isDeposit && evmDepositIsCompleted,
+      depositCompletedRequestId:
+        isDeposit && evmDepositIsCompleted
+          ? (evmDepositCompletedRequest?.request_id ?? undefined)
+          : undefined,
       step1: {
         label: isDeposit
           ? "Allow Pipeline to use USDC"
@@ -959,9 +1029,14 @@ export function useDepositFlow(
     ? stellarDepositStep1State
     : stellarWithdrawStep1State;
 
-  // Step 2 state (request)
+  // Step 2 state (request). A completed (claimed) deposit reads as success so
+  // the StepsCard renders a success pill instead of an actionable Confirm.
   const stellarDepositStep2State: StepState =
-    stellarDepositIsPendingClaim || stellarClaim.isSuccess ? "success" : "idle";
+    stellarDepositIsCompleted ||
+    stellarDepositIsPendingClaim ||
+    stellarClaim.isSuccess
+      ? "success"
+      : "idle";
   const stellarWithdrawStep2State: StepState =
     stellarWithdrawIsPendingClaim || stellarClaimWithdrawal.isSuccess
       ? "success"
@@ -972,7 +1047,7 @@ export function useDepositFlow(
 
   // Step 3 state (claim)
   const stellarStep3State: StepState = isDeposit
-    ? stellarClaim.isSuccess
+    ? stellarDepositIsCompleted || stellarClaim.isSuccess
       ? "success"
       : "idle"
     : stellarClaimWithdrawal.isSuccess
@@ -1003,7 +1078,8 @@ export function useDepositFlow(
     stellarHasBalance === true &&
     bothTrustlinesReady &&
     !stellarRequestDeposit.isPending &&
-    !stellarDepositRequestIsConfirmed;
+    !stellarDepositRequestIsConfirmed &&
+    !stellarDepositIsCompleted;
   const canStellarStep2Withdraw =
     isStellarConnected &&
     stellarCanWithdraw &&
@@ -1111,16 +1187,26 @@ export function useDepositFlow(
     hasBalance: stellarHasBalance,
     meetsMin: stellarMeetsMin,
     isDataPending: stellarIsDataPending,
-    isAmountLocked: stellarRequestIsConfirmed,
+    isAmountLocked:
+      stellarRequestIsConfirmed || (isDeposit && stellarDepositIsCompleted),
     lockedAmountRaw:
       stellarActiveRequest?.amount !== undefined
         ? BigInt(stellarActiveRequest.amount)
         : stellarInflight?.amount !== undefined
           ? BigInt(stellarInflight.amount)
-          : undefined,
+          : isDeposit &&
+              stellarDepositIsCompleted &&
+              stellarDepositCompletedRequest?.amount !== undefined
+            ? BigInt(stellarDepositCompletedRequest.amount)
+            : undefined,
     requestId: stellarRequestId,
     requestIsConfirmed: stellarRequestIsConfirmed,
     isPendingVerification: stellarIsPendingVerification,
+    isDepositCompleted: isDeposit && stellarDepositIsCompleted,
+    depositCompletedRequestId:
+      isDeposit && stellarDepositIsCompleted
+        ? (stellarDepositCompletedRequest?.request_id ?? undefined)
+        : undefined,
     step1: {
       label: isDeposit ? "Enable PLUSD" : "Enable USDC",
       actionLabel: "Enable",


### PR DESCRIPTION
## Problem

On the deposit page, after claiming a deposit (PLUSD received), revisiting the page (reload / navigate back) showed the **Claim** button active again and shortly after the **Confirm** button active — even though the API reports the request `status: "Completed"`.

## Root cause

`useDepositFlow` derived the active deposit request by filtering the API list to `PendingVerification`/`PendingClaim` only. A claimed request settles to `Completed` and drops out of that set, so the flow collapsed back to its **initial** state: `requestIsConfirmed` went false and Confirm re-enabled (Claim flickered during the API's PendingClaim lag, before the on-chain `claimed` state propagated).

Within a single session this was masked by the in-memory `claim.isSuccess` flag (steps render as success pills), so the bug only surfaced on reload / revisit — which is exactly the reported scenario.

## Fix

Recognise the most-recent **`Completed`** deposit as a terminal *done* state (EVM + Stellar), keyed off the API status so it survives reload:

- Steps 1–3 render as **success** (success pills — no actionable Confirm/Claim).
- The amount input is **locked** to the completed deposit amount.
- A **"Make another deposit"** button dismisses the completed request (by `request_id`) and resets the form so a fresh deposit can start.
- The done state takes **precedence over the low-balance banner** — after depositing, the USDC balance is usually below the minimum.

Scoped to the **deposit** direction (per the report). Withdraw is unchanged.

### UX decision

Confirmed with the reporter: a completed deposit shows *done* (survives reload) with an explicit **Make another deposit** reset — rather than silently resetting to a fresh form, or locking with no way to deposit again.

## Tests

- `-deposit.test.tsx`: new regression coverage for the completed/done state, input lock, the reset flow, and done-state-over-low-balance precedence (EVM), plus a Stellar done-state test. Full deposit suite green (104/104).
- Also corrected a stale `-deposit.test.tsx` selector left by #666 (`items-start` → `items-center`).

`tsc --noEmit`, frontend `lint` (0 errors), and `build` all pass.

> Note: `-stake.test.tsx`, `-index.test.tsx` and two stellar hook test files have **pre-existing** failures on `main` (unrelated `ToastProvider`/hook setup issues; frontend vitest isn't in the CI rollup). Not touched by this PR.