### PR TITLE
Show PnL summary on home page

### DIFF
--- a/packages/frontend/src/api/README.md
+++ b/packages/frontend/src/api/README.md
@@ -145,6 +145,21 @@ formatApy(null); // → "—"
 formatApy(undefined); // → "—"
 ```
 
+### `usePnl()`
+
+React Query hook that fetches staking PnL for the connected wallet from
+`GET /v1/pnl`.
+
+```ts
+const { data, isLoading, error } = usePnl();
+// data?.avg_apy — APY as a decimal fraction string, or null
+// data?.total_unrealized_pnl — raw asset-unit decimal string
+```
+
+The hook follows `useWalletView().kind`, uses the active wallet address, and
+passes the matching `chain_id` (`ENV.EVM_CHAIN_ID` or `ENV.STELLAR_CHAIN_ID`).
+It is disabled until the active wallet is connected.
+
 ---
 
 ## localStorage mock key schema
@@ -163,6 +178,13 @@ this event and issues a refetch — no page reload needed.
 | Key                               | Type                     | Purpose                                           |
 | --------------------------------- | ------------------------ | ------------------------------------------------- |
 | `pipeline.mock.api.GET./v1/stats` | JSON `{ vaults: [...] }` | Bypasses the real fetch — `useStats` returns this |
+
+### `usePnl` mock keys
+
+| Key                                                 | Type               | Purpose                                        |
+| --------------------------------------------------- | ------------------ | ---------------------------------------------- |
+| `pipeline.mock.api.GET./v1/pnl`                     | JSON `PnlResponse` | Bypasses the real fetch for any wallet         |
+| `pipeline.mock.api.GET./v1/pnl?wallet=…&chain_id=…` | JSON `PnlResponse` | Per-wallet/per-chain override when exact match |
 
 ### `useRequests` mock keys
 

--- a/packages/frontend/src/api/index.ts
+++ b/packages/frontend/src/api/index.ts
@@ -31,6 +31,8 @@ export type {
 } from "./useWithdrawalVoucher";
 export { useStats, formatApy } from "./useStats";
 export type { VaultStatsItem, StatsResponse, UseStatsResult } from "./useStats";
+export { usePnl } from "./usePnl";
+export type { PnlResponse, UsePnlResult, VaultPnl } from "./usePnl";
 export { useStellarDepositVoucher } from "./useStellarDepositVoucher";
 export type {
   UseStellarDepositVoucherResult,

--- a/packages/frontend/src/api/index.ts
+++ b/packages/frontend/src/api/index.ts
@@ -31,6 +31,14 @@ export type {
 } from "./useWithdrawalVoucher";
 export { useStats, formatApy } from "./useStats";
 export type { VaultStatsItem, StatsResponse, UseStatsResult } from "./useStats";
+export { useStatsPrices } from "./useStatsPrices";
+export type {
+  StatsPriceItem,
+  StatsPricesInterval,
+  StatsPricesResponse,
+  UseStatsPricesParams,
+  UseStatsPricesResult,
+} from "./useStatsPrices";
 export { usePnl } from "./usePnl";
 export type { PnlResponse, UsePnlResult, VaultPnl } from "./usePnl";
 export { useStellarDepositVoucher } from "./useStellarDepositVoucher";

--- a/packages/frontend/src/api/usePnl.test.tsx
+++ b/packages/frontend/src/api/usePnl.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import React from "react";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { usePnl, type PnlResponse } from "./usePnl";
+
+const mockWalletView = vi.hoisted(() => ({ kind: "evm" as "evm" | "stellar" }));
+const mockEvmWallet = vi.hoisted(() => ({
+  address: "0x1234000000000000000000000000000000000001",
+  isConnected: true,
+}));
+const mockStellarWallet = vi.hoisted(() => ({
+  address: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+  isConnected: true,
+}));
+
+vi.mock("@/wallet", () => ({
+  useWalletView: () => ({ kind: mockWalletView.kind }),
+  useEvmWallet: () => mockEvmWallet,
+  useStellarWallet: () => mockStellarWallet,
+  subscribeMock: () => () => {},
+  readMock: () => undefined,
+  parseJson: (value: string) => JSON.parse(value),
+}));
+
+vi.mock("@/lib/env", () => ({
+  ENV: {
+    API_BASE_URL: "http://localhost:8080",
+    EVM_CHAIN_ID: 560048,
+    STELLAR_CHAIN_ID: 99000001,
+  },
+}));
+
+const RESPONSE: PnlResponse = {
+  wallet: mockEvmWallet.address,
+  positions: [],
+  total_unrealized_pnl: "42800000000000000000",
+  total_realized_pnl: "0",
+  total_pnl: "42800000000000000000",
+  avg_apy: "0.0842",
+};
+
+const fetchMock = vi.fn<typeof fetch>();
+vi.stubGlobal("fetch", fetchMock);
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe("usePnl", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    fetchMock.mockClear();
+    mockWalletView.kind = "evm";
+    mockEvmWallet.isConnected = true;
+    mockStellarWallet.isConnected = true;
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  it("fetches EVM PnL with wallet and EVM chain id", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(RESPONSE), { status: 200 }),
+    );
+
+    const { result } = renderHook(() => usePnl(), { wrapper: makeWrapper() });
+
+    await waitFor(() => expect(result.current.data).toEqual(RESPONSE));
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `/v1/pnl?wallet=${mockEvmWallet.address}&chain_id=560048`,
+      ),
+      undefined,
+    );
+  });
+
+  it("fetches Stellar PnL with wallet and Stellar chain id", async () => {
+    mockWalletView.kind = "stellar";
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(RESPONSE), { status: 200 }),
+    );
+
+    const { result } = renderHook(() => usePnl(), { wrapper: makeWrapper() });
+
+    await waitFor(() => expect(result.current.data).toEqual(RESPONSE));
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `/v1/pnl?wallet=${mockStellarWallet.address}&chain_id=99000001`,
+      ),
+      undefined,
+    );
+  });
+
+  it("stays disabled when the active wallet is disconnected", async () => {
+    mockEvmWallet.isConnected = false;
+
+    const { result } = renderHook(() => usePnl(), { wrapper: makeWrapper() });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/frontend/src/api/usePnl.ts
+++ b/packages/frontend/src/api/usePnl.ts
@@ -1,0 +1,97 @@
+/**
+ * React Query hook — fetches staking PnL for the connected wallet from
+ * `GET /v1/pnl`.
+ *
+ * The hook follows the active wallet view:
+ *   - EVM view     -> `wallet=<0x...>&chain_id=<ENV.EVM_CHAIN_ID>`
+ *   - Stellar view -> `wallet=<G...>&chain_id=<ENV.STELLAR_CHAIN_ID>`
+ *
+ * It is disabled until the active wallet is connected. Mock lookup is handled
+ * by `apiFetch`, so `pipeline.mock.api.GET./v1/pnl` can bypass the network.
+ */
+import { useQuery } from "@tanstack/react-query";
+import { useSyncExternalStore } from "react";
+import { ENV } from "@/lib/env";
+import {
+  subscribeMock,
+  useEvmWallet,
+  useStellarWallet,
+  useWalletView,
+} from "@/wallet";
+import { apiFetch } from "./client";
+
+export interface VaultPnl {
+  vault_address: string;
+  shares_balance: string;
+  avg_cost_basis: string;
+  current_share_price: string;
+  unrealized_pnl: string;
+  realized_pnl: string;
+  total_pnl: string;
+}
+
+export interface PnlResponse {
+  wallet: string;
+  positions: VaultPnl[];
+  total_unrealized_pnl: string;
+  total_realized_pnl: string;
+  total_pnl: string;
+  avg_apy?: string | null;
+}
+
+export interface UsePnlResult {
+  data: PnlResponse | undefined;
+  isLoading: boolean;
+  error: Error | null;
+  refetch: () => void;
+}
+
+let mockVersion = 0;
+
+function getMockVersion() {
+  return mockVersion;
+}
+
+function subscribeMockVersion(listener: () => void) {
+  return subscribeMock("pipeline.mock.api", () => {
+    mockVersion += 1;
+    listener();
+  });
+}
+
+export function usePnl(): UsePnlResult {
+  const { kind } = useWalletView();
+  const { address: evmAddress, isConnected: isEvmConnected } = useEvmWallet();
+  const { address: stellarAddress, isConnected: isStellarConnected } =
+    useStellarWallet();
+
+  const isStellar = kind === "stellar";
+  const address = isStellar ? stellarAddress : evmAddress;
+  const isConnected = isStellar ? isStellarConnected : isEvmConnected;
+  const chainId = isStellar ? ENV.STELLAR_CHAIN_ID : ENV.EVM_CHAIN_ID;
+
+  const mockVer = useSyncExternalStore(
+    subscribeMockVersion,
+    getMockVersion,
+    getMockVersion,
+  );
+
+  const query = useQuery<PnlResponse, Error>({
+    queryKey: ["pnl", kind, address, chainId, mockVer],
+    queryFn: () => {
+      const params = new URLSearchParams({
+        wallet: address ?? "",
+        chain_id: String(chainId),
+      });
+      return apiFetch<PnlResponse>(`/v1/pnl?${params.toString()}`);
+    },
+    enabled: isConnected && !!address,
+  });
+
+  return {
+    data: query.data,
+    isLoading: query.isLoading,
+    error: query.error,
+    refetch: () => void query.refetch(),
+  };
+}

--- a/packages/frontend/src/api/useStatsPrices.ts
+++ b/packages/frontend/src/api/useStatsPrices.ts
@@ -1,0 +1,87 @@
+/**
+ * React Query hook — fetches averaged sPLUSD share-price history from
+ * `GET /v1/stats/prices`.
+ */
+import { useQuery } from "@tanstack/react-query";
+import { apiFetch } from "./client";
+
+export type StatsPricesInterval = "hourly" | "daily" | "weekly";
+
+export interface StatsPriceItem {
+  /** ISO-8601 timestamp for the start of the bucket. */
+  timestamp: string;
+  /** Average share price for the period. */
+  avg_price: string;
+}
+
+export interface StatsPricesResponse {
+  vault_address: string;
+  interval: StatsPricesInterval;
+  prices: StatsPriceItem[];
+}
+
+export interface UseStatsPricesParams {
+  vaultAddress: string;
+  chainId: number;
+  periodId: string;
+  enabled?: boolean;
+}
+
+export interface UseStatsPricesResult {
+  data: StatsPricesResponse | undefined;
+  isLoading: boolean;
+  error: Error | null;
+  refetch: () => void;
+}
+
+function periodToQuery(periodId: string): {
+  days?: number;
+  interval: StatsPricesInterval;
+} {
+  switch (periodId) {
+    case "7d":
+      return { days: 7, interval: "hourly" };
+    case "1m":
+      return { days: 30, interval: "daily" };
+    case "3m":
+      return { days: 90, interval: "daily" };
+    case "1y":
+      return { days: 365, interval: "daily" };
+    case "all":
+    default:
+      return { interval: "weekly" };
+  }
+}
+
+export function useStatsPrices({
+  vaultAddress,
+  chainId,
+  periodId,
+  enabled = true,
+}: UseStatsPricesParams): UseStatsPricesResult {
+  const query = useQuery<StatsPricesResponse, Error>({
+    queryKey: ["stats-prices", vaultAddress, chainId, periodId],
+    queryFn: () => {
+      const period = periodToQuery(periodId);
+      const params = new URLSearchParams({
+        vault: vaultAddress,
+        chain_id: String(chainId),
+        interval: period.interval,
+      });
+      if (period.days !== undefined) {
+        params.set("days", String(period.days));
+      }
+      return apiFetch<StatsPricesResponse>(
+        `/v1/stats/prices?${params.toString()}`,
+      );
+    },
+    enabled: enabled && vaultAddress.length > 0,
+  });
+
+  return {
+    data: query.data,
+    isLoading: query.isLoading,
+    error: query.error,
+    refetch: () => void query.refetch(),
+  };
+}

--- a/packages/frontend/src/components/EarnedCard.tsx
+++ b/packages/frontend/src/components/EarnedCard.tsx
@@ -12,7 +12,7 @@ import type { CardPadding } from "@pipeline/ui";
  *
  *   ┌─────────────────────────┐
  *   │  Earned                 │
- *   │  Coming soon            │
+ *   │  Tracked once you stake │
  *   └─────────────────────────┘
  *
  * Composition:
@@ -23,7 +23,7 @@ import type { CardPadding } from "@pipeline/ui";
  * Typography:
  *   - Label "Earned" — Body token (16 / 22) in Graphik LC, primary ink
  *     (`--color-pipeline-ink`). Mirrors Figma node `1497:94693`.
- *   - Value placeholder "Coming soon" — Besley display at 20 / 28 ("Heading
+ *   - Value placeholder "Tracked once you stake" — Besley display at 20 / 28 ("Heading
  *     20" in the Figma type styles, see node `1497:94698`). It uses the
  *     `--color-pipeline-ink-subtle` (content-test/tertiary, 30% alpha) token
  *     to read as muted/disabled, signalling the surface is reserved.
@@ -37,7 +37,7 @@ import type { CardPadding } from "@pipeline/ui";
  *   - The Card renders a `<div>`; we promote it to a region with
  *     `role="region"` + `aria-labelledby` referencing the "Earned" label so
  *     assistive tech announces "Earned, region".
- *   - The "Coming soon" value carries `aria-live="off"` semantics implicitly
+ *   - The placeholder value carries `aria-live="off"` semantics implicitly
  *     (it never changes). It is announced as part of the region's contents.
  *
  * Reuse: this composite belongs to the Disconnected home view alongside
@@ -57,13 +57,17 @@ export interface EarnedCardProps extends Omit<
 > {
   /**
    * Mobile-only: connected balance state.
-   * When `"splusd"` (State C), renders "—" as a placeholder earned value
-   * (no real earned-balance API exists yet — #389 tracks the live data).
+   * When `"splusd"` (State C), renders the tracking placeholder until PnL APY
+   * exists.
    * When `"empty"` or `"plusd"` (States A/B), renders "Nothing yet".
-   * When `undefined`, renders the previous "Coming soon" text (desktop
-   * and disconnected — no change to existing behaviour).
+   * When `undefined`, renders "Tracked once you stake".
    */
   mobileHomeState?: MobileHomeState;
+  /**
+   * Formatted PnL APY label, e.g. `"8.42% p.a."`. When present, this replaces
+   * the placeholder value.
+   */
+  avgApyLabel?: string;
   /**
    * Interior padding forwarded to the `Card` primitive. Defaults to `"lg"`
    * (24px). Set to `"sm"` (8px) on mobile per Figma frame `1989:8292`.
@@ -88,7 +92,7 @@ const labelClasses = [
 // Value row — Besley display, tertiary ink to read as muted/disabled.
 // Mobile (base): heading-s-mobile = 18px / 28px (Figma node 1989:9030).
 // Desktop (md+): heading-s = 20px / 28px.
-// Mirrors Figma node `1497:94698` "Coming soon".
+// Mirrors Figma node `1497:94698` placeholder value.
 const valueClasses = [
   "font-[family-name:var(--font-display)]",
   "text-[length:var(--text-pipeline-heading-s-mobile)]",
@@ -101,7 +105,10 @@ const valueClasses = [
 ].join(" ");
 
 export const EarnedCard = React.forwardRef<HTMLDivElement, EarnedCardProps>(
-  function EarnedCard({ className, mobileHomeState, ...rest }, ref) {
+  function EarnedCard(
+    { className, mobileHomeState, avgApyLabel, ...rest },
+    ref,
+  ) {
     // Use a unique id per instance to avoid duplicate id attributes when both
     // the mobile and desktop blocks render this card in the same DOM.
     const instanceId = React.useId();
@@ -116,31 +123,29 @@ export const EarnedCard = React.forwardRef<HTMLDivElement, EarnedCardProps>(
       .join(" ");
 
     // Determine the display value based on state.
-    // State C (splusd): placeholder "—" (no real earned API yet, #389).
+    // PnL APY, when available, wins over placeholders.
     // States A/B (empty/plusd) when connected: "Nothing yet".
-    // Disconnected / desktop (undefined): original "Coming soon".
+    // Disconnected / desktop / State C without APY: tracking placeholder.
     let earnedValue: string;
     let valueExtra: string | undefined;
 
-    if (mobileHomeState === "splusd") {
-      // State C: earned placeholder — no real source yet.
-      earnedValue = "—";
+    if (avgApyLabel !== undefined) {
+      earnedValue = avgApyLabel;
       valueExtra = undefined;
     } else if (mobileHomeState === "empty" || mobileHomeState === "plusd") {
       // States A/B: "Nothing yet" per Figma frames 1988:7074 / 1984:6501.
       earnedValue = "Nothing yet";
       valueExtra = undefined;
     } else {
-      // Desktop / disconnected: original "Coming soon".
-      earnedValue = "Coming soon";
+      earnedValue = "Tracked once you stake";
       valueExtra = undefined;
     }
 
-    // State C value classes: use green positive token for the earned value.
+    // PnL APY value classes: use green positive token for the earned value.
     // Mobile (base): heading-s-mobile = 18px / 28px (Figma node 1886:46777).
     // Desktop (md+): heading-s = 20px / 28px.
     const stateValueClasses =
-      mobileHomeState === "splusd"
+      avgApyLabel !== undefined
         ? [
             "font-[family-name:var(--font-display)]",
             "text-[length:var(--text-pipeline-heading-s-mobile)]",

--- a/packages/frontend/src/components/PortfolioPlaceholderCard.test.tsx
+++ b/packages/frontend/src/components/PortfolioPlaceholderCard.test.tsx
@@ -70,24 +70,20 @@ describe("PortfolioPlaceholderCard — smoke tests", () => {
     expect(caption).toHaveTextContent("$0.00 unrealized");
   });
 
-  it("shows the sPLUSD balance caption by default", () => {
-    renderCard();
-    expect(screen.getByTestId("splusd-balance-caption")).toHaveTextContent(
-      "0.00 sPLUSD",
-    );
-  });
-
-  it("renders provided sPLUSD and unrealized PnL labels", () => {
+  it("renders provided sPLUSD balance as the main heading and no duplicate sublabel", () => {
     render(
       <PortfolioPlaceholderCard
-        splusdBalanceLabel="1,000.00 sPLUSD"
+        balanceLabel="1,000.00 sPLUSD"
         unrealizedPnlLabel="+$42.80 unrealized"
       />,
     );
 
-    expect(screen.getByTestId("splusd-balance-caption")).toHaveTextContent(
-      "1,000.00 sPLUSD",
-    );
+    expect(
+      screen.getByRole("heading", { name: "1,000.00 sPLUSD" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("splusd-balance-caption"),
+    ).not.toBeInTheDocument();
     expect(screen.getByTestId("earning-caption")).toHaveTextContent(
       "+$42.80 unrealized",
     );
@@ -174,7 +170,6 @@ describe("PortfolioPlaceholderCard — chart structure", () => {
     const label = chart.getAttribute("aria-label") ?? "";
     expect(label).toContain("Total balance");
     expect(label).toContain("$0.00");
-    expect(label).toContain("0.00 sPLUSD");
     expect(label).toContain("$0.00 unrealized");
   });
 

--- a/packages/frontend/src/components/PortfolioPlaceholderCard.test.tsx
+++ b/packages/frontend/src/components/PortfolioPlaceholderCard.test.tsx
@@ -8,7 +8,7 @@
  *   4. "Get PLUSD to start" link is present and points to /deposit.
  *   5. "7D" tab is the default active tab (aria-selected="true").
  *   6. Other tabs start inactive (aria-selected="false").
- *   7. Switching tabs updates active state and the earning caption.
+ *   7. Switching tabs updates active state while PnL captions stay data-driven.
  *   8. Chart wrapper has role="img" and a descriptive aria-label.
  *   9. Chart renders 100 bar slots (100 <g data-bar-slot> elements).
  *  10. Hover shows tooltip; mouse leave hides it.
@@ -64,10 +64,33 @@ describe("PortfolioPlaceholderCard — smoke tests", () => {
     expect(link).toHaveAttribute("href", "/deposit");
   });
 
-  it("shows '+$42.80 earning' caption by default (7D period)", () => {
+  it("shows '$0.00 unrealized' caption by default", () => {
     renderCard();
     const caption = screen.getByTestId("earning-caption");
-    expect(caption).toHaveTextContent("+$42.80 earning");
+    expect(caption).toHaveTextContent("$0.00 unrealized");
+  });
+
+  it("shows the sPLUSD balance caption by default", () => {
+    renderCard();
+    expect(screen.getByTestId("splusd-balance-caption")).toHaveTextContent(
+      "0.00 sPLUSD",
+    );
+  });
+
+  it("renders provided sPLUSD and unrealized PnL labels", () => {
+    render(
+      <PortfolioPlaceholderCard
+        splusdBalanceLabel="1,000.00 sPLUSD"
+        unrealizedPnlLabel="+$42.80 unrealized"
+      />,
+    );
+
+    expect(screen.getByTestId("splusd-balance-caption")).toHaveTextContent(
+      "1,000.00 sPLUSD",
+    );
+    expect(screen.getByTestId("earning-caption")).toHaveTextContent(
+      "+$42.80 unrealized",
+    );
   });
 });
 
@@ -105,7 +128,7 @@ describe("PortfolioPlaceholderCard — SegmentedTabs semantics", () => {
     });
   });
 
-  it("clicking '1M' updates the earning caption to '+$92.80 earning'", async () => {
+  it("clicking '1M' leaves the unrealized PnL caption unchanged", async () => {
     const user = userEvent.setup();
     renderCard();
 
@@ -113,12 +136,12 @@ describe("PortfolioPlaceholderCard — SegmentedTabs semantics", () => {
 
     await waitFor(() => {
       expect(screen.getByTestId("earning-caption")).toHaveTextContent(
-        "+$92.80 earning",
+        "$0.00 unrealized",
       );
     });
   });
 
-  it("clicking 'All' updates the earning caption to '+$842.80 earning'", async () => {
+  it("clicking 'All' leaves the unrealized PnL caption unchanged", async () => {
     const user = userEvent.setup();
     renderCard();
 
@@ -126,7 +149,7 @@ describe("PortfolioPlaceholderCard — SegmentedTabs semantics", () => {
 
     await waitFor(() => {
       expect(screen.getByTestId("earning-caption")).toHaveTextContent(
-        "+$842.80 earning",
+        "$0.00 unrealized",
       );
     });
   });
@@ -151,7 +174,8 @@ describe("PortfolioPlaceholderCard — chart structure", () => {
     const label = chart.getAttribute("aria-label") ?? "";
     expect(label).toContain("Total balance");
     expect(label).toContain("$0.00");
-    expect(label).toContain("earning");
+    expect(label).toContain("0.00 sPLUSD");
+    expect(label).toContain("$0.00 unrealized");
   });
 
   it("chart renders 100 bar slots (100 <g data-bar-slot> elements)", () => {

--- a/packages/frontend/src/components/PortfolioPlaceholderCard.test.tsx
+++ b/packages/frontend/src/components/PortfolioPlaceholderCard.test.tsx
@@ -6,7 +6,7 @@
  *   2. "Total Balance" eyebrow is present.
  *   3. "$0.00" balance heading is present.
  *   4. "Get PLUSD to start" link is present and points to /deposit.
- *   5. "7D" tab is the default active tab (aria-selected="true").
+ *   5. "All" tab is the default active tab (aria-selected="true").
  *   6. Other tabs start inactive (aria-selected="false").
  *   7. Switching tabs updates active state while PnL captions stay data-driven.
  *   8. Chart wrapper has role="img" and a descriptive aria-label.
@@ -91,15 +91,15 @@ describe("PortfolioPlaceholderCard — smoke tests", () => {
 });
 
 describe("PortfolioPlaceholderCard — SegmentedTabs semantics", () => {
-  it("default active tab is '7D' (aria-selected='true')", () => {
+  it("default active tab is 'All' (aria-selected='true')", () => {
     renderCard();
-    const tab7d = screen.getByRole("tab", { name: "7D" });
-    expect(tab7d).toHaveAttribute("aria-selected", "true");
+    const tabAll = screen.getByRole("tab", { name: "All" });
+    expect(tabAll).toHaveAttribute("aria-selected", "true");
   });
 
   it("other tabs default to inactive (aria-selected='false')", () => {
     renderCard();
-    const inactiveTabs = ["1M", "3M", "1Y", "All"];
+    const inactiveTabs = ["7D", "1M", "3M", "1Y"];
     for (const label of inactiveTabs) {
       expect(screen.getByRole("tab", { name: label })).toHaveAttribute(
         "aria-selected",
@@ -108,7 +108,7 @@ describe("PortfolioPlaceholderCard — SegmentedTabs semantics", () => {
     }
   });
 
-  it("clicking '1M' makes it active and deactivates '7D'", async () => {
+  it("clicking '1M' makes it active and deactivates 'All'", async () => {
     const user = userEvent.setup();
     renderCard();
 
@@ -117,7 +117,7 @@ describe("PortfolioPlaceholderCard — SegmentedTabs semantics", () => {
 
     await waitFor(() => {
       expect(tab1m).toHaveAttribute("aria-selected", "true");
-      expect(screen.getByRole("tab", { name: "7D" })).toHaveAttribute(
+      expect(screen.getByRole("tab", { name: "All" })).toHaveAttribute(
         "aria-selected",
         "false",
       );
@@ -177,6 +177,28 @@ describe("PortfolioPlaceholderCard — chart structure", () => {
     const { container } = renderCard();
     const barSlots = container.querySelectorAll("[data-bar-slot]");
     expect(barSlots).toHaveLength(100);
+  });
+
+  it("uses grey fallback bars when no price data is provided", () => {
+    const { container } = renderCard();
+    const firstBar = container.querySelector("[data-bar-slot] rect");
+    expect(firstBar).toHaveAttribute("fill", "#D5D8C8");
+  });
+
+  it("uses chart-positive bars when price data is provided", () => {
+    const { container } = render(
+      <PortfolioPlaceholderCard
+        priceItems={[
+          { timestamp: "2026-01-01T00:00:00Z", avg_price: "1.00" },
+          { timestamp: "2026-01-02T00:00:00Z", avg_price: "1.02" },
+        ]}
+      />,
+    );
+    const firstBar = container.querySelector("[data-bar-slot] rect");
+    expect(firstBar).toHaveAttribute(
+      "fill",
+      "var(--color-pipeline-chart-positive)",
+    );
   });
 
   it("card region is labelled by the '$0.00' heading", () => {

--- a/packages/frontend/src/components/PortfolioPlaceholderCard.tsx
+++ b/packages/frontend/src/components/PortfolioPlaceholderCard.tsx
@@ -19,7 +19,6 @@ import {
  * Layout:
  *   ┌────────────────────────────────────────────────────────────────────┐
  *   │  Total Balance                    [ 7D | 1M | 3M | 1Y | All ]     │
- *   │  $0.00                                                             │
  *   │  0.00 sPLUSD                                                       │
  *   │  $0.00 unrealized                                                  │
  *   │  Get PLUSD to start →                                              │
@@ -69,22 +68,18 @@ export interface PortfolioPlaceholderCardProps extends Omit<
 > {
   /**
    * Mobile-only: the connected balance state (empty / plusd / splusd).
-   * When provided, overrides the static `$0.00` heading and CTA link:
-   *   - "empty"  → `$0.00` + "Get PLUSD to start" → /deposit (State A)
-   *   - "plusd"  → totalBalance + "Stake PLUSD to start earning" → /stake (B)
-   *   - "splusd" → totalBalance (no link, PnL caption) (C)
-   * When `undefined` the desktop behaviour ($0.00 + "Get PLUSD to start") is
-   * preserved byte-for-byte.
+   * When provided, controls CTA copy and link state:
+   *   - "empty"  → "Get PLUSD to start" → /deposit (State A)
+   *   - "plusd"  → "Stake PLUSD to start earning" → /stake (B)
+   *   - "splusd" → no link, PnL caption (C)
    */
   mobileHomeState?: MobileHomeState;
   /**
-   * Mobile-only: formatted total balance string to display in States B and C
-   * (e.g. `"$1,042.80"`). Ignored when `mobileHomeState` is `undefined`.
-   * Defaults to `"$0.00"` when not provided.
+   * Formatted balance string shown under "Total Balance". Connected home passes
+   * the active sPLUSD share amount here; the card no longer displays real total
+   * portfolio value.
    */
-  mobileTotalBalance?: string;
-  /** Formatted sPLUSD share balance displayed below Total Balance. */
-  splusdBalanceLabel?: string;
+  balanceLabel?: string;
   /** Formatted unrealized PnL displayed below the sPLUSD balance. */
   unrealizedPnlLabel?: string;
 }
@@ -123,8 +118,7 @@ export const PortfolioPlaceholderCard = React.forwardRef<
   {
     className,
     mobileHomeState,
-    mobileTotalBalance = "$0.00",
-    splusdBalanceLabel = "0.00 sPLUSD",
+    balanceLabel = "$0.00",
     unrealizedPnlLabel = "$0.00 unrealized",
     ...rest
   },
@@ -214,9 +208,7 @@ export const PortfolioPlaceholderCard = React.forwardRef<
             Total Balance
           </span>
 
-          {/* Balance display — Heading M token, display serif.
-              Mobile connected states show the derived total balance;
-              desktop (and disconnected) always shows the static $0.00. */}
+          {/* Balance display — Heading M token, display serif. */}
           <h2
             id={HEADING_ID}
             className={[
@@ -228,23 +220,8 @@ export const PortfolioPlaceholderCard = React.forwardRef<
               "m-0",
             ].join(" ")}
           >
-            {mobileHomeState !== undefined && mobileHomeState !== "empty"
-              ? mobileTotalBalance
-              : "$0.00"}
+            {balanceLabel}
           </h2>
-
-          <span
-            data-testid="splusd-balance-caption"
-            className={[
-              "font-[family-name:var(--font-body)]",
-              "text-[length:var(--text-pipeline-caption)]",
-              "leading-[var(--text-pipeline-caption--line-height)]",
-              "font-[var(--font-weight-regular)]",
-              "text-[color:var(--color-pipeline-ink-muted)]",
-            ].join(" ")}
-          >
-            {splusdBalanceLabel}
-          </span>
 
           {/* Unrealized PnL caption from `/v1/pnl`. */}
           <span
@@ -306,7 +283,7 @@ export const PortfolioPlaceholderCard = React.forwardRef<
         ref={wrapRef}
         className="relative flex-1"
         role="img"
-        aria-label={`Total balance for ${periodLabel}: ${mobileHomeState !== undefined && mobileHomeState !== "empty" ? mobileTotalBalance : "$0.00"} (${splusdBalanceLabel}, ${unrealizedPnlLabel})`}
+        aria-label={`Total balance for ${periodLabel}: ${balanceLabel} (${unrealizedPnlLabel})`}
         data-node-id="1497:95048-chart"
         onPointerMove={handlePointerMove}
         onPointerLeave={onPointerLeave}

--- a/packages/frontend/src/components/PortfolioPlaceholderCard.tsx
+++ b/packages/frontend/src/components/PortfolioPlaceholderCard.tsx
@@ -3,23 +3,25 @@ import { Link } from "@tanstack/react-router";
 import { Card, SegmentedTabs } from "@pipeline/ui";
 import {
   N,
+  DEFAULT_PERIOD_ID,
   formatMoney,
   formatTime,
   usePortfolioChart,
 } from "./usePortfolioChart";
+import type { StatsPriceItem } from "@/api";
 
 /**
  * PortfolioPlaceholderCard — Connected-state replacement for ConnectWalletPromoCard.
  *
  * Renders in the top-left slot of the home dashboard when `isConnected === true`
- * (Figma node `1497:95048`). This is a **placeholder** — the balance stays `$0.00`
- * and the chart data is procedurally generated (no API calls). Replace the
- * synthetic generator with a real aggregation endpoint when one ships.
+ * (Figma node `1497:95048`). The balance and PnL labels are supplied by the
+ * home route. Chart bars use `/v1/stats/prices` data when available and fall
+ * back to the synthetic placeholder curve when the endpoint has no data.
  *
  * Layout:
  *   ┌────────────────────────────────────────────────────────────────────┐
  *   │  Total Balance                    [ 7D | 1M | 3M | 1Y | All ]     │
- *   │  0.00 sPLUSD                                                       │
+ *   │  $0.00                                                             │
  *   │  $0.00 unrealized                                                  │
  *   │  Get PLUSD to start →                                              │
  *   ├────────────────────────────────────────────────────────────────────┤
@@ -32,10 +34,10 @@ import {
  *   - 100 bar slots. Each slot has 3 nested rectangles (widths 3/2/1 px wide
  *     in SVG-coordinate terms, centred on the slot) at heights 30%/60%/100% of
  *     the slot's balance height, giving a "soft glow" stacked appearance.
- *   - Bar fill: `--color-pipeline-chart-positive` (`#2D7B1F`) — the prototype
- *     colour, introduced as a dedicated chart token.
- *   - Curve is deterministic per period (seeded LCG). Heights are monotonically
- *     non-decreasing. Curve is anchored to `Date.now()` at mount time.
+ *   - Bar fill: `--color-pipeline-chart-positive` (`#2D7B1F`) for real price
+ *     data, `#D5D8C8` for the synthetic fallback.
+ *   - Fallback curve is deterministic per period (seeded LCG). Heights are
+ *     monotonically non-decreasing and anchored to `Date.now()` at mount time.
  *
  * Hover interaction:
  *   - Pointer move over the chart wrapper snaps to the nearest slot index.
