### PR TITLE
Fix Stellar claim byte encoding in browser

### DIFF
--- a/packages/frontend/src/wallet/stellar/contracts/depositManager.test.ts
+++ b/packages/frontend/src/wallet/stellar/contracts/depositManager.test.ts
@@ -32,6 +32,7 @@ const {
   mockScValToNative,
   mockNativeToScVal,
   mockContractCall,
+  mockScvBytes,
   mockBuild,
   mockAddOperation,
 } = vi.hoisted(() => {
@@ -50,6 +51,7 @@ const {
     mockScValToNative: vi.fn(),
     mockNativeToScVal: vi.fn().mockReturnValue({}),
     mockContractCall: vi.fn().mockReturnValue("op"),
+    mockScvBytes: vi.fn().mockReturnValue({}),
     mockBuild,
     mockAddOperation,
   };
@@ -102,7 +104,7 @@ vi.mock("@stellar/stellar-sdk", () => {
     BASE_FEE: "100",
     xdr: {
       ScVal: {
-        scvBytes: vi.fn().mockReturnValue({}),
+        scvBytes: mockScvBytes,
       },
     },
     Address: class {
@@ -270,6 +272,7 @@ describe("DepositManagerClient.buildRequestDeposit()", () => {
     mockIsSimulationError.mockReturnValue(false);
     mockSimulateTransaction.mockResolvedValue({ result: { retval: {} } });
     mockAssembleTransaction.mockReturnValue({ build: mockBuild });
+    mockScvBytes.mockClear();
   });
 
   it("returns assembled XDR string", async () => {
@@ -348,5 +351,37 @@ describe("DepositManagerClient.buildClaimRequest()", () => {
       mockAccount as unknown as Account,
     );
     expect(typeof xdrResult).toBe("string");
+  });
+
+  it("does not require a global Buffer when building claim bytes", async () => {
+    const originalBuffer = Reflect.get(globalThis, "Buffer");
+    vi.stubGlobal("Buffer", undefined);
+
+    try {
+      const client = new DepositManagerClient(CONTRACT_ID);
+      const mockAccount = {
+        accountId: () => CONTRACT_ID,
+        sequenceNumber: () => "1",
+        incrementSequenceNumber: () => {},
+      };
+
+      await expect(
+        client.buildClaimRequest(
+          1n,
+          new Uint8Array(64).fill(0x02),
+          mockAccount as unknown as Account,
+        ),
+      ).resolves.toBe("assembled-xdr");
+
+      expect(mockScvBytes).toHaveBeenCalledWith(expect.any(Uint8Array));
+      expect((mockScvBytes.mock.calls.at(-1)?.[0] as Uint8Array).length).toBe(
+        64,
+      );
+    } finally {
+      vi.unstubAllGlobals();
+      if (originalBuffer !== undefined) {
+        Reflect.set(globalThis, "Buffer", originalBuffer);
+      }
+    }
   });
 });

--- a/packages/frontend/src/wallet/stellar/contracts/depositManager.ts
+++ b/packages/frontend/src/wallet/stellar/contracts/depositManager.ts
@@ -256,7 +256,11 @@ export class DepositManagerClient {
     const op = this.contract.call(
       "claim_request",
       nativeToScVal(requestId, { type: "u128" }),
-      xdr.ScVal.scvBytes(Buffer.from(verifierSignature)),
+      xdr.ScVal.scvBytes(
+        Uint8Array.from(verifierSignature) as Parameters<
+          typeof xdr.ScVal.scvBytes
+        >[0],
+      ),
     );
 
     const tx = new TransactionBuilder(sourceAccount, {

--- a/packages/frontend/src/wallet/stellar/contracts/withdrawalQueue.ts
+++ b/packages/frontend/src/wallet/stellar/contracts/withdrawalQueue.ts
@@ -247,7 +247,11 @@ export class WithdrawalQueueClient {
     const op = this.contract.call(
       "claim_request",
       nativeToScVal(requestId, { type: "u128" }),
-      xdr.ScVal.scvBytes(Buffer.from(verifierSignature)),
+      xdr.ScVal.scvBytes(
+        Uint8Array.from(verifierSignature) as Parameters<
+          typeof xdr.ScVal.scvBytes
+        >[0],
+      ),
     );
 
     const tx = new TransactionBuilder(sourceAccount, {


### PR DESCRIPTION
## Summary
- remove Node Buffer usage from Stellar deposit claim request XDR building
- apply the same browser-safe byte conversion to withdrawal claim requests
- add a regression test for claim building without a global Buffer

## Verification
- yarn workspace @pipeline/frontend test src/wallet/stellar/contracts/depositManager.test.ts
- cd packages/frontend && npx tsc --noEmit
- npx tsx scripts/lint-docs.ts
- yarn workspace @pipeline/frontend build