### PR TITLE
Handle unfunded Stellar account errors

### DIFF
--- a/packages/frontend/src/routes/deposit.tsx
+++ b/packages/frontend/src/routes/deposit.tsx
@@ -214,6 +214,7 @@ function Deposit() {
   // ── Toast: Stellar PLUSD trustline ────────────────────────────────────
   const prevPlusdTrustPending = useRef(false);
   const prevPlusdTrustSuccess = useRef(false);
+  const prevPlusdTrustError = useRef<Error | null>(null);
   const plusdTrustline = flow.trustlines[0];
   useEffect(() => {
     if (!isStellar || !plusdTrustline) return;
@@ -231,11 +232,23 @@ function Deposit() {
         title: "PLUSD trustline enabled",
       });
     }
+    if (
+      plusdTrustline.tx.error &&
+      plusdTrustline.tx.error !== prevPlusdTrustError.current
+    ) {
+      console.error("PLUSD trustline failed:", plusdTrustline.tx.error);
+      toast.update(toastId, {
+        tone: "danger",
+        title: plusdTrustline.tx.error.message,
+      });
+    }
     prevPlusdTrustPending.current = plusdTrustline.tx.isPending;
     prevPlusdTrustSuccess.current = plusdTrustline.tx.isSuccess;
+    prevPlusdTrustError.current = plusdTrustline.tx.error;
   }, [
     plusdTrustline?.tx.isPending,
     plusdTrustline?.tx.isSuccess,
+    plusdTrustline?.tx.error,
     toast,
     isStellar,
     plusdTrustline,
@@ -244,6 +257,7 @@ function Deposit() {
   // ── Toast: Stellar USDC trustline ─────────────────────────────────────
   const prevUsdcTrustPending = useRef(false);
   const prevUsdcTrustSuccess = useRef(false);
+  const prevUsdcTrustError = useRef<Error | null>(null);
   const usdcTrustline = flow.trustlines[1];
   useEffect(() => {
     if (!isStellar || !usdcTrustline) return;
@@ -261,11 +275,23 @@ function Deposit() {
         title: "USDC trustline enabled",
       });
     }
+    if (
+      usdcTrustline.tx.error &&
+      usdcTrustline.tx.error !== prevUsdcTrustError.current
+    ) {
+      console.error("USDC trustline failed:", usdcTrustline.tx.error);
+      toast.update(toastId, {
+        tone: "danger",
+        title: usdcTrustline.tx.error.message,
+      });
+    }
     prevUsdcTrustPending.current = usdcTrustline.tx.isPending;
     prevUsdcTrustSuccess.current = usdcTrustline.tx.isSuccess;
+    prevUsdcTrustError.current = usdcTrustline.tx.error;
   }, [
     usdcTrustline?.tx.isPending,
     usdcTrustline?.tx.isSuccess,
+    usdcTrustline?.tx.error,
     toast,
     isStellar,
     usdcTrustline,
@@ -304,7 +330,11 @@ function Deposit() {
       );
       toast.update(toastId, {
         tone: "danger",
-        title: isDeposit ? "Deposit failed" : "Withdrawal failed",
+        title: isStellar
+          ? flow.step2Tx.error.message
+          : isDeposit
+            ? "Deposit failed"
+            : "Withdrawal failed",
         action: undefined,
       });
     }
@@ -346,7 +376,10 @@ function Deposit() {
     }
     if (flow.step3Tx.error && flow.step3Tx.error !== prevStep3Error.current) {
       console.error("Claim failed:", flow.step3Tx.error);
-      toast.update(toastId, { tone: "danger", title: "Claim failed" });
+      toast.update(toastId, {
+        tone: "danger",
+        title: isStellar ? flow.step3Tx.error.message : "Claim failed",
+      });
     }
     prevStep3IsPending.current = flow.step3Tx.isPending;
     prevStep3IsSuccess.current = flow.step3Tx.isSuccess;
@@ -662,18 +695,16 @@ function Deposit() {
 
         {/* "Make another deposit" — shown once the latest deposit is claimed
             (Completed). Resets the form so a fresh deposit can be started. */}
-        {flow.isConnected &&
-          !isInitialDataLoad &&
-          flow.isDepositCompleted && (
-            <Button
-              data-testid="make-another-deposit"
-              variant="primary-dark"
-              className="w-full"
-              onClick={onMakeAnotherDeposit}
-            >
-              Make another deposit
-            </Button>
-          )}
+        {flow.isConnected && !isInitialDataLoad && flow.isDepositCompleted && (
+          <Button
+            data-testid="make-another-deposit"
+            variant="primary-dark"
+            className="w-full"
+            onClick={onMakeAnotherDeposit}
+          >
+            Make another deposit
+          </Button>
+        )}
       </main>
     </div>
   );

--- a/packages/frontend/src/routes/stake.tsx
+++ b/packages/frontend/src/routes/stake.tsx
@@ -11,10 +11,7 @@ import {
   TokenAmountDisplay,
   TokenInput,
 } from "@pipeline/ui";
-import {
-  useWalletView,
-  useConnectModal,
-} from "@/wallet";
+import { useWalletView, useConnectModal } from "@/wallet";
 import { useToast } from "@/lib/toast";
 import { useStakeFlow } from "@/wallet/useStakeFlow";
 
@@ -111,6 +108,7 @@ function Stake() {
   // ── Toast: step 1 (EVM approve / Stellar trustline) ───────────────────
   const prevStep1IsPending = useRef(false);
   const prevStep1IsSuccess = useRef(false);
+  const prevStep1Error = useRef<Error | null>(null);
   useEffect(() => {
     const toastId = isStellar
       ? isStakeTab
@@ -139,11 +137,20 @@ function Stake() {
     if (flow.step1Tx.isSuccess && !prevStep1IsSuccess.current) {
       toast.update(toastId, { tone: "success", title: successTitle });
     }
+    if (flow.step1Tx.error && flow.step1Tx.error !== prevStep1Error.current) {
+      console.error("Trustline failed:", flow.step1Tx.error);
+      toast.update(toastId, {
+        tone: "danger",
+        title: isStellar ? flow.step1Tx.error.message : "Approval failed",
+      });
+    }
     prevStep1IsPending.current = flow.step1Tx.isPending;
     prevStep1IsSuccess.current = flow.step1Tx.isSuccess;
+    prevStep1Error.current = flow.step1Tx.error;
   }, [
     flow.step1Tx.isPending,
     flow.step1Tx.isSuccess,
+    flow.step1Tx.error,
     toast,
     isStellar,
     isStakeTab,
@@ -175,17 +182,18 @@ function Stake() {
         title: isStakeTab ? "Staked successfully" : "Unstaked successfully",
       });
     }
-    if (
-      flow.step2Tx.error &&
-      flow.step2Tx.error !== prevStep2Error.current
-    ) {
+    if (flow.step2Tx.error && flow.step2Tx.error !== prevStep2Error.current) {
       console.error(
         isStakeTab ? "Stake failed:" : "Unstake failed:",
         flow.step2Tx.error,
       );
       toast.update(toastId, {
         tone: "danger",
-        title: isStakeTab ? "Stake failed" : "Unstake failed",
+        title: isStellar
+          ? flow.step2Tx.error.message
+          : isStakeTab
+            ? "Stake failed"
+            : "Unstake failed",
       });
     }
     prevStep2IsPending.current = flow.step2Tx.isPending;
@@ -201,13 +209,10 @@ function Stake() {
   ]);
 
   // ── Tab-switch handler ─────────────────────────────────────────────────
-  const onSelectTab = useCallback(
-    (next: string) => {
-      setActiveTab(next as "stake" | "unstake");
-      setAmountInput("");
-    },
-    [],
-  );
+  const onSelectTab = useCallback((next: string) => {
+    setActiveTab(next as "stake" | "unstake");
+    setAmountInput("");
+  }, []);
 
   // ── Render ────────────────────────────────────────────────────────────
   return (
@@ -250,9 +255,7 @@ function Stake() {
               token={isStakeTab ? "plusd" : "splusd"}
               tokenLabel={isStakeTab ? "PLUSD" : "sPLUSD"}
               balanceLabel={
-                flow.formattedInputBalance
-                  ? flow.formattedInputBalance
-                  : "—"
+                flow.formattedInputBalance ? flow.formattedInputBalance : "—"
               }
               placeholderValue="0"
               value={amountInput}
@@ -278,9 +281,7 @@ function Stake() {
               token={isStakeTab ? "splusd" : "plusd"}
               tokenLabel={isStakeTab ? "sPLUSD" : "PLUSD"}
               balanceLabel={
-                flow.formattedOutputBalance
-                  ? flow.formattedOutputBalance
-                  : "—"
+                flow.formattedOutputBalance ? flow.formattedOutputBalance : "—"
               }
               value={flow.previewOutputValue}
               style={{
@@ -321,7 +322,9 @@ function Stake() {
           </Card>
         ) : (
           <StepsCard
-            data-testid={isStakeTab ? "stake-steps-card" : "stake-unstake-steps"}
+            data-testid={
+              isStakeTab ? "stake-steps-card" : "stake-unstake-steps"
+            }
             steps={flow.steps}
           />
         )}

--- a/packages/frontend/src/wallet/stellar/errors.test.ts
+++ b/packages/frontend/src/wallet/stellar/errors.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import {
+  isStellarAccountNotFoundError,
+  normalizeStellarActionError,
+} from "./errors";
+
+const ADDRESS = "GAD7YKWKWLZSDKVL2D5FRGKI7IE3PBGN7XNCJQJJH7XCGYEAWXR5FISM";
+
+describe("stellar error helpers", () => {
+  it("detects RPC account-not-found errors", () => {
+    expect(
+      isStellarAccountNotFoundError(new Error(`Account not found: ${ADDRESS}`)),
+    ).toBe(true);
+  });
+
+  it("detects Horizon 404 account errors", () => {
+    expect(
+      isStellarAccountNotFoundError({
+        response: {
+          status: 404,
+          data: { title: "Resource Missing", detail: "Account not found" },
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("normalizes account-not-found into a funding message", () => {
+    const error = normalizeStellarActionError(
+      new Error(`Account not found: ${ADDRESS}`),
+      ADDRESS,
+    );
+
+    expect(error.message).toContain("Stellar account is not funded");
+    expect(error.message).toContain(ADDRESS);
+  });
+
+  it("preserves unrelated errors", () => {
+    const original = new Error("User cancelled");
+
+    expect(normalizeStellarActionError(original, ADDRESS)).toBe(original);
+  });
+});

--- a/packages/frontend/src/wallet/stellar/errors.ts
+++ b/packages/frontend/src/wallet/stellar/errors.ts
@@ -1,0 +1,61 @@
+const ACCOUNT_NOT_FOUND_RE = /account not found/i;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function readString(value: unknown, key: string): string | undefined {
+  if (!isRecord(value)) return undefined;
+  const next = value[key];
+  return typeof next === "string" ? next : undefined;
+}
+
+function readNumber(value: unknown, key: string): number | undefined {
+  if (!isRecord(value)) return undefined;
+  const next = value[key];
+  return typeof next === "number" ? next : undefined;
+}
+
+export function isStellarAccountNotFoundError(err: unknown): boolean {
+  if (err instanceof Error && ACCOUNT_NOT_FOUND_RE.test(err.message)) {
+    return true;
+  }
+
+  if (typeof err === "string" && ACCOUNT_NOT_FOUND_RE.test(err)) {
+    return true;
+  }
+
+  if (!isRecord(err)) return false;
+
+  if (readNumber(err, "status") === 404) return true;
+
+  const message = readString(err, "message");
+  if (message && ACCOUNT_NOT_FOUND_RE.test(message)) return true;
+
+  const response = err.response;
+  if (isRecord(response) && readNumber(response, "status") === 404) {
+    return true;
+  }
+
+  const data = isRecord(response) ? response.data : undefined;
+  const title = readString(data, "title");
+  const detail = readString(data, "detail");
+
+  return [title, detail].some(
+    (part) => part !== undefined && ACCOUNT_NOT_FOUND_RE.test(part),
+  );
+}
+
+export function normalizeStellarActionError(
+  err: unknown,
+  address?: string,
+): Error {
+  if (isStellarAccountNotFoundError(err)) {
+    const suffix = address ? ` (${address})` : "";
+    return new Error(
+      `Stellar account is not funded on this network${suffix}. Add XLM to create it, then try again.`,
+    );
+  }
+
+  return err instanceof Error ? err : new Error(String(err));
+}

--- a/packages/frontend/src/wallet/stellar/useStellarDepositManager.ts
+++ b/packages/frontend/src/wallet/stellar/useStellarDepositManager.ts
@@ -58,6 +58,7 @@ import {
   readMockStellarClaim,
   readMockStellarChangeTrust,
 } from "./mock";
+import { normalizeStellarActionError } from "./errors";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -323,7 +324,7 @@ export function useStellarRequestDeposit(): RequestDepositResult {
             createdAt: Date.now(),
           });
         } catch (err) {
-          setError(err instanceof Error ? err : new Error(String(err)));
+          setError(normalizeStellarActionError(err, address));
         } finally {
           setIsPending(false);
           setIsInFlight(false);
@@ -468,7 +469,7 @@ export function useStellarClaim(): StellarClaimResult {
           setIsSuccess(true);
           clearInflightDeposit(address);
         } catch (err) {
-          setError(err instanceof Error ? err : new Error(String(err)));
+          setError(normalizeStellarActionError(err, address));
         } finally {
           setIsPending(false);
           setIsInFlight(false);
@@ -651,7 +652,7 @@ export function useChangeTrust(): UseChangeTrustResult {
         setIsSuccess(true);
         refetchPlusdTrustline();
       } catch (err) {
-        setError(err instanceof Error ? err : new Error(String(err)));
+        setError(normalizeStellarActionError(err, address));
       } finally {
         setIsPending(false);
         setIsInFlight(false);

--- a/packages/frontend/src/wallet/stellar/useStellarStakedPlusd.test.tsx
+++ b/packages/frontend/src/wallet/stellar/useStellarStakedPlusd.test.tsx
@@ -361,6 +361,27 @@ describe("useStellarStake", () => {
     expect(result.current.error?.message).toMatch(/simulation error/);
   });
 
+  it("account-not-found stake errors explain that the Stellar account needs funding", async () => {
+    mockGetAccount.mockRejectedValue(
+      new Error(`Account not found: ${TEST_ADDRESS}`),
+    );
+    vi.spyOn(mockModule, "readMockStellarStake").mockReturnValue(undefined);
+
+    const { result } = renderHook(() => useStellarStake(), {
+      wrapper: makeWrapper(),
+    });
+
+    act(() => {
+      result.current.write(10_000_000n);
+    });
+
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(result.current.error?.message).toContain(
+      "Stellar account is not funded",
+    );
+    expect(mockBuildDeposit).not.toHaveBeenCalled();
+  });
+
   it("reset clears state", async () => {
     vi.spyOn(mockModule, "readMockStellarStake").mockReturnValue({
       hash: "h",

--- a/packages/frontend/src/wallet/stellar/useStellarStakedPlusd.ts
+++ b/packages/frontend/src/wallet/stellar/useStellarStakedPlusd.ts
@@ -84,6 +84,7 @@ import {
   readMockStellarStakedPlusdShareBalance,
   STELLAR_MOCK_KEYS,
 } from "./mock";
+import { normalizeStellarActionError } from "./errors";
 import { useMock, parseBigInt } from "../evm/mock";
 
 // ── Scale factor for rate-based convert mock arithmetic (SAC 1e7, NOT EVM 1e18) ──
@@ -316,7 +317,7 @@ export function useStellarStake(): StellarStakeResult {
           setData({ hash: sendResult.hash, shares: sharesStr });
           setIsSuccess(true);
         } catch (err) {
-          setError(err instanceof Error ? err : new Error(String(err)));
+          setError(normalizeStellarActionError(err, address));
         } finally {
           setIsPending(false);
           setIsInFlight(false);
@@ -465,7 +466,7 @@ export function useStellarUnstake(): StellarUnstakeResult {
           setData({ hash: sendResult.hash, assets: assetsStr });
           setIsSuccess(true);
         } catch (err) {
-          setError(err instanceof Error ? err : new Error(String(err)));
+          setError(normalizeStellarActionError(err, address));
         } finally {
           setIsPending(false);
           setIsInFlight(false);
@@ -925,7 +926,7 @@ export function useStellarChangeTrustStakedPlusd(): UseStellarChangeTrustStakedP
         setData({ hash: submitResult.hash });
         setIsSuccess(true);
       } catch (err) {
-        setError(err instanceof Error ? err : new Error(String(err)));
+        setError(normalizeStellarActionError(err, address));
       } finally {
         setIsPending(false);
         setIsInFlight(false);

--- a/packages/frontend/src/wallet/stellar/useStellarWithdrawalQueue.ts
+++ b/packages/frontend/src/wallet/stellar/useStellarWithdrawalQueue.ts
@@ -58,6 +58,7 @@ import {
   readMockStellarClaimWithdrawal,
   readMockStellarChangeTrust,
 } from "./mock";
+import { normalizeStellarActionError } from "./errors";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -323,7 +324,7 @@ export function useStellarRequestWithdrawal(): RequestWithdrawalResult {
             createdAt: Date.now(),
           });
         } catch (err) {
-          setError(err instanceof Error ? err : new Error(String(err)));
+          setError(normalizeStellarActionError(err, address));
         } finally {
           setIsPending(false);
           setIsInFlight(false);
@@ -469,7 +470,7 @@ export function useStellarClaimWithdrawal(): StellarClaimWithdrawalResult {
           setIsSuccess(true);
           clearInflightWithdrawal(address);
         } catch (err) {
-          setError(err instanceof Error ? err : new Error(String(err)));
+          setError(normalizeStellarActionError(err, address));
         } finally {
           setIsPending(false);
           setIsInFlight(false);
@@ -655,7 +656,7 @@ export function useStellarChangeTrustUsdc(): UseStellarChangeTrustUsdcResult {
         setIsSuccess(true);
         refetchUsdcTrustline();
       } catch (err) {
-        setError(err instanceof Error ? err : new Error(String(err)));
+        setError(normalizeStellarActionError(err, address));
       } finally {
         setIsPending(false);
         setIsInFlight(false);


### PR DESCRIPTION
## Summary
- normalize Stellar RPC/Horizon account-not-found errors into an explicit funding message
- apply the normalization to Stellar stake, unstake, deposit, withdraw, claim, and trustline write paths
- show the normalized Stellar error in deposit/stake transaction toasts

## Verification
- yarn workspace @pipeline/frontend test src/wallet/stellar/errors.test.ts src/wallet/stellar/useStellarStakedPlusd.test.tsx
- npx tsx scripts/lint-docs.ts (passes with existing warnings)
- yarn workspace @pipeline/frontend build
- yarn workspace @pipeline/frontend eslint src/routes/deposit.tsx src/routes/stake.tsx src/wallet/stellar/errors.ts src/wallet/stellar/errors.test.ts src/wallet/stellar/useStellarStakedPlusd.ts src/wallet/stellar/useStellarDepositManager.ts src/wallet/stellar/useStellarWithdrawalQueue.ts src/wallet/stellar/useStellarStakedPlusd.test.tsx
- yarn workspace @pipeline/frontend prettier --check src/routes/deposit.tsx src/routes/stake.tsx src/wallet/stellar/errors.ts src/wallet/stellar/errors.test.ts src/wallet/stellar/useStellarStakedPlusd.ts src/wallet/stellar/useStellarDepositManager.ts src/wallet/stellar/useStellarWithdrawalQueue.ts src/wallet/stellar/useStellarStakedPlusd.test.tsx

Note: full frontend lint is still blocked by pre-existing unrelated warnings/formatting outside this patch.