### PR TITLE
Fix Stellar stake gating for Soroban share vault

### DIFF
--- a/packages/frontend/src/wallet/README.md
+++ b/packages/frontend/src/wallet/README.md
@@ -880,9 +880,13 @@ const { submit, needsTrustline, data, isPending, isSuccess, error, reset } =
   useStellarChangeTrustStakedPlusd();
 ```
 
-Builds and submits a classic Horizon `changeTrust` op for the sPLUSD share asset.
-`needsTrustline: true` when the connected account has no sPLUSD trustline and the
-share asset identity has been resolved from the vault's `name()` view.
+Builds and submits a classic Horizon `changeTrust` op only when the sPLUSD share
+token is backed by a classic asset. Classic deployments encode the share asset
+in the vault `name()` as `CODE:ISSUER`; Soroban-native vaults return a plain
+token name and require no classic trustline before staking.
+
+`needsTrustline: true` only when a classic share asset is resolved and the
+connected account has no sPLUSD trustline.
 
 ### Stellar mock keys
 

--- a/packages/frontend/src/wallet/stellar/useStellarSacToken.ts
+++ b/packages/frontend/src/wallet/stellar/useStellarSacToken.ts
@@ -235,7 +235,12 @@ export function useStellarSacToken({
   };
 
   // ── useQuery ──────────────────────────────────────────────────────────────
-  const shouldRunQuery = mockRaw === undefined && isConnected && !!address;
+  const shouldRunQuery =
+    mockRaw === undefined &&
+    isConnected &&
+    !!address &&
+    assetCode !== "" &&
+    assetIssuer !== "";
 
   const query = useQuery({
     queryKey: [

--- a/packages/frontend/src/wallet/stellar/useStellarStakedPlusd.test.tsx
+++ b/packages/frontend/src/wallet/stellar/useStellarStakedPlusd.test.tsx
@@ -631,10 +631,9 @@ describe("useStellarChangeTrustStakedPlusd", () => {
       "readMockStellarChangeTrustStakedPlusd",
     ).mockReturnValue({ hash: "trust-mock-hash" });
 
-    const { result } = renderHook(
-      () => useStellarChangeTrustStakedPlusd(),
-      { wrapper: makeWrapper() },
-    );
+    const { result } = renderHook(() => useStellarChangeTrustStakedPlusd(), {
+      wrapper: makeWrapper(),
+    });
 
     act(() => {
       result.current.submit();
@@ -655,10 +654,9 @@ describe("useStellarChangeTrustStakedPlusd", () => {
     // initial state before the promise settles.
     mockName.mockReturnValue(new Promise(() => {})); // never resolves
 
-    const { result } = renderHook(
-      () => useStellarChangeTrustStakedPlusd(),
-      { wrapper: makeWrapper() },
-    );
+    const { result } = renderHook(() => useStellarChangeTrustStakedPlusd(), {
+      wrapper: makeWrapper(),
+    });
 
     // Immediately after mount the query is still loading.
     expect(result.current.trustlineStatus).toBe("loading");
@@ -671,14 +669,11 @@ describe("useStellarChangeTrustStakedPlusd", () => {
     // mockName resolves in beforeEach to a valid "CODE:ISSUER" string.
     // useStellarSacToken is mocked to hasTrustline: false (the default mock).
 
-    const { result } = renderHook(
-      () => useStellarChangeTrustStakedPlusd(),
-      { wrapper: makeWrapper() },
-    );
+    const { result } = renderHook(() => useStellarChangeTrustStakedPlusd(), {
+      wrapper: makeWrapper(),
+    });
 
-    await waitFor(() =>
-      expect(result.current.trustlineStatus).toBe("needed"),
-    );
+    await waitFor(() => expect(result.current.trustlineStatus).toBe("needed"));
     expect(result.current.needsTrustline).toBe(true);
   });
 
@@ -707,10 +702,9 @@ describe("useStellarChangeTrustStakedPlusd", () => {
       isAuthorized: true,
     });
 
-    const { result } = renderHook(
-      () => useStellarChangeTrustStakedPlusd(),
-      { wrapper: makeWrapper() },
-    );
+    const { result } = renderHook(() => useStellarChangeTrustStakedPlusd(), {
+      wrapper: makeWrapper(),
+    });
 
     await waitFor(() =>
       expect(result.current.trustlineStatus).toBe("satisfied"),
@@ -721,19 +715,27 @@ describe("useStellarChangeTrustStakedPlusd", () => {
     vi.mocked(sacModule.useStellarSacToken).mockReturnValue(defaultSacReturn);
   });
 
-  // Regression: name() returns non-"CODE:ISSUER" format → "error", staking blocked
-  it("trustlineStatus is 'error' when name() returns unexpected format", async () => {
-    // Override mockName to return a non-"CODE:ISSUER" string.
-    mockName.mockResolvedValue("not-a-valid-asset-string");
+  it("trustlineStatus is 'not_required' when name() returns a Soroban token name", async () => {
+    mockName.mockResolvedValue("Staked Pipeline USD");
 
-    const { result } = renderHook(
-      () => useStellarChangeTrustStakedPlusd(),
-      { wrapper: makeWrapper() },
-    );
+    const { result } = renderHook(() => useStellarChangeTrustStakedPlusd(), {
+      wrapper: makeWrapper(),
+    });
 
     await waitFor(() =>
-      expect(result.current.trustlineStatus).toBe("error"),
+      expect(result.current.trustlineStatus).toBe("not_required"),
     );
+    expect(result.current.needsTrustline).toBe(false);
+  });
+
+  it("trustlineStatus is 'error' when name() returns malformed classic format", async () => {
+    mockName.mockResolvedValue("sPLUSD:");
+
+    const { result } = renderHook(() => useStellarChangeTrustStakedPlusd(), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.trustlineStatus).toBe("error"));
     // needsTrustline must be false — we don't know enough to assert "needed"
     expect(result.current.needsTrustline).toBe(false);
   });
@@ -742,14 +744,11 @@ describe("useStellarChangeTrustStakedPlusd", () => {
   it("trustlineStatus is 'error' when name() rejects", async () => {
     mockName.mockRejectedValue(new Error("RPC connection refused"));
 
-    const { result } = renderHook(
-      () => useStellarChangeTrustStakedPlusd(),
-      { wrapper: makeWrapper() },
-    );
+    const { result } = renderHook(() => useStellarChangeTrustStakedPlusd(), {
+      wrapper: makeWrapper(),
+    });
 
-    await waitFor(() =>
-      expect(result.current.trustlineStatus).toBe("error"),
-    );
+    await waitFor(() => expect(result.current.trustlineStatus).toBe("error"));
     expect(result.current.needsTrustline).toBe(false);
   });
 
@@ -760,10 +759,9 @@ describe("useStellarChangeTrustStakedPlusd", () => {
       "readMockStellarChangeTrustStakedPlusd",
     ).mockReturnValue(undefined);
 
-    const { result } = renderHook(
-      () => useStellarChangeTrustStakedPlusd(),
-      { wrapper: makeWrapper() },
-    );
+    const { result } = renderHook(() => useStellarChangeTrustStakedPlusd(), {
+      wrapper: makeWrapper(),
+    });
 
     // Wait for name() to resolve so shareAsset is loaded before submit()
     // (otherwise the "share asset not loaded" guard fires first).
@@ -785,10 +783,9 @@ describe("useStellarChangeTrustStakedPlusd", () => {
       "readMockStellarChangeTrustStakedPlusd",
     ).mockReturnValue({ hash: "h" });
 
-    const { result } = renderHook(
-      () => useStellarChangeTrustStakedPlusd(),
-      { wrapper: makeWrapper() },
-    );
+    const { result } = renderHook(() => useStellarChangeTrustStakedPlusd(), {
+      wrapper: makeWrapper(),
+    });
 
     act(() => {
       result.current.submit();

--- a/packages/frontend/src/wallet/stellar/useStellarStakedPlusd.ts
+++ b/packages/frontend/src/wallet/stellar/useStellarStakedPlusd.ts
@@ -16,7 +16,7 @@
  *
  * Trustline hook:
  *   - `useStellarChangeTrustStakedPlusd()` — builds + submits a classic `changeTrust`
- *     op for the sPLUSD share asset; exposes `needsTrustline` + `submit()`.
+ *     op only when the sPLUSD share token is backed by a classic asset.
  *
  * All write hooks expose the same state shape:
  *   `{ write, data, isPending, isSuccess, error, reset }`
@@ -138,26 +138,32 @@ export interface UseStellarStakedPlusdBalanceResult {
  * Fail-safe trustline status for the sPLUSD share asset.
  *
  * - `"loading"`   — share asset or trustline check is still in flight.
- * - `"error"`     — `name()` call failed or returned an unexpected format.
+ * - `"error"`     — `name()` call failed or returned a malformed classic format.
  * - `"needed"`    — share asset resolved, trustline is missing.
  * - `"satisfied"` — share asset resolved AND trustline exists.
+ * - `"not_required"` — deployed vault exposes Soroban shares, so no classic
+ *   trustline is required before staking.
  *
  * The step must be marked "success" and staking may proceed ONLY when
- * `trustlineStatus === "satisfied"`.
+ * `trustlineStatus === "satisfied"` or `"not_required"`.
  */
 export type StellarSplusdTrustlineStatus =
   | "loading"
   | "error"
   | "needed"
-  | "satisfied";
+  | "satisfied"
+  | "not_required";
+
+type StellarShareAsset =
+  | { kind: "classic"; code: string; issuer: string }
+  | { kind: "soroban"; name: string };
 
 export interface UseStellarChangeTrustStakedPlusdResult {
   submit: () => void;
   /**
    * Fail-safe discriminated status for the sPLUSD trustline step.
-   * The step shows "success" and staking is allowed ONLY when this is
-   * `"satisfied"`. While `"loading"` or `"error"` the step remains actionable
-   * (never silently OK) and staking is blocked.
+   * The step shows "success" and staking is allowed when this is `"satisfied"`
+   * or `"not_required"`. While `"loading"` or `"error"` staking is blocked.
    */
   trustlineStatus: StellarSplusdTrustlineStatus;
   /**
@@ -706,14 +712,14 @@ export function useStellarStakedPlusdBalance(): UseStellarStakedPlusdBalanceResu
 // ── useStellarChangeTrustStakedPlusd ──────────────────────────────────────────
 
 /**
- * Hook that builds and submits a classic `changeTrust` op for the sPLUSD asset.
+ * Hook that builds and submits a classic `changeTrust` op for the sPLUSD asset
+ * when the deployed vault exposes one.
  *
- * Staking mints sPLUSD shares to the receiver — without an sPLUSD trustline
- * the deposit fails. This hook derives the share asset's `{ code, issuer }`
- * from the vault's `name()` view (which returns `"sPLUSD:GISSUER"` style,
- * matching the `"CODE:ISSUER"` convention used for PLUSD/USDC in
- * `useStellarDepositManagerAddresses.ts`), then drives `useStellarSacToken`
- * for `hasTrustline` detection.
+ * Older/classic deployments encode the share asset in `name()` as
+ * `"sPLUSD:GISSUER"` and require a Horizon `changeTrust` op before staking.
+ * The current Futurenet vault returns a plain Soroban token name such as
+ * `"Staked Pipeline USD"`; those shares are held by the vault contract itself,
+ * so no classic trustline step is required.
  *
  * Fail-safe status (`trustlineStatus`)
  * --------------------------------------
@@ -723,13 +729,14 @@ export function useStellarStakedPlusdBalance(): UseStellarStakedPlusdBalanceResu
  * "success" while the share asset is still resolving:
  *
  *   - `"loading"` — share asset or token check is still in flight.
- *   - `"error"`   — `name()` call failed or returned an unexpected format.
+ *   - `"error"`   — `name()` call failed or returned a malformed classic format.
  *   - `"needed"`  — share asset resolved, but the trustline is missing.
  *   - `"satisfied"` — share asset resolved AND the trustline exists.
+ *   - `"not_required"` — vault shares are Soroban-native; no classic trustline.
  *
- * The step must only be marked "success" and staking may only proceed when
- * `trustlineStatus === "satisfied"`. Any other status (including loading)
- * keeps the step actionable ("Enable" button) and blocks the stake action.
+ * The step is marked "success" and staking may proceed when
+ * `trustlineStatus === "satisfied"` or `"not_required"`. Any other status
+ * blocks the stake action.
  *
  * `needsTrustline` is kept for backward-compat and is `true` only for the
  * "needed" case (enables the submit button when there is a real missing trustline
@@ -749,33 +756,28 @@ export function useStellarChangeTrustStakedPlusd(): UseStellarChangeTrustStakedP
 
   const { address, isConnected, signTransaction } = useStellarWallet();
 
-  // ── Resolve share asset { code, issuer } from vault name() ─────────────────
+  // ── Resolve share asset mode from vault name() ─────────────────────────────
   //
-  // The vault's SAC name() returns "CODE:ISSUER" style (e.g. "sPLUSD:GISSUER"),
-  // matching the convention used for PLUSD/USDC in
-  // useStellarDepositManagerAddresses.ts (parseClassicAsset). On an unexpected
-  // format we throw (fail-safe) rather than fabricating an issuer, because
-  // building a changeTrust against a wrong asset is worse than blocking.
-  // retry:1 allows one self-heal on a transient RPC error.
-  const shareAssetQuery = useQuery<{ code: string; issuer: string }, Error>({
+  // "CODE:ISSUER" means a classic trustline is required. A plain token name
+  // means Soroban-native vault shares and no changeTrust step.
+  const shareAssetQuery = useQuery<StellarShareAsset, Error>({
     queryKey: ["stellarStakedPlusdShareAsset", stakedPlusdId],
     queryFn: async () => {
       const client = createStakedPlusdClient(stakedPlusdId);
       if (!client) throw new Error("StakedPLUSD not configured");
       const nameStr = await client.name();
-      // Parse "CODE:ISSUER" — same pattern as parseClassicAsset in
-      // useStellarDepositManagerAddresses.ts.
       const parts = nameStr.split(":");
       if (parts.length === 2 && parts[0] && parts[1]) {
-        return { code: parts[0], issuer: parts[1] };
+        return { kind: "classic", code: parts[0], issuer: parts[1] };
       }
-      // Fail-safe: treat unexpected format as an error so trustlineStatus
-      // becomes "error" and staking is blocked (not silently allowed).
+      if (parts.length === 1 && nameStr.trim() !== "") {
+        return { kind: "soroban", name: nameStr };
+      }
       console.warn(
-        `useStellarChangeTrustStakedPlusd: unexpected name() result "${nameStr}", expected "CODE:ISSUER"`,
+        `useStellarChangeTrustStakedPlusd: malformed name() result "${nameStr}", expected "CODE:ISSUER" or a Soroban token name`,
       );
       throw new Error(
-        `StakedPLUSD: unexpected name() result "${nameStr}" — expected "CODE:ISSUER"`,
+        `StakedPLUSD: malformed name() result "${nameStr}" — expected "CODE:ISSUER" or a Soroban token name`,
       );
     },
     enabled: !!stakedPlusdId,
@@ -793,8 +795,8 @@ export function useStellarChangeTrustStakedPlusd(): UseStellarChangeTrustStakedP
 
   // ── Trustline check via useStellarSacToken ─────────────────────────────────
   const sPlusdToken = useStellarSacToken({
-    assetCode: shareAsset?.code ?? "",
-    assetIssuer: shareAsset?.issuer ?? "",
+    assetCode: shareAsset?.kind === "classic" ? shareAsset.code : "",
+    assetIssuer: shareAsset?.kind === "classic" ? shareAsset.issuer : "",
     contractId: stakedPlusdId, // vault IS the share token
     mockKey: STELLAR_MOCK_KEYS.stakedPlusdShareBalance,
   });
@@ -819,6 +821,12 @@ export function useStellarChangeTrustStakedPlusd(): UseStellarChangeTrustStakedP
       // Query finished but no data (e.g. unconfigured) — treat as loading
       // rather than silently OK.
       return "loading";
+    }
+    if (shareAsset.kind === "soroban") {
+      return "not_required";
+    }
+    if (sPlusdToken.error !== null) {
+      return "error";
     }
     if (sPlusdToken.hasTrustline) {
       return "satisfied";
@@ -866,8 +874,8 @@ export function useStellarChangeTrustStakedPlusd(): UseStellarChangeTrustStakedP
       return;
     }
 
-    // ── Share asset not loaded yet ────────────────────────────────────────
-    if (!shareAsset) {
+    // ── Share asset not loaded / not classic yet ──────────────────────────
+    if (!shareAsset || shareAsset.kind !== "classic") {
       setError(new Error("sPLUSD share asset not loaded"));
       return;
     }

--- a/packages/frontend/src/wallet/useStakeFlow.test.tsx
+++ b/packages/frontend/src/wallet/useStakeFlow.test.tsx
@@ -30,6 +30,9 @@ import { useStakeFlow } from "./useStakeFlow";
 // Intercept Horizon.Server.loadAccount so we control balance lines.
 
 const mockLoadAccount = vi.hoisted(() => vi.fn());
+const mockStakedPlusdName = vi.hoisted(() => vi.fn());
+const mockStakedPlusdConvertToShares = vi.hoisted(() => vi.fn());
+const mockStakedPlusdConvertToAssets = vi.hoisted(() => vi.fn());
 
 vi.mock("@stellar/stellar-sdk", async (importOriginal) => {
   const original =
@@ -45,6 +48,19 @@ vi.mock("@stellar/stellar-sdk", async (importOriginal) => {
     Horizon: { Server: MockHorizonServer },
   };
 });
+
+vi.mock("./stellar/contracts/stakedPlusd", () => ({
+  StakedPlusdClient: vi.fn(),
+  createStakedPlusdClient: vi.fn(() => ({
+    name: mockStakedPlusdName,
+    convertToShares: mockStakedPlusdConvertToShares,
+    convertToAssets: mockStakedPlusdConvertToAssets,
+    queryAsset: vi.fn(),
+    balance: vi.fn(),
+    buildDeposit: vi.fn(),
+    buildRedeem: vi.fn(),
+  })),
+}));
 
 // ── Stellar chain mock ────────────────────────────────────────────────────────
 // Provide all chain constants explicitly so StellarWalletsKit.init() and
@@ -73,6 +89,8 @@ vi.mock("@creit.tech/stellar-wallets-kit", () => ({
     authModal: vi.fn().mockRejectedValue(new Error("no modal in tests")),
     signTransaction: vi.fn().mockRejectedValue(new Error("no sign in tests")),
   },
+  addressUpdatedEvent: { subscribe: vi.fn() },
+  disconnectEvent: { subscribe: vi.fn() },
   LOBSTR_ID: "lobstr",
   FREIGHTER_ID: "freighter",
   XBULL_ID: "xbull",
@@ -240,6 +258,12 @@ describe("useStakeFlow — Stellar PLUSD balance (Horizon path, issuer-sensitive
   beforeEach(() => {
     localStorage.clear();
     mockLoadAccount.mockClear();
+    mockStakedPlusdName.mockReset();
+    mockStakedPlusdConvertToShares.mockReset();
+    mockStakedPlusdConvertToAssets.mockReset();
+    mockStakedPlusdName.mockResolvedValue("Staked Pipeline USD");
+    mockStakedPlusdConvertToShares.mockResolvedValue(9_600_000n);
+    mockStakedPlusdConvertToAssets.mockResolvedValue(10_400_000n);
     seedStellarWalletKeys();
     seedDepositManagerMockKeys();
   });
@@ -279,6 +303,25 @@ describe("useStakeFlow — Stellar PLUSD balance (Horizon path, issuer-sensitive
     expect(resultWithAmount.current.hasBalance).toBe(true);
   });
 
+  it("Stake step is enabled when the vault name is Soroban-native and no sPLUSD trustline is required", async () => {
+    mockLoadAccount.mockResolvedValue({
+      balances: makeBalances(PLUSD_BALANCE_50, PROTOCOL_ISSUER),
+    });
+
+    const { result } = renderHook(
+      () => useStakeFlow("stake", 100_000_000n, () => {}),
+      { wrapper: makeWrapper().wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.balance).toBe(PLUSD_BALANCE_50_RAW);
+      expect(result.current.hasBalance).toBe(true);
+      expect(result.current.steps[0]?.state).toBe("success");
+      expect(result.current.steps[1]?.actionLabel).toBe("Stake");
+      expect(result.current.steps[1]?.disabled).toBe(false);
+    });
+  });
+
   it("balance is 0n and hasBalance is false when Horizon PLUSD line has a different issuer", async () => {
     // Arrange: Horizon returns PLUSD from a *different* issuer — issuer mismatch.
     mockLoadAccount.mockResolvedValue({
@@ -311,6 +354,12 @@ describe("useStakeFlow — Stellar sPLUSD balance (Unstake tab, not issuer-sensi
   beforeEach(() => {
     localStorage.clear();
     mockLoadAccount.mockClear();
+    mockStakedPlusdName.mockReset();
+    mockStakedPlusdConvertToShares.mockReset();
+    mockStakedPlusdConvertToAssets.mockReset();
+    mockStakedPlusdName.mockResolvedValue("Staked Pipeline USD");
+    mockStakedPlusdConvertToShares.mockResolvedValue(9_600_000n);
+    mockStakedPlusdConvertToAssets.mockResolvedValue(10_400_000n);
     seedStellarWalletKeys();
     seedDepositManagerMockKeys();
     // sPLUSD balance comes from the vault contract mock key, not Horizon.

--- a/packages/frontend/src/wallet/useStakeFlow.ts
+++ b/packages/frontend/src/wallet/useStakeFlow.ts
@@ -262,7 +262,7 @@ export function useStakeFlow(
   const stellarUnstake = useStellarUnstake();
 
   // Trustline hooks — always mounted.
-  // Stake: needs sPLUSD trustline.
+  // Stake: only classic-asset share deployments need an sPLUSD trustline.
   const splusdTrustline = useStellarChangeTrustStakedPlusd();
   // Unstake: needs PLUSD trustline (same as deposit flow).
   const plusdTrustline = useChangeTrust();
@@ -280,9 +280,7 @@ export function useStakeFlow(
   const stellarAssetsPreview = useStellarUnstakeConvertToAssets(
     !isStake ? amountBig : undefined,
   );
-  const stellarOneStake = isStake
-    ? parseUnits("1", SAC_DECIMALS)
-    : undefined;
+  const stellarOneStake = isStake ? parseUnits("1", SAC_DECIMALS) : undefined;
   const stellarOneUnstake = !isStake
     ? parseUnits("1", SAC_DECIMALS)
     : undefined;
@@ -341,7 +339,9 @@ export function useStakeFlow(
     !evmUnstake.isSuccess;
 
   const evmStep1State: StakeStepState =
-    isStake && (evmHasSufficientAllowance || evmStake.isSuccess) && isEvmConnected
+    isStake &&
+    (evmHasSufficientAllowance || evmStake.isSuccess) &&
+    isEvmConnected
       ? "success"
       : "idle";
   const evmStep2State: StakeStepState = evmStake.isSuccess ? "success" : "idle";
@@ -414,7 +414,9 @@ export function useStakeFlow(
   const stellarIsReady =
     isStellarConnected && stellarInputBalance !== undefined;
   const stellarHasBalance =
-    stellarIsReady && amountBig > 0n && amountBig <= (stellarInputBalance ?? 0n);
+    stellarIsReady &&
+    amountBig > 0n &&
+    amountBig <= (stellarInputBalance ?? 0n);
 
   // Trustline states.
   //
@@ -422,6 +424,9 @@ export function useStakeFlow(
   // "success" is shown ONLY when the trustline is confirmed present, never
   // when the share asset is still loading or errored.
   const stellarSplusdTrustlineStatus = splusdTrustline.trustlineStatus;
+  const stellarSplusdTrustlineSatisfied =
+    stellarSplusdTrustlineStatus === "satisfied" ||
+    stellarSplusdTrustlineStatus === "not_required";
   const stellarSplusdNeedsTrustline = splusdTrustline.needsTrustline;
   const stellarPlusdNeedsTrustline = plusdTrustline.needsTrustline;
 
@@ -443,14 +448,14 @@ export function useStakeFlow(
 
   // Step 2 (stake/unstake) — gated on trustline being present.
   //
-  // canStellarStake: permit staking ONLY when trustlineStatus is "satisfied".
-  // Loading or error states block staking — the mint cannot land on a
-  // non-existent trustline (this is the core safety fix for #685).
+  // canStellarStake: permit staking only when the classic trustline is
+  // satisfied or the vault reports Soroban-native shares that need no trustline.
+  // Loading/error/needed states block staking.
   const canStellarStake =
     isStake &&
     isStellarConnected &&
     stellarHasBalance &&
-    stellarSplusdTrustlineStatus === "satisfied" &&
+    stellarSplusdTrustlineSatisfied &&
     !stellarStake.isPending &&
     !stellarStake.isSuccess;
 
@@ -464,13 +469,11 @@ export function useStakeFlow(
 
   // Step states.
   //
-  // stellarSplusdTrustlineState: "success" ONLY when trustlineStatus is
-  // "satisfied" (and connected). Loading/needed/error all stay "idle" so the
-  // actionable "Enable" button is always shown while resolution is pending.
+  // stellarSplusdTrustlineState: "success" only when the classic trustline is
+  // satisfied or no classic trustline is required. Loading/needed/error all
+  // stay "idle".
   const stellarSplusdTrustlineState: StakeStepState =
-    stellarSplusdTrustlineStatus === "satisfied" && isStellarConnected
-      ? "success"
-      : "idle";
+    stellarSplusdTrustlineSatisfied && isStellarConnected ? "success" : "idle";
   const stellarPlusdTrustlineState: StakeStepState =
     !stellarPlusdNeedsTrustline && isStellarConnected ? "success" : "idle";
   const stellarStakeStepState: StakeStepState = stellarStake.isSuccess


### PR DESCRIPTION
## Summary
- support Soroban-native sPLUSD share vaults that return a plain token name from name()
- keep classic CODE:ISSUER share assets gated by Horizon trustline checks
- avoid empty SAC trustline queries and update stake flow gating/tests/docs

## Verification
- yarn workspace @pipeline/frontend test src/wallet/stellar/useStellarStakedPlusd.test.tsx src/wallet/useStakeFlow.test.tsx
- yarn workspace @pipeline/frontend test src/routes/-stake.test.tsx
- cd packages/frontend && npx tsc --noEmit
- npx tsx scripts/lint-docs.ts
- yarn workspace @pipeline/frontend build