@@ -51,10 +53,10 @@ import {
  *   - Individual bar `<rect>` elements are decorative — no aria attributes.
  *   - The card `<region>` is labelled by the `$0.00` heading.
  *
- * Placeholder rule:
- *   - `$0.00` is a string literal — replace when the aggregation endpoint is ready.
+ * Data rule:
+ *   - Chart `priceItems` come from `/v1/stats/prices`.
+ *   - Empty/invalid price data keeps the fallback curve visible.
  *   - Unrealized PnL caption is supplied by `/v1/pnl`; defaults to `$0.00 unrealized`.
- *   - "Get PLUSD to start" link is always shown — revisit when user holds PLUSD.
  *
  * Figma reference: https://www.figma.com/design/A43rjYYjSwdTmiwwf5cx5n/Pipeline?node-id=1497-95048
  */
@@ -76,12 +78,17 @@ export interface PortfolioPlaceholderCardProps extends Omit<
   mobileHomeState?: MobileHomeState;
   /**
    * Formatted balance string shown under "Total Balance". Connected home passes
-   * the active sPLUSD share amount here; the card no longer displays real total
-   * portfolio value.
+   * the active total balance here.
    */
   balanceLabel?: string;
   /** Formatted unrealized PnL displayed below the sPLUSD balance. */
   unrealizedPnlLabel?: string;
+  /** Active chart period id. Defaults to "all". */
+  activePeriodId?: string;
+  /** Period change callback for tab selection. */
+  onActivePeriodChange?: (id: string) => void;
+  /** Price samples from `/v1/stats/prices`; empty/invalid data uses fallback. */
+  priceItems?: StatsPriceItem[];
 }
 
 /** Base heading id prefix — each instance gets a unique suffix from useId(). */
