### PR TITLE
Fix 55 failing frontend unit tests (test-harness gaps)

### DIFF
--- a/packages/frontend/src/routes/-index.test.tsx
+++ b/packages/frontend/src/routes/-index.test.tsx
@@ -80,6 +80,16 @@ vi.mock("@/wallet/stellar/config", () => ({
   },
 }));
 
+// Disconnected CTAs open the shared ConnectWalletModal via useConnectModal()
+// (issues #638/#645) rather than calling AppKit directly. The gate/modal
+// behavior is covered by ConnectModalProvider.test.tsx; here we only assert the
+// Home CTA is wired to useConnectModal().open().
+const mockConnectModalOpen = vi.fn();
+vi.mock("@/wallet", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/wallet")>()),
+  useConnectModal: () => ({ open: mockConnectModalOpen, close: vi.fn() }),
+}));
+
 vi.mock("@tanstack/react-query", async (importOriginal) => {
   const original =
     await importOriginal<typeof import("@tanstack/react-query")>();
@@ -191,6 +201,7 @@ describe("Home page — disconnected state", () => {
   beforeEach(() => {
     localStorage.clear();
     mockOpen.mockClear();
+    mockConnectModalOpen.mockClear();
     mockNavigate.mockClear();
   });
 
@@ -221,12 +232,7 @@ describe("Home page — disconnected state", () => {
     });
   });
 
-  it("clicking Connect calls useWallet().connect() → opens AppKit modal (when ack flag is pre-set)", async () => {
-    // Pre-seed the terms acknowledgement so the gate is skipped and AppKit
-    // is called directly. The gate modal itself is tested in FirstConnectionModal.test.tsx
-    // and useWallet.test.tsx.
-    localStorage.setItem("pipeline.wallet.termsAcknowledged.pending", "true");
-
+  it("clicking Connect opens the shared ConnectWalletModal via useConnectModal().open()", async () => {
     const user = userEvent.setup();
     renderHome();
 
@@ -237,9 +243,11 @@ describe("Home page — disconnected state", () => {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     await user.click(connectBtns[0]!);
 
-    // useWallet().connect() delegates to useAppKit().open()
+    // The Home CTA's onConnect is wired to useConnectModal().open(), which
+    // routes through the terms gate and opens ConnectWalletModal (issues
+    // #638/#645). It no longer calls AppKit's open() directly.
     await waitFor(() => {
-      expect(mockOpen).toHaveBeenCalledTimes(1);
+      expect(mockConnectModalOpen).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/frontend/src/routes/-stake.test.tsx
+++ b/packages/frontend/src/routes/-stake.test.tsx
@@ -36,6 +36,7 @@ import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { EvmWalletProvider } from "@/wallet/evm/EvmWalletProvider";
+import { ToastProvider } from "@/lib/toast";
 import { Route } from "./stake";
 
 // ── Wagmi / AppKit mocks ──────────────────────────────────────────────────────
@@ -283,7 +284,9 @@ function renderStake() {
   const StakePage = Route.options.component as React.ComponentType;
   return render(
     <EvmWalletProvider>
-      <StakePage />
+      <ToastProvider>
+        <StakePage />
+      </ToastProvider>
     </EvmWalletProvider>,
   );
 }
@@ -1115,8 +1118,10 @@ describe("Stake page — no nested border on token-amount-display (Issue #615)",
     await waitFor(() => {
       const display = screen.getByTestId("token-amount-display");
       // The inline style must explicitly unset the border so the component
-      // renders flush inside the output section card (Issue #615).
-      expect(display.style.border).toBe("none");
+      // renders flush inside the output section card (Issue #615). Assert the
+      // border-style longhand: the `border` shorthand getter round-trips
+      // `border: none` to "medium none currentcolor", returning the width.
+      expect(display.style.borderStyle).toBe("none");
     });
   });
 

--- a/packages/frontend/src/wallet/stellar/useStellarStakedPlusd.test.tsx
+++ b/packages/frontend/src/wallet/stellar/useStellarStakedPlusd.test.tsx
@@ -34,7 +34,7 @@
  */
 
 import { renderHook, act, waitFor } from "@testing-library/react";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import React from "react";
 import {
@@ -45,6 +45,7 @@ import {
   useStellarStakedPlusdBalance,
   useStellarChangeTrustStakedPlusd,
 } from "./useStellarStakedPlusd";
+import { useStellarWallet } from "./useStellarWallet";
 import * as mockModule from "./mock";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -212,6 +213,30 @@ Object.defineProperty(global, "localStorage", { value: localStorageMock });
 // ── Test constants ────────────────────────────────────────────────────────────
 
 const TEST_ADDRESS = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+
+// Reset cross-test mock leakage. `vi.clearAllMocks()` (used in the per-describe
+// beforeEach hooks) only clears call history — it undoes neither `vi.spyOn`
+// spies nor `mockReturnValue` implementations. Two such leaks would otherwise
+// propagate between tests in this file:
+//   1. The "unconfigured guard" tests install a getter spy forcing
+//      `stakedPlusdId` to "" (→ spurious "StakedPLUSD not configured").
+//   2. The disconnected-balance test sets `useStellarWallet` to a disconnected
+//      value via `mockReturnValue` (→ spurious "Stellar wallet not connected").
+// Restore spies after each test, and re-establish the connected wallet default
+// before each, so every test starts from the factory baseline.
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+beforeEach(() => {
+  vi.mocked(useStellarWallet).mockImplementation(() => ({
+    address: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+    isConnected: true,
+    signTransaction: mockSignTransaction,
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+  }));
+});
 
 // ── Tests: useStellarStake ────────────────────────────────────────────────────
 
@@ -596,6 +621,10 @@ describe("useStellarChangeTrustStakedPlusd", () => {
       () => useStellarChangeTrustStakedPlusd(),
       { wrapper: makeWrapper() },
     );
+
+    // submit() requires the share asset, resolved asynchronously via name();
+    // wait for it to load (needsTrustline flips true) before submitting.
+    await waitFor(() => expect(result.current.needsTrustline).toBe(true));
 
     act(() => {
       result.current.submit();

--- a/packages/frontend/src/wallet/stellar/useStellarWithdrawalQueue.test.tsx
+++ b/packages/frontend/src/wallet/stellar/useStellarWithdrawalQueue.test.tsx
@@ -199,6 +199,15 @@ Object.defineProperty(global, "localStorage", { value: localStorageMock });
 
 const TEST_ADDRESS = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
 
+// Restore `vi.spyOn` spies between tests. The per-describe `vi.clearAllMocks()`
+// only clears call history — it does not undo spies. The "unconfigured guard"
+// tests install a getter spy forcing `withdrawalQueueId` to "", which would
+// otherwise leak into every subsequent test (→ spurious
+// "WithdrawalQueue not configured").
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
 // ── Tests: useStellarRequestWithdrawal ────────────────────────────────────────
 
 describe("useStellarRequestWithdrawal", () => {


### PR DESCRIPTION
## Summary

Fixes 55 failing frontend unit tests across 4 files. These were latent because **frontend unit tests are not run in CI** — all four are test-harness/isolation issues, **not product regressions** (no product code is touched).

## Root causes & fixes

| File | Fails | Cause | Fix |
|---|---|---|---|
| `-stake.test.tsx` | 41 | `renderStake()` didn't wrap `<ToastProvider>`, but `stake.tsx` calls `useToast()` (added in #652) | Wrap with `ToastProvider` (mirrors `-deposit.test.tsx`); also fix brittle #615 `border` assertion → `borderStyle` |
| `useStellarStakedPlusd.test.tsx` | 5 | "unconfigured guard" tests install a getter spy forcing the contract id to `""` and never restore it; `vi.clearAllMocks()` doesn't undo spies → leaks into later tests | `afterEach(restoreAllMocks)`; re-establish connected `useStellarWallet` default; await async share-asset load in ChangeTrust declined test |
| `useStellarWithdrawalQueue.test.tsx` | 8 | Same getter-spy leak (`withdrawalQueueId`) | `afterEach(restoreAllMocks)` |
| `-index.test.tsx` | 1 | Home Connect CTA now opens `ConnectWalletModal` via `useConnectModal().open()` (#638/#645), not AppKit directly | Assert the new wiring |

## Verification

- ✅ All **1084** frontend tests pass (66 files)
- ✅ `tsc --noEmit` clean
- ✅ `scripts/lint-docs.ts` 0 errors

Note: pre-existing repo-wide Prettier formatting debt (on files unrelated to this PR) is left untouched to keep the diff scoped.