### PR TITLE
Hide deposit bottom section only on first load (fix flicker)

### DIFF
--- a/docs/user-stories/epic-498/656-hide-bottom-block-while-data-pending.md
+++ b/docs/user-stories/epic-498/656-hide-bottom-block-while-data-pending.md
@@ -10,6 +10,13 @@ default step states before chain balance data and the requests API had resolved.
 This story covers the fix that hides the entire bottom actions block during this
 loading window.
 
+**Refinement (no-flicker):** the loading gate applies **only on the first page
+load**. Once chain/API data has resolved while connected, the bottom block stays
+mounted through later background refetches (React Query refetch on focus/interval,
+balance polling). Re-hiding on every refetch made the block flicker. Stories S1–S6
+describe the initial-load window (before data has ever resolved); S7 covers the
+post-first-load behavior.
+
 ## Actors
 
 - **Connected EVM user** — wallet connected, token balance query in-flight or just resolved.
@@ -68,3 +75,16 @@ token query is not yet enabled)
 **And** the StepsCard is absent (expected — disconnected)
 
 This ensures the disconnected branch evaluates before the `isDataPending` guard.
+
+### S7 — Bottom block stays mounted on a background refetch after first load
+
+**Given** the wallet is connected on EVM
+**And** chain/API data has already resolved once so the StepsCard
+(`data-testid="deposit-steps-card"`) is rendered
+**When** a background refetch puts chain data / the requests API back into a
+pending state (`isDataPending` becomes `true` again)
+**Then** the StepsCard remains rendered — it is **not** re-hidden
+**And** the bottom block does not flicker
+
+The loading gate is latched to the first successful data load, so it fires at most
+once per page visit.

--- a/packages/frontend/src/routes/-deposit.test.tsx
+++ b/packages/frontend/src/routes/-deposit.test.tsx
@@ -2304,6 +2304,32 @@ describe("Deposit page — isDataPending: EVM deposit pending (requestsLoading)"
       expect(screen.getByTestId("deposit-steps-card")).toBeInTheDocument();
     });
   });
+
+  it("StepsCard stays mounted on a background refetch after first load (no re-hide flicker)", async () => {
+    // First load: resolve data so the bottom section (steps card) appears.
+    mockRequestsLoading = false;
+    mockRequestsData = { requests: [] };
+    const { rerender } = renderDeposit();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("deposit-steps-card")).toBeInTheDocument();
+    });
+
+    // Simulate a background refetch — chain data / requests go pending again.
+    mockRequestsLoading = true;
+    const DepositPage = Route.options.component as React.ComponentType;
+    rerender(
+      <EvmWalletProvider>
+        <ToastProvider>
+          <DepositPage />
+        </ToastProvider>
+      </EvmWalletProvider>,
+    );
+
+    // The section must NOT be re-hidden: the loading gate only applies to the
+    // first page load, so the steps card stays mounted (no flicker).
+    expect(screen.getByTestId("deposit-steps-card")).toBeInTheDocument();
+  });
 });
 
 describe("Deposit page — isDataPending: EVM withdraw pending (requestsLoading)", () => {

--- a/packages/frontend/src/routes/deposit.tsx
+++ b/packages/frontend/src/routes/deposit.tsx
@@ -124,6 +124,17 @@ function Deposit() {
     dismissedDepositId,
   );
 
+  // Latch the first successful data load. The bottom section is hidden while
+  // chain/API data is still pending — but only on the *first* page load. Once
+  // data has resolved while connected, keep the section mounted through later
+  // background refetches; otherwise it re-hides on every refetch and flickers.
+  const hasLoadedDataRef = useRef(false);
+  if (flow.isConnected && !flow.isDataPending) {
+    hasLoadedDataRef.current = true;
+  }
+  // Render nothing only during the initial load, before data first resolves.
+  const isInitialDataLoad = flow.isDataPending && !hasLoadedDataRef.current;
+
   // ── "Make another deposit" — dismiss the completed deposit, reset the form ─
   const onMakeAnotherDeposit = useCallback(() => {
     setDismissedDepositId(flow.depositCompletedRequestId);
@@ -487,7 +498,7 @@ function Deposit() {
               Connect
             </Button>
           </Card>
-        ) : flow.isDataPending /* Chain data / requests API still loading — render nothing until resolved. */ ? null : isStellar &&
+        ) : isInitialDataLoad /* First load only: chain data / requests API still loading — render nothing until first resolved (avoids re-hide flicker on background refetches). */ ? null : isStellar &&
           isDeposit &&
           usdcTrustline?.needsTrustline &&
           flow.hasBalance === false &&
@@ -652,7 +663,7 @@ function Deposit() {
         {/* "Make another deposit" — shown once the latest deposit is claimed
             (Completed). Resets the form so a fresh deposit can be started. */}
         {flow.isConnected &&
-          !flow.isDataPending &&
+          !isInitialDataLoad &&
           flow.isDepositCompleted && (
             <Button
               data-testid="make-another-deposit"


### PR DESCRIPTION
## Problem

The deposit/withdraw page hides the bottom actions block (StepsCard + banners) while chain data / the requests API are pending (#656). But the gate re-applied on **every** background refetch — React Query refetch on focus/interval, balance polling — so the section **flickered** after the page had already loaded.

## Fix

Latch the first successful data load. Once data has resolved while connected, keep the section mounted through later refetches. The loading gate now fires **at most once per page visit**.

```ts
const hasLoadedDataRef = useRef(false);
if (flow.isConnected && !flow.isDataPending) {
  hasLoadedDataRef.current = true;
}
const isInitialDataLoad = flow.isDataPending && !hasLoadedDataRef.current;
```

The gate (and the "Make another deposit" button) now check `isInitialDataLoad` instead of raw `flow.isDataPending`. First-load behavior is unchanged; only the re-hide on refetch is removed.

## Tests

- New regression test (story S7): StepsCard stays mounted on a background refetch after first load — fails on the old code, passes now.
- Existing first-load hiding tests (S1–S6) unchanged and green.
- All **1107** frontend tests pass; `tsc` + doc-lint clean.

User story #656 updated to document the first-load-only refinement.