### PR TITLE
Restyle toasts to match Figma

### DIFF
--- a/packages/frontend/src/routes/-test.test.tsx
+++ b/packages/frontend/src/routes/-test.test.tsx
@@ -226,12 +226,12 @@ describe("TestPage — default Status tab", () => {
 
   it("Status tab has no content buttons (read-only — regression for #252)", () => {
     const { container } = renderTestPage("status");
-    // The SegmentedTabs renders two tab buttons (Status + Mocks); only those
-    // should be present on the Status tab. No action buttons (Clear mocks /
-    // Enable) should appear.
+    // The SegmentedTabs renders one button per tab (Status + Mocks + Toasts);
+    // only those should be present on the Status tab. No action buttons (Clear
+    // mocks / Enable) should appear.
     const buttons = container.querySelectorAll("button");
-    // The SegmentedTabs always renders exactly 2 buttons (Status + Mocks).
-    expect(buttons.length).toBe(2);
+    // The SegmentedTabs always renders exactly 3 buttons (Status + Mocks + Toasts).
+    expect(buttons.length).toBe(3);
   });
 
   it("does not render the Write hooks section", () => {

--- a/packages/frontend/src/routes/test.tsx
+++ b/packages/frontend/src/routes/test.tsx
@@ -1,7 +1,8 @@
 /**
  * /test — Diagnostic page.
  *
- * Two-tab layout driven by a TanStack Router search param (`?tab=status|mocks`):
+ * Three-tab layout driven by a TanStack Router search param
+ * (`?tab=status|mocks|toasts`):
  *
  *   - **Status** (default) — the existing read-only sections surfacing runtime
  *     state: ENV, Wallet, DepositManager, USDC balance, ERC-20 approval. No
@@ -10,6 +11,10 @@
  *   - **Mocks** — a global "Clear mocks" button + one scenario card per
  *     meaningful app state. Clicking Enable wipes all `pipeline.mock.*` keys,
  *     seeds only the scenario's keys, and reloads the page.
+ *
+ *   - **Toasts** — trigger buttons for every toast flavour (tones,
+ *     actionable, pending→resolved lifecycle, custom icon) so the restyled
+ *     toasts can be eyeballed on the real site.
  *
  * The active tab is reflected in the URL. Reloading preserves the tab.
  * Invalid `?tab=` values fall back to `"status"`.
@@ -20,6 +25,7 @@
 import React from "react";
 import { createFileRoute } from "@tanstack/react-router";
 import { SegmentedTabs, Button } from "@pipeline/ui";
+import { useToast } from "@/lib/toast";
 import { ENV } from "@/lib/env";
 import {
   useEvmWallet,
@@ -42,11 +48,12 @@ const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 
 // ── Tab type ──────────────────────────────────────────────────────────────────
 
-type TestTab = "status" | "mocks";
+type TestTab = "status" | "mocks" | "toasts";
 
 const TABS = [
   { id: "status", label: "Status" },
   { id: "mocks", label: "Mocks" },
+  { id: "toasts", label: "Toasts" },
 ];
 
 // ── Route ─────────────────────────────────────────────────────────────────────
@@ -54,7 +61,8 @@ const TABS = [
 export const Route = createFileRoute("/test")({
   validateSearch: (raw): { tab: TestTab } => {
     const t = raw.tab;
-    const tab: TestTab = t === "mocks" ? "mocks" : "status";
+    const tab: TestTab =
+      t === "mocks" ? "mocks" : t === "toasts" ? "toasts" : "status";
     return { tab };
   },
   component: TestPage,
@@ -498,6 +506,194 @@ function MocksTab(): React.JSX.Element {
   );
 }
 
+// ── ToastsTab ───────────────────────────────────────────────────────────────
+
+/**
+ * Small token glyph used to demo the `icon` override on a claim toast
+ * (mirrors the PLUSD coin in Figma node 1497:95175).
+ */
+const PlusdGlyph = (
+  <svg
+    viewBox="0 0 20 20"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    aria-hidden="true"
+    className="size-[20px] shrink-0"
+  >
+    <circle cx="10" cy="10" r="10" fill="currentColor" opacity="0.25" />
+    <path
+      d="M10 5v10M7.5 7.5h3.25a1.75 1.75 0 010 3.5H8.75M7.5 11h3.5a1.75 1.75 0 010 3.5H7.5"
+      stroke="currentColor"
+      strokeWidth="1.4"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+/** A labelled group of demo buttons. */
+function ToastGroup({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}): React.JSX.Element {
+  return (
+    <section className="flex flex-col gap-3 border-b border-[color:var(--color-pipeline-line)] pb-6">
+      <h2 className="text-base font-semibold text-[color:var(--color-pipeline-ink)]">
+        {title}
+      </h2>
+      <div className="flex flex-wrap gap-2">{children}</div>
+    </section>
+  );
+}
+
+/** Compact trigger button used throughout the Toasts tab. */
+function ToastButton({
+  onClick,
+  children,
+}: {
+  onClick: () => void;
+  children: React.ReactNode;
+}): React.JSX.Element {
+  return (
+    <Button
+      variant="primary-dark"
+      size="compact"
+      className="text-xs"
+      onClick={onClick}
+    >
+      {children}
+    </Button>
+  );
+}
+
+/**
+ * The Toasts tab — fires every flavour of toast so they can be eyeballed on
+ * the real site (Storybook can't render the Tailwind utilities). Toasts stack
+ * bottom-right; non-pending ones auto-dismiss after 5s, pending ones stick.
+ */
+function ToastsTab(): React.JSX.Element {
+  const toast = useToast();
+
+  // Show a sticky pending toast, then resolve it to `tone`/`title` after 2s —
+  // demonstrates the upsert-by-id lifecycle used by the deposit/stake flows.
+  const showPendingThen = (
+    key: string,
+    tone: "success" | "danger",
+    title: string,
+  ) => {
+    const id = toast.show({
+      id: `demo-${key}`,
+      tone: "pending",
+      title: "Sending…",
+    });
+    window.setTimeout(() => toast.update(id, { tone, title }), 2000);
+  };
+
+  return (
+    <div className="flex flex-col gap-6">
+      <p className="text-sm text-[color:var(--color-pipeline-ink-muted)]">
+        Toasts appear bottom-right. Up to 3 stack at once; non-pending toasts
+        auto-dismiss after 5s.
+      </p>
+
+      <ToastGroup title="Informational (no action)">
+        <ToastButton
+          onClick={() =>
+            toast.show({ tone: "neutral", title: "Neutral notification" })
+          }
+        >
+          neutral
+        </ToastButton>
+        <ToastButton
+          onClick={() =>
+            toast.show({ tone: "success", title: "You staked 1,000.00 PLUSD" })
+          }
+        >
+          success
+        </ToastButton>
+        <ToastButton
+          onClick={() => toast.show({ tone: "danger", title: "Claim failed" })}
+        >
+          danger
+        </ToastButton>
+        <ToastButton
+          onClick={() => toast.show({ tone: "pending", title: "Claiming…" })}
+        >
+          pending (sticky)
+        </ToastButton>
+      </ToastGroup>
+
+      <ToastGroup title="Actionable (with button)">
+        <ToastButton
+          onClick={() =>
+            toast.show({
+              tone: "success",
+              title: "+1,000.00 PLUSD",
+              action: {
+                label: "Stake",
+                onClick: () =>
+                  toast.show({ tone: "neutral", title: "Stake clicked" }),
+              },
+            })
+          }
+        >
+          success + Stake
+        </ToastButton>
+        <ToastButton
+          onClick={() =>
+            toast.show({
+              tone: "neutral",
+              title: "Deposit submitted",
+              action: {
+                label: "View",
+                onClick: () =>
+                  toast.show({ tone: "neutral", title: "View clicked" }),
+              },
+            })
+          }
+        >
+          neutral + View
+        </ToastButton>
+      </ToastGroup>
+
+      <ToastGroup title="Lifecycle (pending → resolved)">
+        <ToastButton
+          onClick={() => showPendingThen("ok", "success", "Deposit submitted")}
+        >
+          pending → success
+        </ToastButton>
+        <ToastButton
+          onClick={() => showPendingThen("err", "danger", "Deposit failed")}
+        >
+          pending → danger
+        </ToastButton>
+      </ToastGroup>
+
+      <ToastGroup title="Custom icon">
+        <ToastButton
+          onClick={() =>
+            toast.show({
+              tone: "success",
+              title: "+1,000.00 PLUSD",
+              icon: PlusdGlyph,
+              action: {
+                label: "Stake",
+                onClick: () =>
+                  toast.show({ tone: "neutral", title: "Stake clicked" }),
+              },
+            })
+          }
+        >
+          claim toast (token icon + Stake)
+        </ToastButton>
+      </ToastGroup>
+    </div>
+  );
+}
+
 // ── Page component ────────────────────────────────────────────────────────────
 
 function TestPage(): React.JSX.Element {
@@ -515,7 +711,13 @@ function TestPage(): React.JSX.Element {
 
         <SegmentedTabs tabs={TABS} activeId={tab} onSelect={setTab} />
 
-        {tab === "status" ? <StatusTab /> : <MocksTab />}
+        {tab === "status" ? (
+          <StatusTab />
+        ) : tab === "mocks" ? (
+          <MocksTab />
+        ) : (
+          <ToastsTab />
+        )}
       </main>
     </div>
   );

--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -3,15 +3,16 @@ import React from "react";
 /**
  * Button — Pipeline UI primitive.
  *
- * Five variants, matching the Figma frame 1497-94556 and toast spec 1497:95109:
+ * Five variants, matching the Figma frame 1497-94556 and toast spec 1497:95175:
  *   - `primary-dark`  — black filled rectangle (e.g. "Connect Wallet" in header)
  *   - `primary-blue`  — navy/cobalt filled rectangle (e.g. "Connect", "Buy")
  *   - `secondary`     — ghost/outlined rectangle (e.g. "Sell" in disabled state —
  *                        transparent fill, ink-primary label, ~0.32 opacity when
  *                        used with the `disabled` prop). Figma nodes 1497:94688–90.
  *   - `circular-blue` — round navy/cobalt CTA (e.g. "Stake")
- *   - `toast-action`  — compact pill CTA for right-aligned actions inside toasts
- *                        (Figma node 1497:95109). White fill, ink text, 32 px tall.
+ *   - `toast-action`  — compact CTA for right-aligned actions inside toasts
+ *                        (Figma node 1497:95175). White fill, ink text, 32 px tall,
+ *                        4 px radius, Body Emphasized label.
  *
  * All variants use design tokens from `@pipeline/ui/styles/theme.css`
  * (no raw colors). Label uses the Body Emphasized type style (Graphik LC
@@ -122,17 +123,17 @@ const variantClasses: Record<ButtonVariant, string> = {
     "disabled:hover:bg-[var(--color-pipeline-brand)]",
   ].join(" "),
 
-  // toast-action — 32px compact pill, white fill, ink text.
-  // Used inside Toast pills for right-aligned follow-up actions (Figma 1497:95109).
+  // toast-action — 32px compact button, white fill, ink text.
+  // Used inside Toast notifications for right-aligned follow-up actions
+  // (Figma node 1497:95175 — "Stake" CTA). 4px radius (radius/radius-s) and
+  // Body Emphasized label (16/22, weight 600, inherited from baseClasses).
   // Inherits the toast's outer surface as focus-ring backdrop — no explicit
   // offset-color needed because the toast background is always dark/coloured.
   "toast-action": [
-    "h-8 min-w-8 px-3",
-    "rounded-[var(--radius-pipeline-pill)]",
+    "h-8 min-w-8 px-2.5",
+    "rounded-[var(--radius-pipeline-button)]",
     "bg-white",
     "text-[color:var(--color-pipeline-ink)]",
-    "text-[length:var(--text-pipeline-caption)]",
-    "leading-[var(--text-pipeline-caption--line-height)]",
     "hover:bg-[color-mix(in_oklab,white_90%,var(--color-pipeline-ink))]",
     "active:bg-[color-mix(in_oklab,white_85%,var(--color-pipeline-ink))]",
     "focus-visible:ring-[var(--color-pipeline-ink)]",
@@ -162,7 +163,12 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         ? compactSizeClasses
         : undefined;
 
-    const composed = [baseClasses, variantClasses[variant], sizeOverride, className]
+    const composed = [
+      baseClasses,
+      variantClasses[variant],
+      sizeOverride,
+      className,
+    ]
       .filter(Boolean)
       .join(" ");
 

--- a/packages/ui/src/components/Toast/Toast.stories.tsx
+++ b/packages/ui/src/components/Toast/Toast.stories.tsx
@@ -9,12 +9,12 @@ const meta = {
     docs: {
       description: {
         component:
-          "Pipeline UI Toast notification pill. Two visual shapes: " +
+          "Pipeline UI Toast notification — a 4px-radius surface with a 20px " +
+          "leading icon and Body-weight title. Two visual shapes: " +
           "**Informational** (icon + title, auto-dismissed) and " +
           "**Actionable** (icon + title + right-aligned action button). " +
-          "Four tones: `neutral` (dark), `success` (green), `danger` (red), `pending` (muted). " +
-          "Figma: Informational node 1497:95187, Actionable node 1497:95109, " +
-          "Base shape node 6860:833 (eq-lib).",
+          "Four tones: `neutral` (dark), `success` (green #208000), `danger` (red), `pending` (muted). " +
+          "Figma: success/actionable node 1497:95175, success/informational node 1497:95270.",
       },
     },
   },
@@ -101,7 +101,8 @@ export const CustomIcon: Story = {
   parameters: {
     docs: {
       description: {
-        story: "Demonstrates the `icon` prop override — any ReactNode replaces the default per-tone icon.",
+        story:
+          "Demonstrates the `icon` prop override — any ReactNode replaces the default per-tone icon.",
       },
     },
   },
@@ -138,7 +139,8 @@ export const AllVariants: Story = {
     layout: "fullscreen",
     docs: {
       description: {
-        story: "Matrix showing all four tones × informational and actionable variants.",
+        story:
+          "Matrix showing all four tones × informational and actionable variants.",
       },
     },
   },
@@ -154,9 +156,17 @@ export const AllVariants: Story = {
       }}
     >
       <Toast tone="neutral" title="You staked 1,000.00 PLUSD" />
-      <Toast tone="neutral" title="Deposit submitted" action={{ label: "View", onClick: () => {} }} />
+      <Toast
+        tone="neutral"
+        title="Deposit submitted"
+        action={{ label: "View", onClick: () => {} }}
+      />
       <Toast tone="success" title="Deposit confirmed" />
-      <Toast tone="success" title="+1,000.00 PLUSD" action={{ label: "Stake", onClick: () => {} }} />
+      <Toast
+        tone="success"
+        title="+1,000.00 PLUSD"
+        action={{ label: "Stake", onClick: () => {} }}
+      />
       <Toast tone="danger" title="Deposit failed" />
       <Toast tone="danger" title="Claim failed" />
       <Toast tone="pending" title="Sending…" />

--- a/packages/ui/src/components/Toast/Toast.tsx
+++ b/packages/ui/src/components/Toast/Toast.tsx
@@ -2,29 +2,30 @@ import React from "react";
 import { Button } from "../Button/Button";
 
 /**
- * Toast — Pipeline UI notification pill.
+ * Toast — Pipeline UI notification.
  *
- * Two visual shapes:
- *   - **Informational** — pill with leading icon + title text.
- *   - **Actionable** — same pill plus a right-aligned action button.
+ * A near-rectangular surface (4px radius) with 16px padding, a 20px leading
+ * icon, and a Body-weight title. Two visual shapes:
+ *   - **Informational** — icon + title text.
+ *   - **Actionable** — same surface plus a right-aligned action button.
  *
  * Four tones, each mapping to a `--color-pipeline-*` fill token:
  *   - `neutral`  → `--color-pipeline-ink` (dark)
- *   - `success`  → `--color-pipeline-success` (green)
+ *   - `success`  → `--color-pipeline-positive-primary` (green #208000)
  *   - `danger`   → `--color-pipeline-danger` (red)
  *   - `pending`  → `--color-pipeline-ink-muted` (muted)
  *
- * Default icons: `check-circle.svg` for neutral/success/danger; `clock-pending.svg`
- * for pending. Pass the `icon` prop to override.
+ * Default icons: a plain checkmark for `success`, `check-circle` for
+ * neutral/danger, and `clock-pending` for `pending`. Pass the `icon` prop to
+ * override (e.g. a token glyph for a claim toast).
  *
  * A11y:
  *   - `role="alert"` + `aria-live="assertive"` for `danger`.
  *   - `role="status"` + `aria-live="polite"` for all other tones.
  *
  * Figma references:
- *   - Informational — node 1497:95187
- *   - Actionable — node 1497:95109
- *   - Base shape (eq-lib) — node 6860:833
+ *   - Success (claim, actionable) — node 1497:95175
+ *   - Success (stake, informational) — node 1497:95270
  */
 
 export type ToastTone = "neutral" | "success" | "danger" | "pending";
@@ -34,8 +35,10 @@ export interface ToastAction {
   onClick: () => void;
 }
 
-export interface ToastProps
-  extends Omit<React.HTMLAttributes<HTMLDivElement>, "title"> {
+export interface ToastProps extends Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  "title"
+> {
   /** Tone controls background color and default icon. Default: "neutral". */
   tone?: ToastTone;
   /** Title text shown next to the leading icon. */
@@ -50,15 +53,36 @@ export interface ToastProps
 }
 
 // SVG icons inlined so the component is self-contained without an asset bundler.
-// Viewbox: 16.6667 × 16.6667 — matches the existing icon assets in packages/ui/src/assets/icons/.
+// Rendered at 20px to match the restyled toast (Figma node 1497:95270).
 
+// Plain checkmark — default for the `success` tone (Figma node 1497:95270).
+const CheckIcon = (
+  <svg
+    viewBox="0 0 20 20"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    aria-hidden="true"
+    className="size-[20px] shrink-0"
+  >
+    <path
+      d="M4.5 10.5L8 14L15.5 6"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+// Circle-enclosed check — default for neutral/danger tones.
+// Viewbox: 16.6667 × 16.6667 — matches the existing icon assets in packages/ui/src/assets/icons/.
 const CheckCircleIcon = (
   <svg
     viewBox="0 0 16.6667 16.6667"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
     aria-hidden="true"
-    className="size-[16px] shrink-0"
+    className="size-[20px] shrink-0"
   >
     <path
       fillRule="evenodd"
@@ -75,7 +99,7 @@ const ClockPendingIcon = (
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
     aria-hidden="true"
-    className="size-[16px] shrink-0"
+    className="size-[20px] shrink-0"
   >
     <path
       fillRule="evenodd"
@@ -89,7 +113,7 @@ const ClockPendingIcon = (
 // Background class per tone. All values reference design tokens from theme.css.
 const toneBackground: Record<ToastTone, string> = {
   neutral: "bg-[var(--color-pipeline-ink)]",
-  success: "bg-[var(--color-pipeline-success)]",
+  success: "bg-[var(--color-pipeline-positive-primary)]",
   danger: "bg-[var(--color-pipeline-danger)]",
   // ink-muted is rgba — Tailwind can't apply it directly with bg- utility; use inline style
   pending: "bg-[rgb(56_55_53_/_0.6)]",
@@ -105,22 +129,25 @@ export const Toast = React.forwardRef<HTMLDivElement, ToastProps>(
     const ariaLive = isDanger ? "assertive" : "polite";
 
     const defaultIcon =
-      tone === "pending" ? ClockPendingIcon : CheckCircleIcon;
+      tone === "pending"
+        ? ClockPendingIcon
+        : tone === "success"
+          ? CheckIcon
+          : CheckCircleIcon;
     const leadingIcon = icon ?? defaultIcon;
 
     const bgClass = toneBackground[tone];
 
     const containerClasses = [
-      "inline-flex items-center gap-3 px-4 py-2",
-      "rounded-[var(--radius-pipeline-pill)]",
+      "inline-flex items-center p-4",
+      "rounded-[var(--radius-pipeline-card)]",
       "shadow-sm",
-      "h-10",
       bgClass,
-      "text-[color:#ffffff]",
+      "text-[color:var(--color-pipeline-on-dark)]",
       "font-[family-name:var(--font-body)]",
       "text-[length:var(--text-pipeline-body)]",
       "leading-[var(--text-pipeline-body--line-height)]",
-      "font-[var(--font-weight-emphasized)]",
+      "font-[var(--font-weight-regular)]",
       className,
     ]
       .filter(Boolean)
@@ -135,17 +162,16 @@ export const Toast = React.forwardRef<HTMLDivElement, ToastProps>(
         {...rest}
       >
         {/* Leading icon */}
-        <span className="shrink-0 text-[color:#ffffff]">{leadingIcon}</span>
+        <span className="shrink-0 text-[color:var(--color-pipeline-on-dark)]">
+          {leadingIcon}
+        </span>
 
-        {/* Title */}
-        <span className="shrink-0 whitespace-nowrap">{title}</span>
+        {/* Title — 8px horizontal padding provides the gap to the icon/button */}
+        <span className="shrink-0 px-2 whitespace-nowrap">{title}</span>
 
         {/* Action button — right-aligned, only when provided */}
         {action && (
-          <Button
-            variant="toast-action"
-            onClick={action.onClick}
-          >
+          <Button variant="toast-action" onClick={action.onClick}>
             {action.label}
           </Button>
         )}

--- a/packages/ui/src/styles/theme.css
+++ b/packages/ui/src/styles/theme.css
@@ -92,6 +92,7 @@
   --color-pipeline-on-warning: #ffffff; /* content on warning fill */
   --color-pipeline-danger: #c0392b; /* fill/danger — error toast bg; base shape node 6860:833 */
   --color-pipeline-on-danger: #ffffff; /* content on danger fill */
+  --color-pipeline-positive-primary: #208000; /* fill/positive-primary — success toast bg; node 1497:95270 */
   --color-pipeline-positive-secondary: rgb(
     32 128 0 / 0.16
   ); /* fill/positive-secondary — step done pill bg; node 1497-95272 */
@@ -167,6 +168,7 @@
   --color-pipeline-on-warning: #ffffff; /* content on warning fill */
   --color-pipeline-danger: #c0392b; /* fill/danger — error toast bg; base shape node 6860:833 */
   --color-pipeline-on-danger: #ffffff; /* content on danger fill */
+  --color-pipeline-positive-primary: #208000; /* fill/positive-primary — success toast bg; node 1497:95270 */
   --color-pipeline-positive-secondary: rgb(
     32 128 0 / 0.16
   ); /* fill/positive-secondary — step done pill bg; node 1497-95272 */


### PR DESCRIPTION
## Summary
Restyle the Toast component to the new Figma design (frames [1497:95175](https://www.figma.com/design/A43rjYYjSwdTmiwwf5cx5n/Pipeline?node-id=1497-95175) claim and [1497:95270](https://www.figma.com/design/A43rjYYjSwdTmiwwf5cx5n/Pipeline?node-id=1497-95270) stake):

- Full-pill → **4px radius** surface; `px-4 py-2` + fixed `h-10` → uniform **16px padding**, content-driven height
- Leading icon **16px → 20px**; `success` default icon is now a **plain checkmark** (matches the stake frame)
- Title weight **emphasized → regular**
- `success` fill **#3a7d44 → #208000** via new `--color-pipeline-positive-primary` token
- `toast-action` button: pill + 12px caption → **4px radius + 16px Body Emphasized** label

## Test page
Added a **Toasts** tab to `/test` (`?tab=toasts`) with trigger buttons for every flavour — tones, actionable (Stake / View), pending→resolved lifecycle, and custom icon — so the toasts can be eyeballed on the real site.

## Verification
- Toast unit tests + full frontend suite pass (the one failing `PortfolioPlaceholderCard` test fails identically on `main` — unrelated)
- `tsc -b`, ESLint, Prettier clean
- Rendered on the live dev server and confirmed success/neutral/pending/actionable variants visually