@@ -120,6 +127,9 @@ export const PortfolioPlaceholderCard = React.forwardRef<
     mobileHomeState,
     balanceLabel = "$0.00",
     unrealizedPnlLabel = "$0.00 unrealized",
+    activePeriodId,
+    onActivePeriodChange,
+    priceItems,
     ...rest
   },
   ref,
@@ -129,16 +139,25 @@ export const PortfolioPlaceholderCard = React.forwardRef<
   const instanceId = React.useId();
   const HEADING_ID = `${HEADING_ID_BASE}-${instanceId}`;
 
-  const {
+  const [uncontrolledActiveId, setUncontrolledActiveId] =
+    React.useState(DEFAULT_PERIOD_ID);
+  const activeId = activePeriodId ?? uncontrolledActiveId;
+  const setActiveId = onActivePeriodChange ?? setUncontrolledActiveId;
+
+  const chart = usePortfolioChart({
     activeId,
     setActiveId,
+    prices: priceItems,
+  });
+  const {
     period,
     curve,
     hoveredIdx,
     tooltip,
     onPointerMove,
     onPointerLeave,
-  } = usePortfolioChart();
+    hasPriceData,
+  } = chart;
 
   /** Ref to the chart wrapper div for getBoundingClientRect on pointer move. */
   const wrapRef = React.useRef<HTMLDivElement>(null);
@@ -168,6 +187,9 @@ export const PortfolioPlaceholderCard = React.forwardRef<
       : "0";
 
   const periodLabel = TABS.find((t) => t.id === activeId)?.label ?? "7D";
