### PR TITLE
Reset deposit form to initial state on completion

### DIFF
--- a/packages/frontend/src/routes/-deposit.test.tsx
+++ b/packages/frontend/src/routes/-deposit.test.tsx
@@ -1273,7 +1273,7 @@ describe("Deposit page — three-step flow", () => {
   });
 });
 
-describe("Deposit page — completed (claimed) deposit terminal state", () => {
+describe("Deposit page — completed (claimed) deposit reset", () => {
   beforeEach(() => {
     mockDirection = "deposit";
     localStorage.clear();
@@ -1302,85 +1302,56 @@ describe("Deposit page — completed (claimed) deposit terminal state", () => {
     created_at: new Date().toISOString(),
   };
 
-  // Regression: a deposit that has settled to `Completed` (e.g. on reload after
-  // claiming) must NOT collapse the flow back to its initial form. Previously
-  // the active-request filter kept only Pending* statuses, so a Completed
-  // request dropped out and Confirm re-enabled (and Claim flickered during the
-  // API's PendingClaim lag). The Completed request must drive a terminal done
-  // state instead.
-  it("renders the done state (no active Confirm/Claim) when the latest deposit is Completed", async () => {
+  // A deposit that has settled to `Completed` (e.g. on reload after claiming)
+  // returns the form to its initial state — there is no terminal "done" layout
+  // and no "Make another deposit" affordance. Waiting for the active request to
+  // clear before resetting avoids re-enabling Claim during the PendingClaim lag.
+  it("returns to the initial form (idle steps, no done affordance) when the latest deposit is Completed", async () => {
     mockRequestsData = { requests: [COMPLETED_DEPOSIT] };
 
     renderDeposit();
 
     await waitFor(() => {
-      // Steps render as success pills — no actionable Confirm/Claim buttons.
-      expect(screen.queryByRole("button", { name: "Confirm" })).toBeNull();
-      expect(screen.queryByRole("button", { name: "Claim" })).toBeNull();
-      expect(screen.getByLabelText("Confirm complete")).toHaveAttribute(
-        "data-state",
-        "success",
-      );
-      expect(screen.getByLabelText("Claim complete")).toHaveAttribute(
-        "data-state",
-        "success",
-      );
-    });
-    // Reset affordance is offered.
-    expect(screen.getByTestId("make-another-deposit")).toBeInTheDocument();
-  });
-
-  it("locks the amount input to the completed deposit amount", async () => {
-    mockRequestsData = { requests: [COMPLETED_DEPOSIT] };
-
-    renderDeposit();
-
-    await waitFor(() => {
-      const input = screen.getByRole("textbox", {
-        name: /USDC amount/i,
-      }) as HTMLInputElement;
-      // 2000000000 raw at 6 dp = 2000.00.
-      expect(input.value).toBe("2000.00");
-      expect(input).toBeDisabled();
-    });
-  });
-
-  it("'Make another deposit' resets the form and restores an actionable flow", async () => {
-    mockRequestsData = { requests: [COMPLETED_DEPOSIT] };
-
-    const user = userEvent.setup();
-    renderDeposit();
-
-    const resetBtn = await screen.findByTestId("make-another-deposit");
-    await user.click(resetBtn);
-
-    await waitFor(() => {
-      // Done state dismissed — reset button gone, Confirm available again.
-      expect(screen.queryByTestId("make-another-deposit")).toBeNull();
+      // Steps reset to idle: actionable buttons render, not success pills.
       expect(
         screen.getByRole("button", { name: "Confirm" }),
       ).toBeInTheDocument();
-      // Input cleared so the user can enter a fresh amount.
+      expect(screen.getByRole("button", { name: "Claim" })).toBeInTheDocument();
+    });
+    expect(screen.queryByLabelText("Confirm complete")).toBeNull();
+    expect(screen.queryByLabelText("Claim complete")).toBeNull();
+    // No terminal done affordance.
+    expect(screen.queryByTestId("make-another-deposit")).toBeNull();
+  });
+
+  it("clears the amount input (not locked to the completed amount)", async () => {
+    mockRequestsData = { requests: [COMPLETED_DEPOSIT] };
+
+    renderDeposit();
+
+    await waitFor(() => {
       const input = screen.getByRole("textbox", {
         name: /USDC amount/i,
       }) as HTMLInputElement;
+      // Reset to empty so the user can enter a fresh amount.
       expect(input.value).toBe("");
       expect(input).not.toBeDisabled();
     });
   });
 
-  it("still shows the done state even when the post-deposit balance is below the minimum", async () => {
-    // After depositing, the USDC balance can drop below the minimum. The done
-    // state must take precedence over the low-balance banner.
+  it("shows the low-balance banner when the post-deposit balance is below the minimum", async () => {
+    // After depositing, the USDC balance can drop below the minimum. With the
+    // form reset to its initial state, the low-balance banner is the correct
+    // initial affordance.
     seedBaseMocks({ balance: BALANCE_500_RAW, allowance: "10000000000" });
     mockRequestsData = { requests: [COMPLETED_DEPOSIT] };
 
     renderDeposit();
 
     await waitFor(() => {
-      expect(screen.getByTestId("make-another-deposit")).toBeInTheDocument();
+      expect(screen.getByTestId("low-balance-banner")).toBeInTheDocument();
     });
-    expect(screen.queryByTestId("low-balance-banner")).toBeNull();
+    expect(screen.queryByTestId("make-another-deposit")).toBeNull();
   });
 });
 
@@ -3062,9 +3033,7 @@ describe("Deposit page — Stellar PLUSD unauthorized trustline guard", () => {
     renderDepositStellar();
 
     await waitFor(() => {
-      expect(
-        screen.getByRole("button", { name: "Claim" }),
-      ).not.toBeDisabled();
+      expect(screen.getByRole("button", { name: "Claim" })).not.toBeDisabled();
     });
     // Normal label shown.
     await waitFor(() => {
@@ -3101,14 +3070,12 @@ describe("Deposit page — Stellar PLUSD unauthorized trustline guard", () => {
 
     // The withdraw Claim button must NOT be disabled due to PLUSD auth state.
     await waitFor(() => {
-      expect(
-        screen.getByRole("button", { name: "Claim" }),
-      ).not.toBeDisabled();
+      expect(screen.getByRole("button", { name: "Claim" })).not.toBeDisabled();
     });
   });
 });
 
-describe("Deposit page — Stellar completed (claimed) deposit terminal state", () => {
+describe("Deposit page — Stellar completed (claimed) deposit reset", () => {
   beforeEach(() => {
     mockDirection = "deposit";
     localStorage.clear();
@@ -3126,10 +3093,10 @@ describe("Deposit page — Stellar completed (claimed) deposit terminal state", 
     localStorage.clear();
   });
 
-  // Regression for the reported bug: on Stellar, after claiming a deposit the
-  // request settles to `Completed`. The flow must show the done state rather
-  // than re-enabling Confirm (or, during the API's PendingClaim lag, Claim).
-  it("shows the done state with a reset affordance when the latest deposit is Completed", async () => {
+  // On Stellar, after claiming a deposit the request settles to `Completed`.
+  // The form returns to its initial state — a fresh Confirm, no terminal "done"
+  // affordance, and a cleared input — instead of staying pinned on success.
+  it("returns to the initial form when the latest deposit is Completed", async () => {
     seedStellarMocks({
       usdcBalance: "5000",
       sacPlusdBalance: SAC_1000_PLUS, // PLUSD trustline present
@@ -3150,10 +3117,17 @@ describe("Deposit page — Stellar completed (claimed) deposit terminal state", 
     renderDepositStellar();
 
     await waitFor(() => {
-      // No actionable Confirm/Claim — the steps are success pills.
-      expect(screen.queryByRole("button", { name: "Confirm" })).toBeNull();
-      expect(screen.queryByRole("button", { name: "Claim" })).toBeNull();
-      expect(screen.getByTestId("make-another-deposit")).toBeInTheDocument();
+      // A fresh Confirm is rendered for a new deposit; no done affordance.
+      expect(
+        screen.getByRole("button", { name: "Confirm" }),
+      ).toBeInTheDocument();
     });
+    expect(screen.queryByTestId("make-another-deposit")).toBeNull();
+    // Input reset to empty so a fresh amount can be entered.
+    const input = screen.getByRole("textbox", {
+      name: /USDC amount/i,
+    }) as HTMLInputElement;
+    expect(input.value).toBe("");
+    expect(input).not.toBeDisabled();
   });
 });

--- a/packages/frontend/src/routes/deposit.tsx
+++ b/packages/frontend/src/routes/deposit.tsx
@@ -100,8 +100,8 @@ function Deposit() {
   // ── Local state ───────────────────────────────────────────────────────
   const [amountInput, setAmountInput] = useState("");
   const [copied, setCopied] = useState(false);
-  // `request_id` of a completed deposit the user dismissed via "Make another
-  // deposit". Suppresses the done state so a fresh deposit can be entered.
+  // `request_id` of a completed deposit the page has already reset for. Gates
+  // the auto-reset effect so it fires once per completed deposit.
   const [dismissedDepositId, setDismissedDepositId] = useState<
     string | undefined
   >(undefined);
@@ -135,11 +135,23 @@ function Deposit() {
   // Render nothing only during the initial load, before data first resolves.
   const isInitialDataLoad = flow.isDataPending && !hasLoadedDataRef.current;
 
-  // ── "Make another deposit" — dismiss the completed deposit, reset the form ─
-  const onMakeAnotherDeposit = useCallback(() => {
-    setDismissedDepositId(flow.depositCompletedRequestId);
-    setAmountInput("");
-  }, [flow.depositCompletedRequestId]);
+  // ── Auto-reset once a deposit settles to `Completed` ──────────────────
+  // There is no terminal "done" state: when the latest deposit completes the
+  // form returns to its initial state so a fresh deposit can start. Dismiss the
+  // completed request (so this fires once), clear the input, and reset the
+  // request/claim mutations.
+  const {
+    isDepositCompleted,
+    depositCompletedRequestId,
+    reset: resetFlow,
+  } = flow;
+  useEffect(() => {
+    if (isDepositCompleted) {
+      setDismissedDepositId(depositCompletedRequestId);
+      setAmountInput("");
+      resetFlow();
+    }
+  }, [isDepositCompleted, depositCompletedRequestId, resetFlow]);
 
   // ── Connect modal (shared single instance via ConnectModalProvider) ───
   const { open: openConnectModal } = useConnectModal();
@@ -501,8 +513,7 @@ function Deposit() {
         ) : isInitialDataLoad /* First load only: chain data / requests API still loading — render nothing until first resolved (avoids re-hide flicker on background refetches). */ ? null : isStellar &&
           isDeposit &&
           usdcTrustline?.needsTrustline &&
-          flow.hasBalance === false &&
-          !flow.isDepositCompleted ? (
+          flow.hasBalance === false ? (
           /* No USDC trustline (Stellar deposit, no USDC balance) — must be
              established before the account can hold or deposit USDC. Takes the
              place of the low-balance banner; same layout, but the action adds
@@ -539,9 +550,7 @@ function Deposit() {
               {usdcTrustline?.enabling ? "Adding…" : "Add trustline"}
             </Button>
           </Card>
-        ) : isDeposit &&
-          flow.hasBalance === false &&
-          !flow.isDepositCompleted ? (
+        ) : isDeposit && flow.hasBalance === false ? (
           /* Insufficient-balance banner — deposit only. Figma: node 1825-10214. */
           <Card
             variant="yellow"
@@ -659,21 +668,6 @@ function Deposit() {
             ]}
           />
         )}
-
-        {/* "Make another deposit" — shown once the latest deposit is claimed
-            (Completed). Resets the form so a fresh deposit can be started. */}
-        {flow.isConnected &&
-          !isInitialDataLoad &&
-          flow.isDepositCompleted && (
-            <Button
-              data-testid="make-another-deposit"
-              variant="primary-dark"
-              className="w-full"
-              onClick={onMakeAnotherDeposit}
-            >
-              Make another deposit
-            </Button>
-          )}
       </main>
     </div>
   );

--- a/packages/frontend/src/wallet/useDepositFlow.ts
+++ b/packages/frontend/src/wallet/useDepositFlow.ts
@@ -160,16 +160,25 @@ export interface FlowState {
   requestIsConfirmed: boolean;
   isPendingVerification: boolean;
 
-  // ── Completed (claimed) deposit terminal state ────────────────────────
+  // ── Completed (claimed) deposit reset signal ──────────────────────────
   /**
    * True (deposit direction only) when the latest deposit request has settled
-   * to `Completed` and has not been dismissed. Drives the "done" layout: all
-   * steps success, no active Confirm/Claim, input locked to the completed
-   * amount, and a "Make another deposit" reset affordance.
+   * to `Completed` and has not been dismissed. The page reacts by resetting the
+   * form back to its initial state (clears the input, resets the request/claim
+   * mutations) so a fresh deposit can start — there is no terminal "done"
+   * layout. Gated by `depositCompletedRequestId` to fire once per completed
+   * deposit.
    */
   isDepositCompleted: boolean;
-  /** `request_id` of the completed deposit currently shown as done (for dismissal). */
+  /** `request_id` of the completed deposit that triggered the reset (for dismissal). */
   depositCompletedRequestId: string | undefined;
+
+  /**
+   * Resets the active-direction request/claim mutations to their initial state.
+   * Called (with an input clear) when a deposit settles to `Completed` so the
+   * form returns to its initial state instead of staying pinned on success.
+   */
+  reset: () => void;
 
   // ── Steps ──────────────────────────────────────────────────────────────
   step1: StepInfo;
@@ -242,8 +251,8 @@ function parseRequestId(value: string | undefined): bigint | undefined {
  * @param amountBig - Parsed amount from the text input (bigint at active decimals).
  * @param setAmountInput - Input setter (for quick-amount handlers).
  * @param dismissedDepositRequestId - `request_id` of a `Completed` deposit the
- *   user has dismissed via "Make another deposit". When it matches the latest
- *   completed deposit, the done state is suppressed so a fresh deposit can start.
+ *   page has already reacted to. When it matches the latest completed deposit,
+ *   `isDepositCompleted` is suppressed so the reset fires only once.
  */
 export function useDepositFlow(
   direction: Direction,
@@ -375,9 +384,9 @@ export function useDepositFlow(
 
   // Most-recent claimed deposit. The active-request filter above keeps only
   // `PendingVerification`/`PendingClaim`, so a claimed request settles to
-  // `Completed` and drops out of that set. We track it separately to drive the
-  // terminal "done" state instead of collapsing back to the initial form (which
-  // re-enabled Confirm and, during the API's PendingClaim lag, Claim).
+  // `Completed` and drops out of that set. We track it separately so the page
+  // can reset the form once the deposit settles (waiting for the active request
+  // to clear avoids re-enabling Claim during the API's PendingClaim lag).
   const evmDepositCompletedRequest =
     requestsData?.requests
       .filter((r) => r.type === "Deposit" && r.status === "Completed")
@@ -386,8 +395,8 @@ export function useDepositFlow(
           new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
       )[0] ?? null;
 
-  // Terminal done state: the latest deposit is `Completed` (no newer Pending*
-  // request) and the user has not dismissed it via "Make another deposit".
+  // Reset signal: the latest deposit is `Completed` (no newer Pending* request)
+  // and the page has not yet reacted to it.
   const evmDepositIsCompleted =
     evmDepositActiveRequest === null &&
     evmDepositCompletedRequest !== null &&
@@ -446,8 +455,8 @@ export function useDepositFlow(
       )[0] ?? null;
 
   // Most-recent claimed deposit (settled to `Completed`). Tracked separately so
-  // the flow can show a terminal "done" state instead of collapsing back to the
-  // initial form once the claimed request drops out of the active set.
+  // the page can reset the form once the claimed request drops out of the active
+  // set (waiting for that avoids re-enabling Claim during the PendingClaim lag).
   const stellarDepositCompletedRequest =
     requestsData?.requests
       .filter((r) => r.type === "Deposit" && r.status === "Completed")
@@ -456,8 +465,8 @@ export function useDepositFlow(
           new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
       )[0] ?? null;
 
-  // Terminal done state: the latest deposit is `Completed` (no newer Pending*
-  // request) and the user has not dismissed it via "Make another deposit".
+  // Reset signal: the latest deposit is `Completed` (no newer Pending* request)
+  // and the page has not yet reacted to it.
   const stellarDepositIsCompleted =
     stellarDepositActiveRequest === null &&
     stellarDepositCompletedRequest !== null &&
@@ -734,8 +743,7 @@ export function useDepositFlow(
       evmDepositMeetsMin &&
       !evmDepositNeedsApproval &&
       !evmRequestDeposit.isPending &&
-      !evmDepositRequestIsConfirmed &&
-      !evmDepositIsCompleted;
+      !evmDepositRequestIsConfirmed;
     const canEvmClaimDeposit =
       isEvmConnected &&
       evmDepositRequestId !== undefined &&
@@ -770,21 +778,17 @@ export function useDepositFlow(
       : canEvmConfirmWithdraw;
     const canEvmClaim = isDeposit ? canEvmClaimDeposit : canEvmClaimWithdraw;
 
-    // Step states. When the deposit is completed (claimed) every step reads as
-    // success — the StepsCard then renders success pills instead of actionable
-    // buttons.
+    // Step states.
     const evmDepositStep1State: StepState =
-      evmDepositIsCompleted ||
       (!evmDepositNeedsApproval && amountBig > 0n && isEvmConnected) ||
       evmDepositRequestIsConfirmed
         ? "success"
         : "idle";
     const evmDepositStep2State: StepState =
-      evmDepositIsCompleted || evmDepositIsPendingClaim || evmClaim.isSuccess
-        ? "success"
-        : "idle";
-    const evmDepositStep3State: StepState =
-      evmDepositIsCompleted || evmClaim.isSuccess ? "success" : "idle";
+      evmDepositIsPendingClaim || evmClaim.isSuccess ? "success" : "idle";
+    const evmDepositStep3State: StepState = evmClaim.isSuccess
+      ? "success"
+      : "idle";
 
     const evmWithdrawStep1State: StepState =
       (evmHasSufficientWithdrawAllowance && isEvmConnected) ||
@@ -856,17 +860,11 @@ export function useDepositFlow(
       hasBalance: evmHasBalance,
       meetsMin: evmMeetsMin,
       isDataPending: evmIsDataPending,
-      isAmountLocked:
-        evmActiveRequest !== null || (isDeposit && evmDepositIsCompleted),
+      isAmountLocked: evmActiveRequest !== null,
       lockedAmountRaw:
         evmActiveRequest !== null && evmDecimals !== undefined
           ? BigInt(evmActiveRequest.amount)
-          : isDeposit &&
-              evmDepositIsCompleted &&
-              evmDepositCompletedRequest !== null &&
-              evmDecimals !== undefined
-            ? BigInt(evmDepositCompletedRequest.amount)
-            : undefined,
+          : undefined,
       requestId: evmRequestId,
       requestIsConfirmed: evmRequestIsConfirmed,
       isPendingVerification: evmIsPendingVerification,
@@ -875,6 +873,15 @@ export function useDepositFlow(
         isDeposit && evmDepositIsCompleted
           ? (evmDepositCompletedRequest?.request_id ?? undefined)
           : undefined,
+      reset: () => {
+        if (isDeposit) {
+          evmRequestDeposit.reset();
+          evmClaim.reset();
+        } else {
+          evmRequestWithdrawal.reset();
+          evmClaimWithdrawal.reset();
+        }
+      },
       step1: {
         label: isDeposit
           ? "Allow Pipeline to use USDC"
@@ -1029,14 +1036,9 @@ export function useDepositFlow(
     ? stellarDepositStep1State
     : stellarWithdrawStep1State;
 
-  // Step 2 state (request). A completed (claimed) deposit reads as success so
-  // the StepsCard renders a success pill instead of an actionable Confirm.
+  // Step 2 state (request).
   const stellarDepositStep2State: StepState =
-    stellarDepositIsCompleted ||
-    stellarDepositIsPendingClaim ||
-    stellarClaim.isSuccess
-      ? "success"
-      : "idle";
+    stellarDepositIsPendingClaim || stellarClaim.isSuccess ? "success" : "idle";
   const stellarWithdrawStep2State: StepState =
     stellarWithdrawIsPendingClaim || stellarClaimWithdrawal.isSuccess
       ? "success"
@@ -1047,7 +1049,7 @@ export function useDepositFlow(
 
   // Step 3 state (claim)
   const stellarStep3State: StepState = isDeposit
-    ? stellarDepositIsCompleted || stellarClaim.isSuccess
+    ? stellarClaim.isSuccess
       ? "success"
       : "idle"
     : stellarClaimWithdrawal.isSuccess
@@ -1078,8 +1080,7 @@ export function useDepositFlow(
     stellarHasBalance === true &&
     bothTrustlinesReady &&
     !stellarRequestDeposit.isPending &&
-    !stellarDepositRequestIsConfirmed &&
-    !stellarDepositIsCompleted;
+    !stellarDepositRequestIsConfirmed;
   const canStellarStep2Withdraw =
     isStellarConnected &&
     stellarCanWithdraw &&
@@ -1187,18 +1188,13 @@ export function useDepositFlow(
     hasBalance: stellarHasBalance,
     meetsMin: stellarMeetsMin,
     isDataPending: stellarIsDataPending,
-    isAmountLocked:
-      stellarRequestIsConfirmed || (isDeposit && stellarDepositIsCompleted),
+    isAmountLocked: stellarRequestIsConfirmed,
     lockedAmountRaw:
       stellarActiveRequest?.amount !== undefined
         ? BigInt(stellarActiveRequest.amount)
         : stellarInflight?.amount !== undefined
           ? BigInt(stellarInflight.amount)
-          : isDeposit &&
-              stellarDepositIsCompleted &&
-              stellarDepositCompletedRequest?.amount !== undefined
-            ? BigInt(stellarDepositCompletedRequest.amount)
-            : undefined,
+          : undefined,
     requestId: stellarRequestId,
     requestIsConfirmed: stellarRequestIsConfirmed,
     isPendingVerification: stellarIsPendingVerification,
@@ -1207,6 +1203,15 @@ export function useDepositFlow(
       isDeposit && stellarDepositIsCompleted
         ? (stellarDepositCompletedRequest?.request_id ?? undefined)
         : undefined,
+    reset: () => {
+      if (isDeposit) {
+        stellarRequestDeposit.reset();
+        stellarClaim.reset();
+      } else {
+        stellarRequestWithdrawal.reset();
+        stellarClaimWithdrawal.reset();
+      }
+    },
     step1: {
       label: isDeposit ? "Enable PLUSD" : "Enable USDC",
       actionLabel: "Enable",


### PR DESCRIPTION
## What

Removes the terminal "Make another deposit" done-state. When a deposit settles to `Completed`, the form returns to its initial state instead of staying pinned on a success layout with a reset button.

## Why

The done-state required an explicit "Make another deposit" tap to start a fresh deposit. The desired behavior is for the form to simply return to its initial state once a deposit completes.

## Changes

**`wallet/useDepositFlow.ts`**
- Dropped `isDepositCompleted` from all step-state, gate, and amount-lock logic (EVM + Stellar) — no more "all steps success / input locked to completed amount" layout.
- Added `reset()` to `FlowState`, which resets the active-direction request/claim mutations.
- Kept the completed-deposit detection (`isDepositCompleted` / `depositCompletedRequestId`), now repurposed as a one-shot reset *signal*. It still waits for the active request to clear before firing, so Claim can't flicker during the API's PendingClaim lag.

**`routes/deposit.tsx`**
- Replaced the "Make another deposit" button + callback with an effect that dismisses the completed request (fire-once), clears the input, and calls `flow.reset()`.
- Removed the `!flow.isDepositCompleted` guards on the low-balance / trustline banners, so a below-minimum post-deposit balance correctly shows the low-balance banner in the reset state.

**`routes/-deposit.test.tsx`**
- Rewrote the EVM and Stellar "terminal state" suites to assert the new behavior: idle steps, fresh `Confirm`, cleared/editable input, no `make-another-deposit`, low-balance banner when applicable.

## Verification

- Deposit route tests: 107/107
- Wallet + route suites: 565/565
- `tsc -b` clean, eslint clean (no warnings), prettier clean
- Pre-existing unrelated failure (`PortfolioPlaceholderCard` chart tooltip) confirmed failing on a clean checkout, untouched here.