+  const barFill = hasPriceData
+    ? "var(--color-pipeline-chart-positive)"
+    : "#D5D8C8";
 
   const composed = [
     "relative flex flex-col gap-6",
@@ -307,7 +329,7 @@ export const PortfolioPlaceholderCard = React.forwardRef<
                   y={y0}
                   width={3}
                   height={barH}
-                  fill="var(--color-pipeline-chart-positive)"
+                  fill={barFill}
                   opacity={0.35}
                 />
                 {/* Mid rect (60% height) */}
@@ -316,7 +338,7 @@ export const PortfolioPlaceholderCard = React.forwardRef<
                   y={y0 + barH * 0.4}
                   width={2}
                   height={barH * 0.6}
-                  fill="var(--color-pipeline-chart-positive)"
+                  fill={barFill}
                   opacity={0.65}
                 />
                 {/* Core rect (30% height, full opacity) */}
@@ -325,7 +347,7 @@ export const PortfolioPlaceholderCard = React.forwardRef<
                   y={y0 + barH * 0.7}
                   width={1}
                   height={barH * 0.3}
-                  fill="var(--color-pipeline-chart-positive)"
+                  fill={barFill}
                   opacity={1}
                 />
               </g>

--- a/packages/frontend/src/components/PortfolioPlaceholderCard.tsx
+++ b/packages/frontend/src/components/PortfolioPlaceholderCard.tsx
@@ -20,7 +20,8 @@ import {
  *   ┌────────────────────────────────────────────────────────────────────┐
  *   │  Total Balance                    [ 7D | 1M | 3M | 1Y | All ]     │
  *   │  $0.00                                                             │
- *   │  +$42.80 earning  ← updates with selected period                  │
+ *   │  0.00 sPLUSD                                                       │
+ *   │  $0.00 unrealized                                                  │
  *   │  Get PLUSD to start →                                              │
  *   ├────────────────────────────────────────────────────────────────────┤
  *   │  ████████████████████████████████████████████████████████████      │
@@ -47,20 +48,19 @@ import {
  *   - Mouse only — touch support deferred (logged in tech-debt-tracker.md).
  *
  * Accessibility:
- *   - Chart wrap: `role="img"` + descriptive `aria-label` (period + earning).
+ *   - Chart wrap: `role="img"` + descriptive `aria-label` (period + unrealized PnL).
  *   - Individual bar `<rect>` elements are decorative — no aria attributes.
  *   - The card `<region>` is labelled by the `$0.00` heading.
  *
  * Placeholder rule:
  *   - `$0.00` is a string literal — replace when the aggregation endpoint is ready.
- *   - Earning caption uses the prototype's per-period synthetic value — replace
- *     when real per-period earnings are available.
+ *   - Unrealized PnL caption is supplied by `/v1/pnl`; defaults to `$0.00 unrealized`.
  *   - "Get PLUSD to start" link is always shown — revisit when user holds PLUSD.
  *
  * Figma reference: https://www.figma.com/design/A43rjYYjSwdTmiwwf5cx5n/Pipeline?node-id=1497-95048
  */
 
-/** Mobile home balance state — drives CTA copy and earning caption. */
+/** Mobile home balance state — drives CTA copy and connected balance state. */
 export type MobileHomeState = "empty" | "plusd" | "splusd";
 
 export interface PortfolioPlaceholderCardProps extends Omit<
@@ -72,7 +72,7 @@ export interface PortfolioPlaceholderCardProps extends Omit<
    * When provided, overrides the static `$0.00` heading and CTA link:
    *   - "empty"  → `$0.00` + "Get PLUSD to start" → /deposit (State A)
    *   - "plusd"  → totalBalance + "Stake PLUSD to start earning" → /stake (B)
-   *   - "splusd" → totalBalance (no link, earning caption) (C)
+   *   - "splusd" → totalBalance (no link, PnL caption) (C)
    * When `undefined` the desktop behaviour ($0.00 + "Get PLUSD to start") is
    * preserved byte-for-byte.
    */
@@ -83,6 +83,10 @@ export interface PortfolioPlaceholderCardProps extends Omit<
    * Defaults to `"$0.00"` when not provided.
    */
   mobileTotalBalance?: string;
+  /** Formatted sPLUSD share balance displayed below Total Balance. */
+  splusdBalanceLabel?: string;
+  /** Formatted unrealized PnL displayed below the sPLUSD balance. */
+  unrealizedPnlLabel?: string;
 }
 
 /** Base heading id prefix — each instance gets a unique suffix from useId(). */
@@ -116,7 +120,14 @@ export const PortfolioPlaceholderCard = React.forwardRef<
   HTMLDivElement,
   PortfolioPlaceholderCardProps
 >(function PortfolioPlaceholderCard(
-  { className, mobileHomeState, mobileTotalBalance = "$0.00", ...rest },
+  {
+    className,
+    mobileHomeState,
+    mobileTotalBalance = "$0.00",
+    splusdBalanceLabel = "0.00 sPLUSD",
+    unrealizedPnlLabel = "$0.00 unrealized",
+    ...rest
+  },
   ref,
 ) {
   // Use a unique id per instance to avoid duplicate id attributes when both
@@ -133,7 +144,6 @@ export const PortfolioPlaceholderCard = React.forwardRef<
     tooltip,
     onPointerMove,
     onPointerLeave,
-    earning,
   } = usePortfolioChart();
 
   /** Ref to the chart wrapper div for getBoundingClientRect on pointer move. */
@@ -164,7 +174,6 @@ export const PortfolioPlaceholderCard = React.forwardRef<
       : "0";
 
   const periodLabel = TABS.find((t) => t.id === activeId)?.label ?? "7D";
-  const earningStr = formatMoney(earning);
 
   const composed = [
     "relative flex flex-col gap-6",
@@ -224,9 +233,20 @@ export const PortfolioPlaceholderCard = React.forwardRef<
               : "$0.00"}
           </h2>
 
-          {/* Earning caption — updates with selected period.
-              Mobile State C: show "—" placeholder (no real earned data yet).
-              All other states: show the synthetic period-based earning. */}
+          <span
+            data-testid="splusd-balance-caption"
+            className={[
+              "font-[family-name:var(--font-body)]",
+              "text-[length:var(--text-pipeline-caption)]",
+              "leading-[var(--text-pipeline-caption--line-height)]",
+              "font-[var(--font-weight-regular)]",
+              "text-[color:var(--color-pipeline-ink-muted)]",
+            ].join(" ")}
+          >
+            {splusdBalanceLabel}
+          </span>
+
+          {/* Unrealized PnL caption from `/v1/pnl`. */}
           <span
             data-testid="earning-caption"
             className={[
@@ -234,19 +254,15 @@ export const PortfolioPlaceholderCard = React.forwardRef<
               "text-[length:var(--text-pipeline-caption)]",
               "leading-[var(--text-pipeline-caption--line-height)]",
               "font-[var(--font-weight-regular)]",
-              // State C shows "—" as a placeholder; other states use muted
-              // ink with synthetic earning value.
-              mobileHomeState === "splusd"
-                ? "text-[color:var(--color-pipeline-ink-muted)]"
-                : "text-[color:var(--color-pipeline-ink-muted)]",
+              "text-[color:var(--color-pipeline-ink-muted)]",
             ].join(" ")}
           >
-            {mobileHomeState === "splusd" ? "—" : `+${earningStr} earning`}
+            {unrealizedPnlLabel}
           </span>
 
           {/* State A: "Get PLUSD to start" link to /deposit.
               State B: "Stake PLUSD to start earning" link to /stake.
-              State C: no link (earning caption is sufficient context).
+              State C: no link (PnL caption is sufficient context).
               Desktop (no mobileHomeState): "Get PLUSD to start" as before. */}
           {mobileHomeState === "splusd" ? null : (
             <Link
@@ -290,7 +306,7 @@ export const PortfolioPlaceholderCard = React.forwardRef<
         ref={wrapRef}
         className="relative flex-1"
         role="img"
-        aria-label={`Total balance for ${periodLabel}: ${mobileHomeState !== undefined && mobileHomeState !== "empty" ? mobileTotalBalance : "$0.00"} (+${earningStr} earning)`}
+        aria-label={`Total balance for ${periodLabel}: ${mobileHomeState !== undefined && mobileHomeState !== "empty" ? mobileTotalBalance : "$0.00"} (${splusdBalanceLabel}, ${unrealizedPnlLabel})`}
         data-node-id="1497:95048-chart"
         onPointerMove={handlePointerMove}
         onPointerLeave={onPointerLeave}

--- a/packages/frontend/src/components/RecentActivityCard.test.tsx
+++ b/packages/frontend/src/components/RecentActivityCard.test.tsx
@@ -162,7 +162,10 @@ describe("RecentActivityCard — disconnected wallet", () => {
       disconnect: vi.fn(),
       openConnectModal: vi.fn(),
     });
-    mockUseStellarWallet.mockReturnValue({ isConnected: false, address: undefined });
+    mockUseStellarWallet.mockReturnValue({
+      isConnected: false,
+      address: undefined,
+    });
     mockUseRequests.mockReturnValue({
       data: undefined,
       isLoading: false,
@@ -202,7 +205,10 @@ describe("RecentActivityCard — connected + 3 rows", () => {
       disconnect: vi.fn(),
       openConnectModal: vi.fn(),
     });
-    mockUseStellarWallet.mockReturnValue({ isConnected: false, address: undefined });
+    mockUseStellarWallet.mockReturnValue({
+      isConnected: false,
+      address: undefined,
+    });
     mockUseRequests.mockReturnValue({
       data: FIXTURE_3,
       isLoading: false,
@@ -218,6 +224,11 @@ describe("RecentActivityCard — connected + 3 rows", () => {
   it("renders three list items", () => {
     renderCard();
     expect(screen.getAllByRole("listitem")).toHaveLength(3);
+  });
+
+  it("adds 16px internal space above row separators", () => {
+    renderCard();
+    expect(screen.getByTestId("home-activity-row-inner-0")).toHaveClass("pb-4");
   });
 
   it("renders the Deposit (Buy) amount string", () => {
@@ -268,7 +279,10 @@ describe("RecentActivityCard — connected + 6 rows (MAX_ROWS cap)", () => {
       disconnect: vi.fn(),
       openConnectModal: vi.fn(),
     });
-    mockUseStellarWallet.mockReturnValue({ isConnected: false, address: undefined });
+    mockUseStellarWallet.mockReturnValue({
+      isConnected: false,
+      address: undefined,
+    });
     mockUseRequests.mockReturnValue({
       data: FIXTURE_6,
       isLoading: false,
@@ -302,7 +316,10 @@ describe("RecentActivityCard — connected + empty list", () => {
       disconnect: vi.fn(),
       openConnectModal: vi.fn(),
     });
-    mockUseStellarWallet.mockReturnValue({ isConnected: false, address: undefined });
+    mockUseStellarWallet.mockReturnValue({
+      isConnected: false,
+      address: undefined,
+    });
     mockUseRequests.mockReturnValue({
       data: { requests: [] },
       isLoading: false,
@@ -337,7 +354,10 @@ describe("RecentActivityCard — connected + loading", () => {
       disconnect: vi.fn(),
       openConnectModal: vi.fn(),
     });
-    mockUseStellarWallet.mockReturnValue({ isConnected: false, address: undefined });
+    mockUseStellarWallet.mockReturnValue({
+      isConnected: false,
+      address: undefined,
+    });
     mockUseRequests.mockReturnValue({
       data: undefined,
       isLoading: true,
@@ -376,7 +396,10 @@ describe("RecentActivityCard — connected + error", () => {
       disconnect: vi.fn(),
       openConnectModal: vi.fn(),
     });
-    mockUseStellarWallet.mockReturnValue({ isConnected: false, address: undefined });
+    mockUseStellarWallet.mockReturnValue({
+      isConnected: false,
+      address: undefined,
+    });
     mockUseRequests.mockReturnValue({
       data: undefined,
       isLoading: false,
@@ -436,8 +459,16 @@ describe("RecentActivityCard — active chain gating (Issue #644)", () => {
     // The card previously keyed off EVM isConnected. With EVM disconnected and
     // Stellar active + connected, the list should render.
     mockUseWalletView.mockReturnValue({ kind: "stellar" });
-    mockUseStellarWallet.mockReturnValue({ isConnected: true, address: "GSTELLAR1" });
-    mockUseWallet.mockReturnValue({ isConnected: false, address: undefined, disconnect: vi.fn(), openConnectModal: vi.fn() });
+    mockUseStellarWallet.mockReturnValue({
+      isConnected: true,
+      address: "GSTELLAR1",
+    });
+    mockUseWallet.mockReturnValue({
+      isConnected: false,
+      address: undefined,
+      disconnect: vi.fn(),
+      openConnectModal: vi.fn(),
+    });
     mockUseRequests.mockReturnValue({
       data: STELLAR_FIXTURE,
       isLoading: false,
@@ -459,8 +490,16 @@ describe("RecentActivityCard — active chain gating (Issue #644)", () => {
 
   it("Stellar view + Stellar disconnected → empty state renders, list absent", () => {
     mockUseWalletView.mockReturnValue({ kind: "stellar" });
-    mockUseStellarWallet.mockReturnValue({ isConnected: false, address: undefined });
-    mockUseWallet.mockReturnValue({ isConnected: true, address: "0xEVM", disconnect: vi.fn(), openConnectModal: vi.fn() });
+    mockUseStellarWallet.mockReturnValue({
+      isConnected: false,
+      address: undefined,
+    });
+    mockUseWallet.mockReturnValue({
+      isConnected: true,
+      address: "0xEVM",
+      disconnect: vi.fn(),
+      openConnectModal: vi.fn(),
+    });
     mockUseRequests.mockReturnValue({
       data: undefined,
       isLoading: false,
@@ -478,8 +517,16 @@ describe("RecentActivityCard — active chain gating (Issue #644)", () => {
 
   it("EVM view + EVM connected drives the card, Stellar connection state is ignored", () => {
     mockUseWalletView.mockReturnValue({ kind: "evm" });
-    mockUseWallet.mockReturnValue({ isConnected: true, address: "0xEVM", disconnect: vi.fn(), openConnectModal: vi.fn() });
-    mockUseStellarWallet.mockReturnValue({ isConnected: false, address: undefined });
+    mockUseWallet.mockReturnValue({
+      isConnected: true,
+      address: "0xEVM",
+      disconnect: vi.fn(),
+      openConnectModal: vi.fn(),
+    });
+    mockUseStellarWallet.mockReturnValue({
+      isConnected: false,
+      address: undefined,
+    });
     mockUseRequests.mockReturnValue({
       data: FIXTURE_3,
       isLoading: false,
@@ -518,7 +565,7 @@ describe("RecentActivityCard — Stellar decimals (Issue #674)", () => {
         type: "Stake",
         amount: "10000000",
         assets: "10000000", // 1.0 PLUSD at 7 decimals
-        shares: "9900000",  // 0.99 sPLUSD at 7 decimals
+        shares: "9900000", // 0.99 sPLUSD at 7 decimals
         status: "Completed",
         created_at: "2026-06-01T11:00:00Z",
       },
@@ -527,8 +574,16 @@ describe("RecentActivityCard — Stellar decimals (Issue #674)", () => {
 
   it("Stellar Deposit: 10000000 at 7 dp renders '+1.00 PLUSD', not '+10.00 PLUSD' (the bug)", () => {
     mockUseWalletView.mockReturnValue({ kind: "stellar" });
-    mockUseStellarWallet.mockReturnValue({ isConnected: true, address: "GSTELLAR1" });
-    mockUseWallet.mockReturnValue({ isConnected: false, address: undefined, disconnect: vi.fn(), openConnectModal: vi.fn() });
+    mockUseStellarWallet.mockReturnValue({
+      isConnected: true,
+      address: "GSTELLAR1",
+    });
+    mockUseWallet.mockReturnValue({
+      isConnected: false,
+      address: undefined,
+      disconnect: vi.fn(),
+      openConnectModal: vi.fn(),
+    });
     mockUseRequests.mockReturnValue({
       data: STELLAR_7DP,
       isLoading: false,
@@ -544,8 +599,16 @@ describe("RecentActivityCard — Stellar decimals (Issue #674)", () => {
 
   it("Stellar Stake: 10000000/9900000 at 7 dp renders non-zero PLUSD/sPLUSD (the bug)", () => {
     mockUseWalletView.mockReturnValue({ kind: "stellar" });
-    mockUseStellarWallet.mockReturnValue({ isConnected: true, address: "GSTELLAR1" });
-    mockUseWallet.mockReturnValue({ isConnected: false, address: undefined, disconnect: vi.fn(), openConnectModal: vi.fn() });
+    mockUseStellarWallet.mockReturnValue({
+      isConnected: true,
+      address: "GSTELLAR1",
+    });
+    mockUseWallet.mockReturnValue({
+      isConnected: false,
+      address: undefined,
+      disconnect: vi.fn(),
+      openConnectModal: vi.fn(),
+    });
     mockUseRequests.mockReturnValue({
       data: STELLAR_7DP,
       isLoading: false,
@@ -563,8 +626,16 @@ describe("RecentActivityCard — Stellar decimals (Issue #674)", () => {
 
   it("EVM regression: EVM Deposit at 6 dp still renders correctly after the fix", () => {
     mockUseWalletView.mockReturnValue({ kind: "evm" });
-    mockUseWallet.mockReturnValue({ isConnected: true, address: "0xEVM", disconnect: vi.fn(), openConnectModal: vi.fn() });
-    mockUseStellarWallet.mockReturnValue({ isConnected: false, address: undefined });
+    mockUseWallet.mockReturnValue({
+      isConnected: true,
+      address: "0xEVM",
+      disconnect: vi.fn(),
+      openConnectModal: vi.fn(),
+    });
+    mockUseStellarWallet.mockReturnValue({
+      isConnected: false,
+      address: undefined,
+    });
     mockUseRequests.mockReturnValue({
       data: FIXTURE_3,
       isLoading: false,
@@ -574,13 +645,23 @@ describe("RecentActivityCard — Stellar decimals (Issue #674)", () => {
 
     renderCard();
 
-    expect(screen.getAllByText("+1,000.00 USDC").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("+1,000.00 USDC").length).toBeGreaterThanOrEqual(
+      1,
+    );
   });
 
   it("EVM regression: EVM Stake at 18 dp still renders correctly after the fix", () => {
     mockUseWalletView.mockReturnValue({ kind: "evm" });
-    mockUseWallet.mockReturnValue({ isConnected: true, address: "0xEVM", disconnect: vi.fn(), openConnectModal: vi.fn() });
-    mockUseStellarWallet.mockReturnValue({ isConnected: false, address: undefined });
+    mockUseWallet.mockReturnValue({
+      isConnected: true,
+      address: "0xEVM",
+      disconnect: vi.fn(),
+      openConnectModal: vi.fn(),
+    });
+    mockUseStellarWallet.mockReturnValue({
+      isConnected: false,
+      address: undefined,
+    });
     mockUseRequests.mockReturnValue({
       data: FIXTURE_3,
       isLoading: false,

--- a/packages/frontend/src/components/RecentActivityCard.tsx
+++ b/packages/frontend/src/components/RecentActivityCard.tsx
@@ -149,7 +149,12 @@ export const RecentActivityCard = React.forwardRef<
             <ul className="flex flex-col" data-testid="home-activity-list">
               {requests.slice(0, MAX_ROWS).map((item, i) => (
                 <li key={i} data-testid={`home-activity-row-${i}`}>
-                  {renderRequestRow(item, kind)}
+                  {renderRequestRow(
+                    item,
+                    kind,
+                    `home-activity-row-inner-${i}`,
+                    "pb-4",
+                  )}
                 </li>
               ))}
             </ul>

--- a/packages/frontend/src/components/activity/renderRequestRow.tsx
+++ b/packages/frontend/src/components/activity/renderRequestRow.tsx
@@ -107,6 +107,7 @@ export function renderRequestRow(
   item: RequestItem,
   chainKind: WalletViewKind,
   testId?: string,
+  className?: string,
 ): React.ReactNode {
   const timestamp = formatActivityTime(item.created_at);
   // Derive decimal scales from the active chain (Issue #674).
@@ -119,6 +120,7 @@ export function renderRequestRow(
       return (
         <ActivityRow
           data-testid={testId}
+          className={className}
           icon="check-circle"
           tone="success"
           title="Buy"
@@ -132,6 +134,7 @@ export function renderRequestRow(
     return (
       <ActivityRow
         data-testid={testId}
+        className={className}
         icon="clock-pending"
         tone="warning"
         title="Buy"
@@ -153,6 +156,7 @@ export function renderRequestRow(
       return (
         <ActivityRow
           data-testid={testId}
+          className={className}
           icon="check-circle"
           tone="success"
           title="Sell"
@@ -166,6 +170,7 @@ export function renderRequestRow(
     return (
       <ActivityRow
         data-testid={testId}
+        className={className}
         icon="clock-pending"
         tone="warning"
         title="Sell"
@@ -186,12 +191,17 @@ export function renderRequestRow(
     // response. Falling back to item.amount or "0" would silently zero out
     // the row and hide data regressions.
     const assets =
-      item.assets !== undefined ? formatTokenAmount(item.assets, stakeDecimals) : "—";
+      item.assets !== undefined
+        ? formatTokenAmount(item.assets, stakeDecimals)
+        : "—";
     const shares =
-      item.shares !== undefined ? formatTokenAmount(item.shares, stakeDecimals) : "—";
+      item.shares !== undefined
+        ? formatTokenAmount(item.shares, stakeDecimals)
+        : "—";
     return (
       <ActivityRow
         data-testid={testId}
+        className={className}
         icon="arrow-down-circle"
         title="Stake"
         timestamp={timestamp}
@@ -207,12 +217,17 @@ export function renderRequestRow(
 
   // Unstake — fail-loud: see Stake branch above for rationale.
   const assets =
-    item.assets !== undefined ? formatTokenAmount(item.assets, stakeDecimals) : "—";
+    item.assets !== undefined
+      ? formatTokenAmount(item.assets, stakeDecimals)
+      : "—";
   const shares =
-    item.shares !== undefined ? formatTokenAmount(item.shares, stakeDecimals) : "—";
+    item.shares !== undefined
+      ? formatTokenAmount(item.shares, stakeDecimals)
+      : "—";
   return (
     <ActivityRow
       data-testid={testId}
+      className={className}
       icon="arrow-up-circle"
       title="Unstake"
       timestamp={timestamp}

--- a/packages/frontend/src/components/usePortfolioChart.test.ts
+++ b/packages/frontend/src/components/usePortfolioChart.test.ts
@@ -14,6 +14,7 @@ import {
   generateCurve,
   formatMoney,
   formatTime,
+  pricesToCurve,
 } from "./usePortfolioChart";
 
 // Stable anchor time so tests are deterministic regardless of when they run.
@@ -140,11 +141,29 @@ describe("formatTime", () => {
 // ── Edge cases ────────────────────────────────────────────────────────────────
 
 describe("Edge cases", () => {
-  it("generateCurve with unknown periodId falls back to 7d config", () => {
-    const curve7d = generateCurve("7d", FIXED_NOW);
+  it("generateCurve with unknown periodId falls back to all config", () => {
+    const curveAll = generateCurve("all", FIXED_NOW);
     const curveUnknown = generateCurve("invalid", FIXED_NOW);
     expect(curveUnknown).toHaveLength(N);
-    // Falls back to PERIODS["7d"] config — same earning so same end balance
-    expect(curveUnknown[N - 1]!.balance).toBe(curve7d[N - 1]!.balance);
+    // Falls back to PERIODS["all"] config — same earning so same end balance.
+    expect(curveUnknown[N - 1]!.balance).toBe(curveAll[N - 1]!.balance);
+  });
+});
+
+describe("pricesToCurve", () => {
+  it("returns null for missing or empty API data", () => {
+    expect(pricesToCurve(undefined)).toBeNull();
+    expect(pricesToCurve([])).toBeNull();
+  });
+
+  it("maps valid API prices into 100 chart points", () => {
+    const curve = pricesToCurve([
+      { timestamp: "2026-01-01T00:00:00Z", avg_price: "1.00" },
+      { timestamp: "2026-01-02T00:00:00Z", avg_price: "1.02" },
+    ]);
+
+    expect(curve).toHaveLength(N);
+    expect(curve?.[0]?.balance).toBe(1);
+    expect(curve?.[N - 1]?.balance).toBe(1.02);
   });
 });

--- a/packages/frontend/src/components/usePortfolioChart.ts
+++ b/packages/frontend/src/components/usePortfolioChart.ts
@@ -3,12 +3,13 @@
  *
  * Owns:
  *  - Active time-range period (7d / 1m / 3m / 1y / all).
- *  - Deterministic balance-history curve generated per period.
+ *  - Price-history curve from `/v1/stats/prices` when available.
+ *  - Deterministic balance-history curve generated per period as a fallback.
  *  - Hover state (nearest slot index, tooltip content).
  *
- * Data is entirely synthetic (placeholder) — no API calls, no React Query.
- * Replace `generateCurve` with a real data fetch when the aggregation endpoint
- * ships. See Issue #389 for the graduation plan.
+ * The hook does not fetch by itself. Callers pass optional price samples from
+ * `/v1/stats/prices`; when samples are absent or invalid, `generateCurve`
+ * keeps the existing placeholder chart visible.
  *
  * Algorithm:
  *   The curve mirrors the prototype in
@@ -21,6 +22,7 @@
  */
 
 import { useCallback, useRef, useState } from "react";
+import type { StatsPriceItem } from "@/api";
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -51,11 +53,13 @@ export const PERIODS: Record<string, PeriodConfig> = {
   all: { days: 730, earning: 842.8, fmt: "month" },
 };
 
+export const DEFAULT_PERIOD_ID = "all";
+
 /** Default period used as a fallback when an unknown id is requested. */
 const DEFAULT_PERIOD: PeriodConfig = {
-  days: 7,
-  earning: 42.8,
-  fmt: "datetime",
+  days: PERIODS[DEFAULT_PERIOD_ID]!.days,
+  earning: PERIODS[DEFAULT_PERIOD_ID]!.earning,
+  fmt: PERIODS[DEFAULT_PERIOD_ID]!.fmt,
 };
 
 /** Safely look up a period, falling back to DEFAULT_PERIOD. */
@@ -135,6 +139,53 @@ export function generateCurve(
     height: (balance / END_BALANCE) * 100,
     timestamp: now - periodMs + i * stepMs,
   }));
+}
+
+function parsePricePoint(point: StatsPriceItem): CurvePoint | null {
+  const balance = Number(point.avg_price);
+  const timestamp = new Date(point.timestamp).getTime();
+  if (!Number.isFinite(balance) || balance <= 0) return null;
+  if (!Number.isFinite(timestamp)) return null;
+  return {
+    balance,
+    height: 0,
+    timestamp,
+  };
+}
+
+function pickPoint(points: CurvePoint[], index: number): CurvePoint {
+  if (points.length === 1) return points[0]!;
+  const sourceIndex = Math.round((index / (N - 1)) * (points.length - 1));
+  return points[Math.min(points.length - 1, sourceIndex)]!;
+}
+
+/**
+ * Converts API share-price samples into the 100-slot chart shape.
+ *
+ * Returns `null` when the API response is empty or invalid so callers can keep
+ * the synthetic placeholder curve.
+ */
+export function pricesToCurve(
+  prices: StatsPriceItem[] | undefined,
+): CurvePoint[] | null {
+  const points = (prices ?? [])
+    .map(parsePricePoint)
+    .filter((point): point is CurvePoint => point !== null)
+    .sort((a, b) => a.timestamp - b.timestamp);
+
+  if (points.length === 0) return null;
+
+  const maxBalance = Math.max(...points.map((point) => point.balance));
+  if (!Number.isFinite(maxBalance) || maxBalance <= 0) return null;
+
+  return Array.from({ length: N }, (_, index) => {
+    const source = pickPoint(points, index);
+    return {
+      balance: source.balance,
+      height: Math.max(2, (source.balance / maxBalance) * 100),
+      timestamp: source.timestamp,
+    };
+  });
 }
 
 /**
@@ -217,11 +268,26 @@ export interface PortfolioChartState {
   onPointerLeave: () => void;
   /** Earning amount for the active period */
   earning: number;
+  /** True when the curve is backed by `/v1/stats/prices` data. */
+  hasPriceData: boolean;
 }
 
-export function usePortfolioChart(): PortfolioChartState {
-  const [activeId, setActiveId] = useState("7d");
+export interface UsePortfolioChartOptions {
+  activeId?: string;
+  setActiveId?: (id: string) => void;
+  prices?: StatsPriceItem[];
+}
+
+export function usePortfolioChart({
+  activeId: controlledActiveId,
+  setActiveId: controlledSetActiveId,
+  prices,
+}: UsePortfolioChartOptions = {}): PortfolioChartState {
+  const [uncontrolledActiveId, setUncontrolledActiveId] =
+    useState(DEFAULT_PERIOD_ID);
   const [hoveredIdx, setHoveredIdx] = useState<number | null>(null);
+  const activeId = controlledActiveId ?? uncontrolledActiveId;
+  const setActiveId = controlledSetActiveId ?? setUncontrolledActiveId;
 
   // Stable anchor time — generated once per mount so the chart doesn't
   // re-render with a different curve on every hover event.
@@ -230,13 +296,15 @@ export function usePortfolioChart(): PortfolioChartState {
   // Recompute the curve only when the period changes (not on hover).
   // We use a ref + derived value pattern to keep it cheap.
   const curveRef = useRef<{ id: string; curve: CurvePoint[] } | null>(null);
+  const priceCurve = pricesToCurve(prices);
+
   if (curveRef.current === null || curveRef.current.id !== activeId) {
     curveRef.current = {
       id: activeId,
       curve: generateCurve(activeId, nowRef.current),
     };
   }
-  const curve = curveRef.current.curve;
+  const curve = priceCurve ?? curveRef.current.curve;
 
   const period = getPeriod(activeId);
 
@@ -269,5 +337,6 @@ export function usePortfolioChart(): PortfolioChartState {
     onPointerMove,
     onPointerLeave,
     earning: period.earning,
+    hasPriceData: priceCurve !== null,
   };
 }

--- a/packages/frontend/src/routes/-index.test.tsx
+++ b/packages/frontend/src/routes/-index.test.tsx
@@ -90,6 +90,15 @@ vi.mock("@/wallet", async (importOriginal) => ({
   useConnectModal: () => ({ open: mockConnectModalOpen, close: vi.fn() }),
 }));
 
+const mockPnlData = vi.hoisted(() => ({
+  current: undefined as
+    | {
+        total_unrealized_pnl: string;
+        avg_apy?: string | null;
+      }
+    | undefined,
+}));
+
 vi.mock("@tanstack/react-query", async (importOriginal) => {
   const original =
     await importOriginal<typeof import("@tanstack/react-query")>();
@@ -146,6 +155,7 @@ vi.mock("@tanstack/react-router", async (importOriginal) => {
 
 const mockEnv = vi.hoisted(() => ({
   EVM_CHAIN_ID: 560048,
+  STELLAR_CHAIN_ID: 99000001,
   EVM_RPC_URL: "https://ethereum-hoodi-rpc.publicnode.com",
   DEPOSIT_MANAGER_ADDRESS:
     "0x3333000000000000000000000000000000000003" as `0x${string}`,
@@ -165,7 +175,17 @@ vi.mock("@/lib/env", () => ({
 vi.mock("@/api", () => ({
   useRequests: () => ({ data: undefined, isLoading: false, error: null }),
   useStats: () => ({ data: undefined, isLoading: false, error: null }),
-  formatApy: () => "—",
+  usePnl: () => ({
+    data: mockPnlData.current,
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+  formatApy: (apy: string | null | undefined) => {
+    if (apy == null) return "—";
+    const num = Number(apy);
+    return Number.isFinite(num) ? `${(num * 100).toFixed(2)}%` : "—";
+  },
 }));
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -206,6 +226,10 @@ function renderHomeStellar() {
   );
 }
 
+beforeEach(() => {
+  mockPnlData.current = undefined;
+});
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe("Home page — disconnected state", () => {
@@ -214,6 +238,7 @@ describe("Home page — disconnected state", () => {
     mockOpen.mockClear();
     mockConnectModalOpen.mockClear();
     mockNavigate.mockClear();
+    mockPnlData.current = undefined;
   });
 
   afterEach(() => {
@@ -251,7 +276,6 @@ describe("Home page — disconnected state", () => {
     const connectBtns = await screen.findAllByRole("button", {
       name: "Connect",
     });
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     await user.click(connectBtns[0]!);
 
     // The Home CTA's onConnect is wired to useConnectModal().open(), which
@@ -268,7 +292,6 @@ describe("Home page — disconnected state", () => {
 
     // Both mobile and desktop blocks render StartHereCard; click the first Buy.
     const buyBtns = await screen.findAllByRole("button", { name: "Buy" });
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     await user.click(buyBtns[0]!);
 
     await waitFor(() => {
@@ -293,7 +316,6 @@ describe("Home page — disconnected state", () => {
     expect(sellBtns[0]).toBeDisabled();
     // Desktop instance must be enabled.
     expect(sellBtns[1]).not.toBeDisabled();
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     await user.click(sellBtns[1]!);
 
     await waitFor(() => {
@@ -326,7 +348,6 @@ describe("Home page — disconnected state", () => {
     const stakeBtns = await screen.findAllByRole("button", {
       name: "Stake PLUSD",
     });
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     await user.click(stakeBtns[0]!);
 
     await waitFor(() => {
@@ -355,7 +376,6 @@ describe("Home page — disconnected state", () => {
       name: "Stake PLUSD",
     });
     expect(stakeBtns[0]).not.toBeDisabled();
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     await user.click(stakeBtns[0]!);
 
     await waitFor(() => {
@@ -464,7 +484,6 @@ describe("Home page — SegmentedTabs default + click semantics", () => {
 
     // Click the first "1M" tab found.
     const tabs1m = await screen.findAllByRole("tab", { name: "1M" });
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     await user.click(tabs1m[0]!);
 
     await waitFor(() => {
@@ -482,7 +501,6 @@ describe("Home page — SegmentedTabs default + click semantics", () => {
     renderHome();
 
     const tabs3m = await screen.findAllByRole("tab", { name: "3M" });
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     await user.click(tabs3m[0]!);
 
     // open() was not called (tab switch is purely visual, no wallet action)
@@ -791,12 +809,43 @@ describe("Home page — mobile State C: connected, has sPLUSD", () => {
     });
   });
 
-  it("mobile EarnedCard shows '—' placeholder (State C)", async () => {
+  it("mobile EarnedCard shows tracking placeholder when State C has no PnL APY yet", async () => {
     renderHome();
     await waitFor(() => {
-      // "—" is the placeholder earned value for State C.
-      const elements = screen.getAllByText("—");
+      const elements = screen.getAllByText("Tracked once you stake");
       expect(elements.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  it("mobile EarnedCard shows avg APY from PnL when available", async () => {
+    mockPnlData.current = {
+      total_unrealized_pnl: "42800000000000000000",
+      avg_apy: "0.0842",
+    };
+
+    renderHome();
+
+    await waitFor(() => {
+      const elements = screen.getAllByText("8.42% p.a.");
+      expect(elements.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  it("mobile portfolio chart summary shows unrealized PnL and sPLUSD amount", async () => {
+    mockPnlData.current = {
+      total_unrealized_pnl: "42800000000000000000",
+      avg_apy: "0.0842",
+    };
+
+    renderHome();
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId("earning-caption")[0]).toHaveTextContent(
+        "+$42.80 unrealized",
+      );
+      expect(
+        screen.getAllByTestId("splusd-balance-caption")[0],
+      ).toHaveTextContent("1,000.00 sPLUSD");
     });
   });
 

--- a/packages/frontend/src/routes/-index.test.tsx
+++ b/packages/frontend/src/routes/-index.test.tsx
@@ -407,11 +407,13 @@ describe("Home page — connected state (mock)", () => {
     });
   });
 
-  it("shows '$0.00' balance literal", async () => {
-    // Both mobile (State A) and desktop render $0.00; at least one must appear.
+  it("shows '0.00 sPLUSD' balance literal", async () => {
+    // Both mobile (State A) and desktop render sPLUSD shares; at least one must appear.
     renderHome();
     await waitFor(() => {
-      const headings = screen.getAllByRole("heading", { name: "$0.00" });
+      const headings = screen.getAllByRole("heading", {
+        name: "0.00 sPLUSD",
+      });
       expect(headings.length).toBeGreaterThanOrEqual(1);
     });
   });
@@ -548,7 +550,7 @@ describe("Home page — card height parity (connected)", () => {
     renderHome();
 
     await waitFor(() => {
-      const cards = screen.getAllByRole("region", { name: "$0.00" });
+      const cards = screen.getAllByRole("region", { name: "0.00 sPLUSD" });
       expect(cards.some((c) => c.className.includes("min-h-[274px]"))).toBe(
         true,
       );
@@ -831,7 +833,7 @@ describe("Home page — mobile State C: connected, has sPLUSD", () => {
     });
   });
 
-  it("mobile portfolio chart summary shows unrealized PnL and sPLUSD amount", async () => {
+  it("mobile portfolio chart summary shows sPLUSD as the main balance and unrealized PnL below it", async () => {
     mockPnlData.current = {
       total_unrealized_pnl: "42800000000000000000",
       avg_apy: "0.0842",
@@ -840,12 +842,15 @@ describe("Home page — mobile State C: connected, has sPLUSD", () => {
     renderHome();
 
     await waitFor(() => {
+      expect(
+        screen.getAllByRole("heading", { name: "1,000.00 sPLUSD" })[0],
+      ).toBeInTheDocument();
       expect(screen.getAllByTestId("earning-caption")[0]).toHaveTextContent(
         "+$42.80 unrealized",
       );
       expect(
-        screen.getAllByTestId("splusd-balance-caption")[0],
-      ).toHaveTextContent("1,000.00 sPLUSD");
+        screen.queryByTestId("splusd-balance-caption"),
+      ).not.toBeInTheDocument();
     });
   });
 
@@ -1049,7 +1054,7 @@ describe("Home page — Stellar connected balances (#688)", () => {
     localStorage.clear();
   });
 
-  it("Case 1: has PLUSD, 0 sPLUSD — Total Balance reflects PLUSD, Stake enabled, mobile state plusd", async () => {
+  it("Case 1: has PLUSD, 0 sPLUSD — Total Balance shows sPLUSD only, Stake enabled, mobile state plusd", async () => {
     // Seed 500 PLUSD at 7-decimal scale: 500 * 10^7 = 5_000_000_000n
     localStorage.setItem(
       "pipeline.mock.wallet.stellar.balance.sac.plusd",
@@ -1060,14 +1065,18 @@ describe("Home page — Stellar connected balances (#688)", () => {
     renderHomeStellar();
 
     await waitFor(() => {
-      // Total Balance should NOT be $0.00 (PLUSD balance present).
-      const headings = screen.getAllByRole("heading");
-      const balanceHeading = headings.find(
-        (h) => h.textContent && /\$[\d,]+\.\d{2}/.test(h.textContent),
-      );
-      expect(balanceHeading).not.toBeUndefined();
-      // The balance rendered must not be $0.00.
-      expect(balanceHeading?.textContent).not.toBe("$0.00");
+      const headings = screen.getAllByRole("heading", {
+        name: "0.00 sPLUSD",
+      });
+      expect(headings.length).toBeGreaterThanOrEqual(1);
+      expect(
+        screen.queryByTestId("splusd-balance-caption"),
+      ).not.toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      const subLine = screen.getByTestId("plusd-in-usdc");
+      expect(subLine).toHaveTextContent(/\$500\.00 USDC/);
     });
 
     // Stake CTA should be enabled (has PLUSD).
@@ -1086,7 +1095,7 @@ describe("Home page — Stellar connected balances (#688)", () => {
     });
   });
 
-  it("Case 2: has sPLUSD — Total Balance includes sPLUSD-to-PLUSD, mobile state splusd, RecentActivityCard present", async () => {
+  it("Case 2: has sPLUSD — Total Balance shows sPLUSD shares, mobile state splusd, RecentActivityCard present", async () => {
     // Seed 100 sPLUSD at 7-decimal scale: 100 * 10^7 = 1_000_000_000n
     localStorage.setItem(
       "pipeline.mock.wallet.stellar.stakedPlusd.shareBalance",
@@ -1111,6 +1120,13 @@ describe("Home page — Stellar connected balances (#688)", () => {
       expect(elements.length).toBeGreaterThanOrEqual(1);
     });
 
+    await waitFor(() => {
+      const headings = screen.getAllByRole("heading", {
+        name: "100.00 sPLUSD",
+      });
+      expect(headings.length).toBeGreaterThanOrEqual(1);
+    });
+
     // Mobile RecentActivityCard should be present (State C).
     await waitFor(() => {
       const cards = screen.getAllByRole("region", { name: "Recent activity" });
@@ -1119,14 +1135,16 @@ describe("Home page — Stellar connected balances (#688)", () => {
     });
   });
 
-  it("Case 3: zero balances / no trustline — $0.00 Total Balance, Stake disabled, mobile state empty", async () => {
+  it("Case 3: zero balances / no trustline — 0.00 sPLUSD Total Balance, Stake disabled, mobile state empty", async () => {
     // No balance keys seeded → all balances undefined → State A.
 
     renderHomeStellar();
 
-    // Total Balance should be $0.00.
+    // Total Balance should show sPLUSD shares only.
     await waitFor(() => {
-      const zeroHeadings = screen.getAllByRole("heading", { name: "$0.00" });
+      const zeroHeadings = screen.getAllByRole("heading", {
+        name: "0.00 sPLUSD",
+      });
       expect(zeroHeadings.length).toBeGreaterThanOrEqual(1);
     });
 
@@ -1144,7 +1162,7 @@ describe("Home page — Stellar connected balances (#688)", () => {
     });
   });
 
-  it("Case 4: decimal-scale assertion — 7-decimal PLUSD is formatted as $1,234.57, not mis-scaled", async () => {
+  it("Case 4: decimal-scale assertion — 7-decimal PLUSD StartHere balance is formatted as $1,234.57, not mis-scaled", async () => {
     // Seed 1234.5678900 PLUSD at 7-decimal fixed-point.
     // 1234.5678900 * 10^7 = 12_345_678_900n
     localStorage.setItem(
@@ -1154,16 +1172,12 @@ describe("Home page — Stellar connected balances (#688)", () => {
 
     renderHomeStellar();
 
-    // The Total Balance heading must show "$1,234.57" — not a mis-scaled value.
+    // The StartHere PLUSD sub-line must show "$1,234.57" — not a mis-scaled value.
     // If the 18-decimal path were used by mistake, 12_345_678_900n at 18 decimals
     // would render as "$0.00" (value ~1.23e-8), proving the 7-decimal path is taken.
     await waitFor(() => {
-      // We look for a heading with "$1,234.57" (Total Balance, mobile block).
-      const headings = screen.getAllByRole("heading");
-      const balanceHeading = headings.find(
-        (h) => h.textContent === "$1,234.57",
-      );
-      expect(balanceHeading).not.toBeUndefined();
+      const subLine = screen.getByTestId("plusd-in-usdc");
+      expect(subLine).toHaveTextContent("$1,234.57 USDC");
     });
   });
 
@@ -1180,9 +1194,11 @@ describe("Home page — Stellar connected balances (#688)", () => {
       const elements = screen.getAllByText("Total Balance");
       expect(elements.length).toBeGreaterThanOrEqual(1);
     });
-    // $0.00 because no EVM PLUSD balance seeded.
+    // 0.00 sPLUSD because no EVM sPLUSD balance seeded.
     await waitFor(() => {
-      const zeroHeadings = screen.getAllByRole("heading", { name: "$0.00" });
+      const zeroHeadings = screen.getAllByRole("heading", {
+        name: "0.00 sPLUSD",
+      });
       expect(zeroHeadings.length).toBeGreaterThanOrEqual(1);
     });
   });

--- a/packages/frontend/src/routes/-index.test.tsx
+++ b/packages/frontend/src/routes/-index.test.tsx
@@ -9,8 +9,8 @@
  *   1. Disconnected → ConnectWalletPromoCard renders; click invokes connect().
  *   2. Connected (via mock) → PortfolioPlaceholderCard renders; $0.00 visible;
  *      "Get PLUSD to start" link is present; ConnectWallet promo is absent.
- *   3. SegmentedTabs default + click: default tab is "7D"; clicking "1M" makes
- *      it the active tab; no data fetch occurs.
+ *   3. SegmentedTabs default + click: default tab is "All"; clicking "1M"
+ *      makes it the active tab; no wallet action occurs.
  *   4. Card height parity: both cards carry the `min-h-[274px]` utility class.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
@@ -161,6 +161,7 @@ const mockEnv = vi.hoisted(() => ({
     "0x3333000000000000000000000000000000000003" as `0x${string}`,
   STAKED_PLUSD_ADDRESS:
     "0x0000000000000000000000000000000000000000" as `0x${string}`,
+  STELLAR_STAKED_PLUSD_ID: "",
   WALLETCONNECT_PROJECT_ID: "replace-me",
 }));
 
@@ -177,6 +178,12 @@ vi.mock("@/api", () => ({
   useStats: () => ({ data: undefined, isLoading: false, error: null }),
   usePnl: () => ({
     data: mockPnlData.current,
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+  useStatsPrices: () => ({
+    data: undefined,
     isLoading: false,
     error: null,
     refetch: vi.fn(),
@@ -407,12 +414,12 @@ describe("Home page — connected state (mock)", () => {
     });
   });
 
-  it("shows '0.00 sPLUSD' balance literal", async () => {
-    // Both mobile (State A) and desktop render sPLUSD shares; at least one must appear.
+  it("shows '$0.00' sPLUSD balance literal", async () => {
+    // Both mobile (State A) and desktop render the sPLUSD balance in currency format.
     renderHome();
     await waitFor(() => {
       const headings = screen.getAllByRole("heading", {
-        name: "0.00 sPLUSD",
+        name: "$0.00",
       });
       expect(headings.length).toBeGreaterThanOrEqual(1);
     });
@@ -460,12 +467,12 @@ describe("Home page — SegmentedTabs default + click semantics", () => {
     localStorage.clear();
   });
 
-  it("default active tab is '7D'", async () => {
+  it("default active tab is 'All'", async () => {
     // Both mobile and desktop blocks render PortfolioPlaceholderCard in
-    // the connected state; check the first "7D" tab found.
+    // the connected state; check the first "All" tab found.
     renderHome();
     await waitFor(() => {
-      const tabs = screen.getAllByRole("tab", { name: "7D" });
+      const tabs = screen.getAllByRole("tab", { name: "All" });
       expect(tabs.length).toBeGreaterThanOrEqual(1);
       expect(tabs[0]).toHaveAttribute("aria-selected", "true");
     });
@@ -480,7 +487,7 @@ describe("Home page — SegmentedTabs default + click semantics", () => {
     });
   });
 
-  it("clicking '1M' makes it the active tab and deactivates '7D'", async () => {
+  it("clicking '1M' makes it the active tab and deactivates 'All'", async () => {
     const user = userEvent.setup();
     renderHome();
 
@@ -492,9 +499,9 @@ describe("Home page — SegmentedTabs default + click semantics", () => {
       // At least one "1M" tab should now be active.
       const active1mTabs = screen.getAllByRole("tab", { name: "1M" });
       expect(active1mTabs[0]).toHaveAttribute("aria-selected", "true");
-      // The corresponding "7D" tab (in the same tablist) should be inactive.
-      const tabs7d = screen.getAllByRole("tab", { name: "7D" });
-      expect(tabs7d[0]).toHaveAttribute("aria-selected", "false");
+      // The corresponding "All" tab (in the same tablist) should be inactive.
+      const tabsAll = screen.getAllByRole("tab", { name: "All" });
+      expect(tabsAll[0]).toHaveAttribute("aria-selected", "false");
     });
   });
 
@@ -550,7 +557,7 @@ describe("Home page — card height parity (connected)", () => {
     renderHome();
 
     await waitFor(() => {
-      const cards = screen.getAllByRole("region", { name: "0.00 sPLUSD" });
+      const cards = screen.getAllByRole("region", { name: "$0.00" });
       expect(cards.some((c) => c.className.includes("min-h-[274px]"))).toBe(
         true,
       );
@@ -833,7 +840,7 @@ describe("Home page — mobile State C: connected, has sPLUSD", () => {
     });
   });
 
-  it("mobile portfolio chart summary shows sPLUSD as the main balance and unrealized PnL below it", async () => {
+  it("mobile portfolio chart summary shows sPLUSD balance in currency format and unrealized PnL below it", async () => {
     mockPnlData.current = {
       total_unrealized_pnl: "42800000000000000000",
       avg_apy: "0.0842",
@@ -843,7 +850,7 @@ describe("Home page — mobile State C: connected, has sPLUSD", () => {
 
     await waitFor(() => {
       expect(
-        screen.getAllByRole("heading", { name: "1,000.00 sPLUSD" })[0],
+        screen.getAllByRole("heading", { name: "$1,000.00" })[0],
       ).toBeInTheDocument();
       expect(screen.getAllByTestId("earning-caption")[0]).toHaveTextContent(
         "+$42.80 unrealized",
@@ -1066,7 +1073,7 @@ describe("Home page — Stellar connected balances (#688)", () => {
 
     await waitFor(() => {
       const headings = screen.getAllByRole("heading", {
-        name: "0.00 sPLUSD",
+        name: "$0.00",
       });
       expect(headings.length).toBeGreaterThanOrEqual(1);
       expect(
@@ -1095,7 +1102,7 @@ describe("Home page — Stellar connected balances (#688)", () => {
     });
   });
 
-  it("Case 2: has sPLUSD — Total Balance shows sPLUSD shares, mobile state splusd, RecentActivityCard present", async () => {
+  it("Case 2: has sPLUSD — Total Balance shows sPLUSD shares in currency format, mobile state splusd, RecentActivityCard present", async () => {
     // Seed 100 sPLUSD at 7-decimal scale: 100 * 10^7 = 1_000_000_000n
     localStorage.setItem(
       "pipeline.mock.wallet.stellar.stakedPlusd.shareBalance",
@@ -1122,7 +1129,7 @@ describe("Home page — Stellar connected balances (#688)", () => {
 
     await waitFor(() => {
       const headings = screen.getAllByRole("heading", {
-        name: "100.00 sPLUSD",
+        name: "$100.00",
       });
       expect(headings.length).toBeGreaterThanOrEqual(1);
     });
@@ -1135,7 +1142,7 @@ describe("Home page — Stellar connected balances (#688)", () => {
     });
   });
 
-  it("Case 3: zero balances / no trustline — 0.00 sPLUSD Total Balance, Stake disabled, mobile state empty", async () => {
+  it("Case 3: zero balances / no trustline — $0.00 sPLUSD Total Balance, Stake disabled, mobile state empty", async () => {
     // No balance keys seeded → all balances undefined → State A.
 
     renderHomeStellar();
@@ -1143,7 +1150,7 @@ describe("Home page — Stellar connected balances (#688)", () => {
     // Total Balance should show sPLUSD shares only.
     await waitFor(() => {
       const zeroHeadings = screen.getAllByRole("heading", {
-        name: "0.00 sPLUSD",
+        name: "$0.00",
       });
       expect(zeroHeadings.length).toBeGreaterThanOrEqual(1);
     });
@@ -1194,10 +1201,10 @@ describe("Home page — Stellar connected balances (#688)", () => {
       const elements = screen.getAllByText("Total Balance");
       expect(elements.length).toBeGreaterThanOrEqual(1);
     });
-    // 0.00 sPLUSD because no EVM sPLUSD balance seeded.
+    // $0.00 because no EVM sPLUSD balance seeded.
     await waitFor(() => {
       const zeroHeadings = screen.getAllByRole("heading", {
-        name: "0.00 sPLUSD",
+        name: "$0.00",
       });
       expect(zeroHeadings.length).toBeGreaterThanOrEqual(1);
     });

--- a/packages/frontend/src/routes/-transactions.test.tsx
+++ b/packages/frontend/src/routes/-transactions.test.tsx
@@ -223,6 +223,11 @@ describe("Transactions page — default Buy tab", () => {
     expect(screen.getByText("+1,000.00 PLUSD")).toBeInTheDocument();
   });
 
+  it("adds 16px internal space above each row separator", () => {
+    renderTransactions();
+    expect(screen.getByTestId("transactions-row-0")).toHaveClass("pb-4");
+  });
+
   it("does not show Withdraw amount under the Buy tab", () => {
     renderTransactions();
 
@@ -634,6 +639,12 @@ describe("Shared renderRequestRow helper — contract", () => {
     });
   });
 
+  it("forwards optional className to ActivityRow", () => {
+    const node = renderRequestRow(FIXTURE.requests[0]!, "evm", "row", "pb-4");
+    const { container } = render(<>{node}</>);
+    expect(container.firstElementChild).toHaveClass("pb-4");
+  });
+
   it("returns a non-null element for a pending Deposit row", () => {
     const pendingDeposit: RequestItem = {
       type: "Deposit",
@@ -801,7 +812,7 @@ describe("Transactions page — Stellar decimals (Issue #674)", () => {
         type: "Stake",
         amount: "10000000",
         assets: "10000000", // 1.0 PLUSD at 7 decimals
-        shares: "9900000",  // 0.99 sPLUSD at 7 decimals
+        shares: "9900000", // 0.99 sPLUSD at 7 decimals
         status: "Completed",
         created_at: "2026-06-01T11:00:00Z",
       },

--- a/packages/frontend/src/routes/index.tsx
+++ b/packages/frontend/src/routes/index.tsx
@@ -30,6 +30,7 @@ import { StakeCard } from "@/components/StakeCard";
 import { EarnedCard } from "@/components/EarnedCard";
 import { RecentActivityCard } from "@/components/RecentActivityCard";
 import { QnaSection } from "@/components/QnaSection";
+import { usePnl, formatApy } from "@/api";
 
 /**
  * Home page — full composition (Figma `1497:94556` desktop, `1989:8292` mobile).
@@ -108,6 +109,37 @@ function formatBigintUSD(value: bigint | undefined, decimals = 18): string {
   }).format(asFloat);
 }
 
+function formatBigintTokenAmount(
+  value: bigint | undefined,
+  decimals: number,
+  symbol: string,
+): string {
+  if (value === undefined || value === 0n) return `0.00 ${symbol}`;
+  const asFloat = parseFloat(formatUnits(value, decimals));
+  const formatted = new Intl.NumberFormat("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(asFloat);
+  return `${formatted} ${symbol}`;
+}
+
+function formatRawDecimalUSD(
+  value: string | null | undefined,
+  decimals: number,
+  options: { signed?: boolean; suffix?: string } = {},
+): string {
+  const raw = value === undefined || value === null ? 0 : Number(value);
+  const amount = Number.isFinite(raw) ? raw / 10 ** decimals : 0;
+  const absFormatted = new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(Math.abs(amount));
+  const sign = options.signed && amount > 0 ? "+" : amount < 0 ? "-" : "";
+  return `${sign}${absFormatted}${options.suffix ? ` ${options.suffix}` : ""}`;
+}
+
 /**
  * Connected-wallet balance state selector for the mobile home page.
  *
@@ -139,6 +171,7 @@ function Home() {
   const { kind } = useWalletView();
   const isConnected =
     kind === "stellar" ? stellar.isConnected : evm.isConnected;
+  const pnl = usePnl();
 
   const { open: openConnectModal } = useConnectModal();
   const navigate = useNavigate();
@@ -228,6 +261,21 @@ function Home() {
   const totalBalanceFormatted = isConnected
     ? formatBigintUSD(totalBalanceBigint, activeDecimals)
     : "$0.00";
+  const splusdBalanceFormatted = formatBigintTokenAmount(
+    splusdSharesActive,
+    activeDecimals,
+    "sPLUSD",
+  );
+  const unrealizedPnlFormatted = formatRawDecimalUSD(
+    pnl.data?.total_unrealized_pnl,
+    activeDecimals,
+    { signed: true, suffix: "unrealized" },
+  );
+  const avgApyFormatted = formatApy(pnl.data?.avg_apy);
+  const earnedApyLabel =
+    isConnected && avgApyFormatted !== "—"
+      ? `${avgApyFormatted} p.a.`
+      : undefined;
 
   // ── Mobile home state ──────────────────────────────────────────────────────
   // deriveMobileHomeState only compares > 0n so it is scale-agnostic.
@@ -282,6 +330,8 @@ function Home() {
               className="min-h-[256px] md:min-h-[274px]"
               mobileHomeState={mobileHomeState}
               mobileTotalBalance={totalBalanceFormatted}
+              splusdBalanceLabel={splusdBalanceFormatted}
+              unrealizedPnlLabel={unrealizedPnlFormatted}
               data-testid="home-portfolio-placeholder"
             />
           ) : (
@@ -317,6 +367,7 @@ function Home() {
               <EarnedCard
                 padding="sm"
                 mobileHomeState={isConnected ? mobileHomeState : undefined}
+                avgApyLabel={earnedApyLabel}
                 data-testid="home-earned-card"
               />
             </div>
@@ -374,6 +425,10 @@ function Home() {
             {isConnected ? (
               <PortfolioPlaceholderCard
                 className="col-span-4 row-start-1"
+                mobileHomeState={mobileHomeState}
+                mobileTotalBalance={totalBalanceFormatted}
+                splusdBalanceLabel={splusdBalanceFormatted}
+                unrealizedPnlLabel={unrealizedPnlFormatted}
                 data-testid="home-portfolio-placeholder"
               />
             ) : (
@@ -405,7 +460,10 @@ function Home() {
                 onSell={onSell}
                 data-testid="home-start-here-card"
               />
-              <EarnedCard data-testid="home-earned-card" />
+              <EarnedCard
+                avgApyLabel={earnedApyLabel}
+                data-testid="home-earned-card"
+              />
             </div>
 
             {/* Row 2, columns 3–4: Stake CTA card. */}

--- a/packages/frontend/src/routes/index.tsx
+++ b/packages/frontend/src/routes/index.tsx
@@ -90,25 +90,6 @@ import { usePnl, formatApy } from "@/api";
  * preserved at md+ via `md:grid` and `md:grid-cols-7`.
  */
 
-/**
- * Derives a human-readable USD string from a bigint balance.
- *
- * @param value   - Raw bigint balance. Returns `"$0.00"` when `undefined` or `0n`.
- * @param decimals - Decimal precision of `value`. Defaults to `18` (EVM) to
- *                   preserve all existing call sites unchanged. Pass `SAC_DECIMALS`
- *                   (7) for Stellar balances to avoid the 18-decimal mis-scale.
- */
-function formatBigintUSD(value: bigint | undefined, decimals = 18): string {
-  if (value === undefined || value === 0n) return "$0.00";
-  const asFloat = parseFloat(formatUnits(value, decimals));
-  return new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency: "USD",
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  }).format(asFloat);
-}
-
 function formatBigintTokenAmount(
   value: bigint | undefined,
   decimals: number,
@@ -194,7 +175,7 @@ function Home() {
     token: ENV.STAKED_PLUSD_ADDRESS,
   });
 
-  // Convert EVM sPLUSD shares → PLUSD-equivalent for Total Balance (State C).
+  // Convert EVM sPLUSD shares → PLUSD-equivalent for StakeCard State C.
   const { data: evmSplusdInPlusd } =
     useStakedPlusdConvertToAssets(evmSplusdBalance);
 
@@ -238,7 +219,7 @@ function Home() {
     ? stellarSplusdInPlusd
     : evmSplusdInPlusd;
 
-  // Decimal count for the active chain (used by formatBigintUSD and StakeCard).
+  // Decimal count for the active chain (used by home balance labels and StakeCard).
   const activeDecimals = isStellar ? SAC_DECIMALS : 18;
 
   // Formatted PLUSD display string passed to StartHereCard's `mobilePlusdBalance`
@@ -251,16 +232,6 @@ function Home() {
       : undefined
     : evmPlusdFormatted;
 
-  // ── Total Balance ──────────────────────────────────────────────────────────
-  // Total Balance = PLUSD balance + sPLUSD converted to PLUSD, at active scale.
-  const totalBalanceBigint: bigint | undefined =
-    plusdBalanceActive !== undefined || splusdInPlusdActive !== undefined
-      ? (plusdBalanceActive ?? 0n) + (splusdInPlusdActive ?? 0n)
-      : undefined;
-
-  const totalBalanceFormatted = isConnected
-    ? formatBigintUSD(totalBalanceBigint, activeDecimals)
-    : "$0.00";
   const splusdBalanceFormatted = formatBigintTokenAmount(
     splusdSharesActive,
     activeDecimals,
@@ -329,8 +300,7 @@ function Home() {
             <PortfolioPlaceholderCard
               className="min-h-[256px] md:min-h-[274px]"
               mobileHomeState={mobileHomeState}
-              mobileTotalBalance={totalBalanceFormatted}
-              splusdBalanceLabel={splusdBalanceFormatted}
+              balanceLabel={splusdBalanceFormatted}
               unrealizedPnlLabel={unrealizedPnlFormatted}
               data-testid="home-portfolio-placeholder"
             />
@@ -426,8 +396,7 @@ function Home() {
               <PortfolioPlaceholderCard
                 className="col-span-4 row-start-1"
                 mobileHomeState={mobileHomeState}
-                mobileTotalBalance={totalBalanceFormatted}
-                splusdBalanceLabel={splusdBalanceFormatted}
+                balanceLabel={splusdBalanceFormatted}
                 unrealizedPnlLabel={unrealizedPnlFormatted}
                 data-testid="home-portfolio-placeholder"
               />

--- a/packages/frontend/src/routes/index.tsx
+++ b/packages/frontend/src/routes/index.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { useState } from "react";
 import { formatUnits } from "viem";
 import { Card } from "@pipeline/ui";
 import { ENV } from "@/lib/env";
@@ -30,7 +31,7 @@ import { StakeCard } from "@/components/StakeCard";
 import { EarnedCard } from "@/components/EarnedCard";
 import { RecentActivityCard } from "@/components/RecentActivityCard";
 import { QnaSection } from "@/components/QnaSection";
-import { usePnl, formatApy } from "@/api";
+import { usePnl, formatApy, useStatsPrices } from "@/api";
 
 /**
  * Home page — full composition (Figma `1497:94556` desktop, `1989:8292` mobile).
@@ -90,18 +91,18 @@ import { usePnl, formatApy } from "@/api";
  * preserved at md+ via `md:grid` and `md:grid-cols-7`.
  */
 
-function formatBigintTokenAmount(
+function formatBigintCurrency(
   value: bigint | undefined,
   decimals: number,
-  symbol: string,
 ): string {
-  if (value === undefined || value === 0n) return `0.00 ${symbol}`;
+  if (value === undefined || value === 0n) return "$0.00";
   const asFloat = parseFloat(formatUnits(value, decimals));
-  const formatted = new Intl.NumberFormat("en-US", {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
     minimumFractionDigits: 2,
     maximumFractionDigits: 2,
   }).format(asFloat);
-  return `${formatted} ${symbol}`;
 }
 
 function formatRawDecimalUSD(
@@ -153,6 +154,7 @@ function Home() {
   const isConnected =
     kind === "stellar" ? stellar.isConnected : evm.isConnected;
   const pnl = usePnl();
+  const [chartPeriodId, setChartPeriodId] = useState("all");
 
   const { open: openConnectModal } = useConnectModal();
   const navigate = useNavigate();
@@ -232,10 +234,9 @@ function Home() {
       : undefined
     : evmPlusdFormatted;
 
-  const splusdBalanceFormatted = formatBigintTokenAmount(
+  const splusdBalanceFormatted = formatBigintCurrency(
     splusdSharesActive,
     activeDecimals,
-    "sPLUSD",
   );
   const unrealizedPnlFormatted = formatRawDecimalUSD(
     pnl.data?.total_unrealized_pnl,
@@ -247,6 +248,16 @@ function Home() {
     isConnected && avgApyFormatted !== "—"
       ? `${avgApyFormatted} p.a.`
       : undefined;
+  const activeSplusdVaultAddress = isStellar
+    ? ENV.STELLAR_STAKED_PLUSD_ID
+    : ENV.STAKED_PLUSD_ADDRESS;
+  const activeChainId = isStellar ? ENV.STELLAR_CHAIN_ID : ENV.EVM_CHAIN_ID;
+  const prices = useStatsPrices({
+    vaultAddress: activeSplusdVaultAddress,
+    chainId: activeChainId,
+    periodId: chartPeriodId,
+    enabled: isConnected && activeSplusdVaultAddress.length > 0,
+  });
 
   // ── Mobile home state ──────────────────────────────────────────────────────
   // deriveMobileHomeState only compares > 0n so it is scale-agnostic.
@@ -302,6 +313,9 @@ function Home() {
               mobileHomeState={mobileHomeState}
               balanceLabel={splusdBalanceFormatted}
               unrealizedPnlLabel={unrealizedPnlFormatted}
+              activePeriodId={chartPeriodId}
+              onActivePeriodChange={setChartPeriodId}
+              priceItems={prices.data?.prices}
               data-testid="home-portfolio-placeholder"
             />
           ) : (
@@ -398,6 +412,9 @@ function Home() {
                 mobileHomeState={mobileHomeState}
                 balanceLabel={splusdBalanceFormatted}
                 unrealizedPnlLabel={unrealizedPnlFormatted}
+                activePeriodId={chartPeriodId}
+                onActivePeriodChange={setChartPeriodId}
+                priceItems={prices.data?.prices}
                 data-testid="home-portfolio-placeholder"
               />
             ) : (

--- a/packages/frontend/src/routes/transactions.tsx
+++ b/packages/frontend/src/routes/transactions.tsx
@@ -170,7 +170,7 @@ function Transactions() {
             filtered.length > 0 &&
             filtered.map((item, i) => (
               <React.Fragment key={i}>
-                {renderRequestRow(item, kind, `transactions-row-${i}`)}
+                {renderRequestRow(item, kind, `transactions-row-${i}`, "pb-4")}
               </React.Fragment>
             ))}
         </div>

--- a/packages/ui/src/styles/theme.css
+++ b/packages/ui/src/styles/theme.css
@@ -92,7 +92,9 @@
   --color-pipeline-on-warning: #ffffff; /* content on warning fill */
   --color-pipeline-danger: #c0392b; /* fill/danger — error toast bg; base shape node 6860:833 */
   --color-pipeline-on-danger: #ffffff; /* content on danger fill */
-  --color-pipeline-positive-secondary: rgb(32 128 0 / 0.16); /* fill/positive-secondary — step done pill bg; node 1497-95272 */
+  --color-pipeline-positive-secondary: rgb(
+    32 128 0 / 0.16
+  ); /* fill/positive-secondary — step done pill bg; node 1497-95272 */
   --color-pipeline-positive: #1a6600; /* content/positive — step done check icon; dark-green on positive-secondary */
   --color-pipeline-chart-positive: #2d7b1f; /* chart bar fill — portfolio stacked-bars chart; prototype value */
 
@@ -165,7 +167,9 @@
   --color-pipeline-on-warning: #ffffff; /* content on warning fill */
   --color-pipeline-danger: #c0392b; /* fill/danger — error toast bg; base shape node 6860:833 */
   --color-pipeline-on-danger: #ffffff; /* content on danger fill */
-  --color-pipeline-positive-secondary: rgb(32 128 0 / 0.16); /* fill/positive-secondary — step done pill bg; node 1497-95272 */
+  --color-pipeline-positive-secondary: rgb(
+    32 128 0 / 0.16
+  ); /* fill/positive-secondary — step done pill bg; node 1497-95272 */
   --color-pipeline-positive: #1a6600; /* content/positive — step done check icon; dark-green on positive-secondary */
   --color-pipeline-chart-positive: #2d7b1f; /* chart bar fill — portfolio stacked-bars chart; prototype value */
 
@@ -188,7 +192,7 @@
   --text-pipeline-heading-m-mobile--line-height: 28px; /* font/line-height/heading-m (mobile) */
   --text-pipeline-heading-s: 20px; /* Heading 20 — Get PLUSD card titles (desktop) */
   --text-pipeline-heading-s--line-height: 28px; /* Heading 20 line-height (desktop) */
-  --text-pipeline-heading-s-mobile: 18px; /* Heading 18 — Get PLUSD / Earn / Coming soon (mobile, below md) */
+  --text-pipeline-heading-s-mobile: 18px; /* Heading 18 — Get PLUSD / Earn / Tracked once you stake (mobile, below md) */
   --text-pipeline-heading-s-mobile--line-height: 28px; /* Heading 18 line-height (mobile) */
   --text-pipeline-body: 16px; /* font/font-size/body */
   --text-pipeline-body--line-height: 22px; /* font/line-height/body */


### PR DESCRIPTION
## Summary
- add a chain-aware `usePnl` frontend API hook for `GET /v1/pnl`
- show PnL `avg_apy` in the home Earned card, with `Tracked once you stake` as the fallback copy
- replace the chart summary's synthetic earning caption with unrealized PnL and add the active sPLUSD share amount under Total Balance

## Verification
- yarn workspace @pipeline/frontend test src/api/usePnl.test.tsx src/components/PortfolioPlaceholderCard.test.tsx src/routes/-index.test.tsx
- npx tsx scripts/lint-docs.ts (passes with existing warnings)
- yarn workspace @pipeline/frontend build
- yarn workspace @pipeline/frontend eslint src/api/usePnl.ts src/api/usePnl.test.tsx src/api/index.ts src/routes/index.tsx src/routes/-index.test.tsx src/components/EarnedCard.tsx src/components/PortfolioPlaceholderCard.tsx src/components/PortfolioPlaceholderCard.test.tsx
- yarn workspace @pipeline/frontend prettier --check src/api/usePnl.ts src/api/usePnl.test.tsx src/api/index.ts src/api/README.md src/routes/index.tsx src/routes/-index.test.tsx src/components/EarnedCard.tsx src/components/PortfolioPlaceholderCard.tsx src/components/PortfolioPlaceholderCard.test.tsx ../../packages/ui/src/styles/theme.css
- git diff --check

Note: full `yarn workspace @pipeline/frontend lint` is still blocked by pre-existing unrelated Prettier warnings outside this patch.