### PR TITLE
Home stake card: staked state, unstake deep-link, earned PnL

### DIFF
--- a/packages/frontend/src/components/EarnedCard.tsx
+++ b/packages/frontend/src/components/EarnedCard.tsx
@@ -64,10 +64,11 @@ export interface EarnedCardProps extends Omit<
    */
   mobileHomeState?: MobileHomeState;
   /**
-   * Formatted PnL APY label, e.g. `"8.42% p.a."`. When present, this replaces
-   * the placeholder value.
+   * Formatted total PnL in dollars, e.g. `"+$123.00"` (realized + unrealized,
+   * sourced from `GET /v1/pnl` `total_pnl`). When present, this replaces the
+   * placeholder value.
    */
-  avgApyLabel?: string;
+  earnedPnlLabel?: string;
   /**
    * Interior padding forwarded to the `Card` primitive. Defaults to `"lg"`
    * (24px). Set to `"sm"` (8px) on mobile per Figma frame `1989:8292`.
@@ -106,7 +107,7 @@ const valueClasses = [
 
 export const EarnedCard = React.forwardRef<HTMLDivElement, EarnedCardProps>(
   function EarnedCard(
-    { className, mobileHomeState, avgApyLabel, ...rest },
+    { className, mobileHomeState, earnedPnlLabel, ...rest },
     ref,
   ) {
     // Use a unique id per instance to avoid duplicate id attributes when both
@@ -123,14 +124,14 @@ export const EarnedCard = React.forwardRef<HTMLDivElement, EarnedCardProps>(
       .join(" ");
 
     // Determine the display value based on state.
-    // PnL APY, when available, wins over placeholders.
+    // Total PnL (dollars), when available, wins over placeholders.
     // States A/B (empty/plusd) when connected: "Nothing yet".
-    // Disconnected / desktop / State C without APY: tracking placeholder.
+    // Disconnected / desktop / State C without PnL: tracking placeholder.
     let earnedValue: string;
     let valueExtra: string | undefined;
 
-    if (avgApyLabel !== undefined) {
-      earnedValue = avgApyLabel;
+    if (earnedPnlLabel !== undefined) {
+      earnedValue = earnedPnlLabel;
       valueExtra = undefined;
     } else if (mobileHomeState === "empty" || mobileHomeState === "plusd") {
       // States A/B: "Nothing yet" per Figma frames 1988:7074 / 1984:6501.
@@ -141,11 +142,11 @@ export const EarnedCard = React.forwardRef<HTMLDivElement, EarnedCardProps>(
       valueExtra = undefined;
     }
 
-    // PnL APY value classes: use green positive token for the earned value.
+    // PnL value classes: use the green positive token for the earned value.
     // Mobile (base): heading-s-mobile = 18px / 28px (Figma node 1886:46777).
     // Desktop (md+): heading-s = 20px / 28px.
     const stateValueClasses =
-      avgApyLabel !== undefined
+      earnedPnlLabel !== undefined
         ? [
             "font-[family-name:var(--font-display)]",
             "text-[length:var(--text-pipeline-heading-s-mobile)]",

--- a/packages/frontend/src/components/PortfolioPlaceholderCard.tsx
+++ b/packages/frontend/src/components/PortfolioPlaceholderCard.tsx
@@ -268,7 +268,7 @@ export const PortfolioPlaceholderCard = React.forwardRef<
               to={mobileHomeState === "plusd" ? "/stake" : "/deposit"}
               search={
                 mobileHomeState === "plusd"
-                  ? undefined
+                  ? { tab: "stake" as const }
                   : { direction: "deposit" as const }
               }
               className={[

--- a/packages/frontend/src/components/StakeCard.tsx
+++ b/packages/frontend/src/components/StakeCard.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { formatUnits } from "viem";
-import { Button, Card } from "@pipeline/ui";
+import { Button, Card, CoinIcon } from "@pipeline/ui";
 import type { CardPadding } from "@pipeline/ui";
 import { useStats, formatApy } from "@/api";
 
@@ -82,31 +82,46 @@ export interface StakeCardProps extends Omit<
    */
   onStake?: () => void;
   /**
+   * Click handler for the "Unstake" text link shown in the `"splusd"` state.
+   * Expected to navigate to the stake page's Unstake tab
+   * (`/stake?tab=unstake`). Falls back to {@link StakeCardProps.onStake} when
+   * omitted.
+   */
+  onUnstake?: () => void;
+  /**
    * When `true`, the Stake CTA is rendered in its disabled state (per Figma
    * node `1497:95069`). Pass `true` when the connected wallet's PLUSD balance
    * is zero so the button cannot initiate a stake flow with no tokens.
    */
   stakeDisabled?: boolean;
   /**
-   * Mobile-only: connected balance state.
+   * Connected balance state.
    * - `"empty"` (State A): circular CTA disabled, labelled "Nothing to Stake".
    * - `"plusd"` (State B): circular CTA enabled, labelled "Stake".
    * - `"splusd"` (State C): "Staked PLUSD" balance display + "Stake More" CTA
    *   + "Unstake" text link.
-   * When `undefined` the desktop/disconnected appearance is preserved.
+   * When `undefined` the marketing CTA appearance ("Stake PLUSD / Earn X%") is
+   * preserved. The empty/plusd labels are mobile-specific; the `"splusd"`
+   * staked layout is shared by mobile and the desktop dashboard (Figma node
+   * `1497:95217`).
    */
   mobileHomeState?: MobileHomeState;
   /**
-   * Mobile-only: sPLUSD share balance (raw bigint at `splusdDecimals` scale).
-   * Displayed as the top number ("shares") in State C.
+   * sPLUSD share balance (raw bigint at `splusdDecimals` scale). Displayed as
+   * the top number ("shares") in the `"splusd"` state.
    */
   mobileSplusdShares?: bigint;
   /**
-   * Mobile-only: sPLUSD shares converted to PLUSD-equivalent (raw bigint at
-   * `splusdDecimals` scale). Displayed as the sub-line ("X.XX sPLUSD") in
-   * State C.
+   * sPLUSD shares converted to PLUSD-equivalent (raw bigint at `splusdDecimals`
+   * scale). Displayed as the sub-line ("X.XX sPLUSD") in the `"splusd"` state.
    */
   mobileSplusdInPlusd?: bigint;
+  /**
+   * Preformatted USD value of the staked position (e.g. `"$1,000.00"`). When
+   * provided, it is appended to the `"splusd"` sub-line as `· $X.XX` (Figma
+   * node `1497:95226`). Omitted from the sub-line when `undefined`.
+   */
+  splusdUsdValue?: string;
   /**
    * Decimal precision of `mobileSplusdShares` and `mobileSplusdInPlusd`.
    * Defaults to `18` (EVM). Pass `7` for Stellar SAC balances to avoid a
@@ -143,11 +158,13 @@ export const StakeCard = React.forwardRef<HTMLDivElement, StakeCardProps>(
   function StakeCard(
     {
       onStake,
+      onUnstake,
       stakeDisabled,
       className,
       mobileHomeState,
       mobileSplusdShares,
       mobileSplusdInPlusd,
+      splusdUsdValue,
       splusdDecimals = 18,
       ...rest
     },
@@ -232,36 +249,49 @@ export const StakeCard = React.forwardRef<HTMLDivElement, StakeCardProps>(
             >
               {sharesFormatted}
             </p>
-            {/* Sub-line: PLUSD-equivalent */}
-            <p
-              className={[
-                "font-[family-name:var(--font-body)]",
-                "text-[length:var(--text-pipeline-caption)]",
-                "leading-[var(--text-pipeline-caption--line-height)]",
-                "font-[var(--font-weight-regular)]",
-                "text-[color:var(--color-pipeline-ink-muted)]",
-                "m-0",
-              ].join(" ")}
+            {/* Sub-line: sPLUSD coin icon + PLUSD-equivalent + USD value
+                (Figma node 1497:95225 / 1497:95226). */}
+            <div
+              className="flex w-full items-center gap-1"
               data-testid="splusd-in-plusd"
             >
-              {inPlusdFormatted} sPLUSD
-            </p>
+              <CoinIcon
+                token="splusd"
+                size="sm"
+                className="size-4 shrink-0"
+                aria-hidden
+              />
+              <p
+                className={[
+                  "font-[family-name:var(--font-body)]",
+                  "text-[length:var(--text-pipeline-caption)]",
+                  "leading-[var(--text-pipeline-caption--line-height)]",
+                  "font-[var(--font-weight-regular)]",
+                  "text-[color:var(--color-pipeline-ink-muted)]",
+                  "m-0",
+                ].join(" ")}
+              >
+                {inPlusdFormatted} sPLUSD
+                {splusdUsdValue ? ` · ${splusdUsdValue}` : ""}
+              </p>
+            </div>
           </header>
 
-          {/* Bottom section: "Stake More" CTA + "Unstake" text link */}
+          {/* Bottom section: "Unstake" text link (bottom-left) + "Stake More"
+              circular CTA (bottom-right), per Figma node 1497:95228. */}
           <div
-            className="flex w-full flex-col items-end gap-2"
+            className="flex w-full items-end justify-between"
             data-testid="home-stake-actions"
           >
-            {/* "Unstake" text link */}
+            {/* "Unstake" text link — bottom-left. */}
             <button
               type="button"
-              onClick={onStake}
+              onClick={onUnstake ?? onStake}
               className={[
                 "font-[family-name:var(--font-body)]",
-                "text-[length:var(--text-pipeline-caption)]",
-                "leading-[var(--text-pipeline-caption--line-height)]",
-                "font-[var(--font-weight-regular)]",
+                "text-[length:var(--text-pipeline-body)]",
+                "leading-[var(--text-pipeline-body--line-height)]",
+                "font-[var(--font-weight-emphasized)]",
                 "text-[color:var(--color-pipeline-ink-muted)]",
                 "underline-offset-2 hover:underline",
                 "cursor-pointer border-0 bg-transparent p-0",
@@ -270,7 +300,7 @@ export const StakeCard = React.forwardRef<HTMLDivElement, StakeCardProps>(
             >
               Unstake
             </button>
-            {/* "Stake More" circular CTA.
+            {/* "Stake More" circular CTA — bottom-right, label on two lines.
                 Size: 88px on mobile (matching the base Stake button),
                 restoring the default 128px on desktop (md+). */}
             <Button
@@ -281,7 +311,10 @@ export const StakeCard = React.forwardRef<HTMLDivElement, StakeCardProps>(
               data-node-id="1497:94713"
               data-testid="home-stake-more-button"
             >
-              Stake More
+              <span className="flex flex-col items-center leading-[var(--text-pipeline-body--line-height)]">
+                <span>Stake</span>
+                <span>More</span>
+              </span>
             </Button>
           </div>
         </Card>

--- a/packages/frontend/src/routes/-index.test.tsx
+++ b/packages/frontend/src/routes/-index.test.tsx
@@ -94,6 +94,7 @@ const mockPnlData = vi.hoisted(() => ({
   current: undefined as
     | {
         total_unrealized_pnl: string;
+        total_pnl?: string;
         avg_apy?: string | null;
       }
     | undefined,
@@ -358,7 +359,10 @@ describe("Home page — disconnected state", () => {
     await user.click(stakeBtns[0]!);
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith({ to: "/stake" });
+      expect(mockNavigate).toHaveBeenCalledWith({
+        to: "/stake",
+        search: { tab: "stake" },
+      });
     });
   });
 
@@ -386,7 +390,10 @@ describe("Home page — disconnected state", () => {
     await user.click(stakeBtns[0]!);
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith({ to: "/stake" });
+      expect(mockNavigate).toHaveBeenCalledWith({
+        to: "/stake",
+        search: { tab: "stake" },
+      });
     });
   });
 });
@@ -802,23 +809,41 @@ describe("Home page — mobile State C: connected, has sPLUSD", () => {
     });
   });
 
-  it("mobile StakeCard shows 'Stake More' CTA (State C)", async () => {
+  it("StakeCard shows 'Stake More' CTA (State C)", async () => {
+    renderHome();
+    await waitFor(() => {
+      // Rendered on both the mobile stack and the desktop dashboard.
+      expect(
+        screen.getAllByRole("button", { name: "Stake More PLUSD" }).length,
+      ).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  it("StakeCard shows 'Unstake' link (State C)", async () => {
     renderHome();
     await waitFor(() => {
       expect(
-        screen.getByRole("button", { name: "Stake More PLUSD" }),
-      ).toBeInTheDocument();
+        screen.getAllByTestId("unstake-link").length,
+      ).toBeGreaterThanOrEqual(1);
     });
   });
 
-  it("mobile StakeCard shows 'Unstake' link (State C)", async () => {
+  it("clicking 'Unstake' navigates to /stake?tab=unstake (State C)", async () => {
+    const user = userEvent.setup();
     renderHome();
+
+    const links = await screen.findAllByTestId("unstake-link");
+    await user.click(links[0]!);
+
     await waitFor(() => {
-      expect(screen.getByTestId("unstake-link")).toBeInTheDocument();
+      expect(mockNavigate).toHaveBeenCalledWith({
+        to: "/stake",
+        search: { tab: "unstake" },
+      });
     });
   });
 
-  it("mobile EarnedCard shows tracking placeholder when State C has no PnL APY yet", async () => {
+  it("EarnedCard shows tracking placeholder when State C has no PnL yet", async () => {
     renderHome();
     await waitFor(() => {
       const elements = screen.getAllByText("Tracked once you stake");
@@ -826,18 +851,22 @@ describe("Home page — mobile State C: connected, has sPLUSD", () => {
     });
   });
 
-  it("mobile EarnedCard shows avg APY from PnL when available", async () => {
+  it("EarnedCard shows total PnL in dollars from the pnl API when available", async () => {
     mockPnlData.current = {
       total_unrealized_pnl: "42800000000000000000",
+      total_pnl: "123000000000000000000", // 123 PLUSD at 18 dp
       avg_apy: "0.0842",
     };
 
     renderHome();
 
     await waitFor(() => {
-      const elements = screen.getAllByText("8.42% p.a.");
+      // total_pnl rendered as a signed USD value (Earned card) — not a percent.
+      const elements = screen.getAllByText("+$123.00");
       expect(elements.length).toBeGreaterThanOrEqual(1);
     });
+    // The old APY label must no longer appear.
+    expect(screen.queryByText("8.42% p.a.")).not.toBeInTheDocument();
   });
 
   it("mobile portfolio chart summary shows sPLUSD balance in currency format and unrealized PnL below it", async () => {
@@ -872,10 +901,38 @@ describe("Home page — mobile State C: connected, has sPLUSD", () => {
   it("sPLUSD shares display is present in State C", async () => {
     renderHome();
     await waitFor(() => {
-      const sharesEl = screen.getByTestId("splusd-shares");
-      expect(sharesEl).toBeInTheDocument();
+      const sharesEls = screen.getAllByTestId("splusd-shares");
+      expect(sharesEls.length).toBeGreaterThanOrEqual(1);
       // 1000 sPLUSD shares at 18 decimals.
-      expect(sharesEl.textContent).toContain("1,000.00");
+      expect(sharesEls[0]?.textContent).toContain("1,000.00");
+    });
+  });
+
+  it("StakeCard staked sub-line shows the sPLUSD label, USD value and coin icon (State C)", async () => {
+    // The PLUSD-equivalent figure comes from convertToAssets, which is gated on
+    // a non-zero STAKED_PLUSD_ADDRESS — so in this EVM mock (zero-address) the
+    // numeric value is 0; the precise figure is asserted in the Stellar suite.
+    renderHome();
+    await waitFor(() => {
+      const subLine = screen.getAllByTestId("splusd-in-plusd")[0];
+      // "{X} sPLUSD · ${USD}" with the position's USD value appended
+      // (Figma node 1497:95226).
+      expect(subLine?.textContent).toContain("sPLUSD");
+      expect(subLine?.textContent).toMatch(/· \$[\d,]+\.\d{2}/);
+      // The sPLUSD coin icon precedes the figures.
+      expect(subLine?.querySelector("img")).toBeInTheDocument();
+    });
+  });
+
+  it("desktop StakeCard renders the staked state, not the marketing CTA (State C)", async () => {
+    renderHome();
+    await waitFor(() => {
+      // Both the mobile and desktop instances now show the staked layout, so
+      // there is no generic "Stake" CTA (home-stake-button) anywhere.
+      expect(screen.queryByTestId("home-stake-button")).not.toBeInTheDocument();
+      expect(
+        screen.getAllByTestId("home-stake-more-button").length,
+      ).toBeGreaterThanOrEqual(2);
     });
   });
 });
@@ -1132,6 +1189,15 @@ describe("Home page — Stellar connected balances (#688)", () => {
         name: "$100.00",
       });
       expect(headings.length).toBeGreaterThanOrEqual(1);
+    });
+
+    // Staked sub-line: 100 shares × 1.04 rate = 104.00 PLUSD-equivalent,
+    // labelled sPLUSD, with the position's USD value ($100.00) appended and the
+    // sPLUSD coin icon (Figma node 1497:95226).
+    await waitFor(() => {
+      const subLine = screen.getAllByTestId("splusd-in-plusd")[0];
+      expect(subLine?.textContent).toContain("104.00 sPLUSD · $100.00");
+      expect(subLine?.querySelector("img")).toBeInTheDocument();
     });
 
     // Mobile RecentActivityCard should be present (State C).

--- a/packages/frontend/src/routes/-stake.test.tsx
+++ b/packages/frontend/src/routes/-stake.test.tsx
@@ -128,6 +128,10 @@ vi.mock("@/wallet/config", () => ({
 
 // ── TanStack Router mock ──────────────────────────────────────────────────────
 
+// Mutable initial tab for tests — drives the injected useSearch so a test can
+// deep-link the Unstake tab (`/stake?tab=unstake`) without a router context.
+let mockTab: "stake" | "unstake" = "stake";
+
 vi.mock("@tanstack/react-router", async (importOriginal) => {
   const original =
     await importOriginal<typeof import("@tanstack/react-router")>();
@@ -135,9 +139,26 @@ vi.mock("@tanstack/react-router", async (importOriginal) => {
     ...original,
     useNavigate: vi.fn(() => vi.fn()),
     useRouterState: vi.fn(() => "/stake"),
-    createFileRoute: original.createFileRoute,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    createFileRoute: (path: any) => {
+      const realRoute = original.createFileRoute(path);
+      return (options: Record<string, unknown>) => {
+        const route = realRoute(options);
+        // Inject a controllable useSearch so the Stake component can read the
+        // initial `tab` without a router context.
+        (route as unknown as Record<string, unknown>).useSearch = () => ({
+          tab: mockTab,
+        });
+        return route;
+      };
+    },
     Link: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   };
+});
+
+// Every test starts on the Stake tab unless it explicitly deep-links Unstake.
+beforeEach(() => {
+  mockTab = "stake";
 });
 
 // ── ENV mock ──────────────────────────────────────────────────────────────────
@@ -685,6 +706,24 @@ describe("Stake page — Unstake tab", () => {
         screen.getByRole("textbox", { name: /sPLUSD amount/i }),
       ).toBeInTheDocument();
     });
+  });
+
+  it("deep-links the Unstake tab via ?tab=unstake (no click needed)", async () => {
+    // `/stake?tab=unstake` — the home StakeCard's "Unstake" link target.
+    mockTab = "unstake";
+    renderStake();
+
+    await waitFor(() => {
+      // Unstake tab is active on mount: input is the sPLUSD amount field.
+      expect(
+        screen.getByRole("textbox", { name: /sPLUSD amount/i }),
+      ).toBeInTheDocument();
+    });
+    // The Unstake tab is selected (aria-selected) without any interaction.
+    expect(screen.getByRole("tab", { name: "Unstake" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
   });
 
   it("switch to Unstake clears the amount input", async () => {

--- a/packages/frontend/src/routes/index.tsx
+++ b/packages/frontend/src/routes/index.tsx
@@ -31,7 +31,7 @@ import { StakeCard } from "@/components/StakeCard";
 import { EarnedCard } from "@/components/EarnedCard";
 import { RecentActivityCard } from "@/components/RecentActivityCard";
 import { QnaSection } from "@/components/QnaSection";
-import { usePnl, formatApy, useStatsPrices } from "@/api";
+import { usePnl, useStatsPrices } from "@/api";
 
 /**
  * Home page — full composition (Figma `1497:94556` desktop, `1989:8292` mobile).
@@ -243,11 +243,6 @@ function Home() {
     activeDecimals,
     { signed: true, suffix: "unrealized" },
   );
-  const avgApyFormatted = formatApy(pnl.data?.avg_apy);
-  const earnedApyLabel =
-    isConnected && avgApyFormatted !== "—"
-      ? `${avgApyFormatted} p.a.`
-      : undefined;
   const activeSplusdVaultAddress = isStellar
     ? ENV.STELLAR_STAKED_PLUSD_ID
     : ENV.STAKED_PLUSD_ADDRESS;
@@ -265,6 +260,16 @@ function Home() {
     ? deriveMobileHomeState(plusdBalanceActive, splusdSharesActive)
     : "empty";
 
+  // "Earned" shows the staked position's total PnL in dollars (realized +
+  // unrealized) once the user holds sPLUSD; otherwise the EarnedCard keeps its
+  // per-state placeholder ("Nothing yet" / "Tracked once you stake").
+  const earnedPnlLabel =
+    mobileHomeState === "splusd" && pnl.data?.total_pnl != null
+      ? formatRawDecimalUSD(pnl.data.total_pnl, activeDecimals, {
+          signed: true,
+        })
+      : undefined;
+
   // Disable Stake only when connected with zero or undefined PLUSD balance.
   // When disconnected the CTA stays enabled so the user can navigate to /stake.
   const stakeDisabled =
@@ -275,7 +280,9 @@ function Home() {
     navigate({ to: "/deposit", search: { direction: "deposit" } });
   const onSell = () =>
     navigate({ to: "/deposit", search: { direction: "withdraw" } });
-  const onStake = () => navigate({ to: "/stake" });
+  const onStake = () => navigate({ to: "/stake", search: { tab: "stake" } });
+  const onUnstake = () =>
+    navigate({ to: "/stake", search: { tab: "unstake" } });
 
   return (
     <div
@@ -351,7 +358,7 @@ function Home() {
               <EarnedCard
                 padding="sm"
                 mobileHomeState={isConnected ? mobileHomeState : undefined}
-                avgApyLabel={earnedApyLabel}
+                earnedPnlLabel={earnedPnlLabel}
                 data-testid="home-earned-card"
               />
             </div>
@@ -362,10 +369,12 @@ function Home() {
               padding="sm"
               style={{ width: 189, flexShrink: 0 }}
               onStake={onStake}
+              onUnstake={onUnstake}
               stakeDisabled={stakeDisabled}
               mobileHomeState={isConnected ? mobileHomeState : undefined}
               mobileSplusdShares={splusdSharesActive}
               mobileSplusdInPlusd={splusdInPlusdActive}
+              splusdUsdValue={splusdBalanceFormatted}
               splusdDecimals={activeDecimals}
               data-testid="home-stake-card"
             />
@@ -447,16 +456,30 @@ function Home() {
                 data-testid="home-start-here-card"
               />
               <EarnedCard
-                avgApyLabel={earnedApyLabel}
+                earnedPnlLabel={earnedPnlLabel}
                 data-testid="home-earned-card"
               />
             </div>
 
-            {/* Row 2, columns 3–4: Stake CTA card. */}
+            {/* Row 2, columns 3–4: Stake CTA card. Once the user holds sPLUSD
+                the card switches to the "Staked PLUSD" balance layout (Figma
+                node 1497:95217); otherwise it keeps the marketing CTA. The
+                empty/plusd button labels are mobile-specific, so the desktop
+                instance only opts into the `"splusd"` state. */}
             <StakeCard
               className="col-span-2 col-start-3 row-start-2"
               onStake={onStake}
+              onUnstake={onUnstake}
               stakeDisabled={stakeDisabled}
+              mobileHomeState={
+                isConnected && mobileHomeState === "splusd"
+                  ? "splusd"
+                  : undefined
+              }
+              mobileSplusdShares={splusdSharesActive}
+              mobileSplusdInPlusd={splusdInPlusdActive}
+              splusdUsdValue={splusdBalanceFormatted}
+              splusdDecimals={activeDecimals}
               data-testid="home-stake-card"
             />
 

--- a/packages/frontend/src/routes/stake.tsx
+++ b/packages/frontend/src/routes/stake.tsx
@@ -11,12 +11,12 @@ import {
   TokenAmountDisplay,
   TokenInput,
 } from "@pipeline/ui";
-import {
-  useWalletView,
-  useConnectModal,
-} from "@/wallet";
+import { useWalletView, useConnectModal } from "@/wallet";
 import { useToast } from "@/lib/toast";
 import { useStakeFlow } from "@/wallet/useStakeFlow";
+
+/** Active tab of the stake page; also the `?tab=` search-param value. */
+type StakeTab = "stake" | "unstake";
 
 /**
  * Stake route — chain-aware stake/unstake page.
@@ -70,8 +70,14 @@ function Stake() {
   // ── Connect modal ────────────────────────────────────────────────────
   const { open: openConnectModal } = useConnectModal();
 
+  // ── Initial tab from the URL ──────────────────────────────────────────
+  // `/stake?tab=unstake` deep-links the Unstake tab (e.g. the home StakeCard's
+  // "Unstake" link). The URL only seeds the initial tab; in-page switching is
+  // local state, so subsequent tab toggles do not push history entries.
+  const { tab: initialTab } = Route.useSearch();
+
   // ── Local state ───────────────────────────────────────────────────────
-  const [activeTab, setActiveTab] = useState<"stake" | "unstake">("stake");
+  const [activeTab, setActiveTab] = useState<StakeTab>(initialTab);
   const [amountInput, setAmountInput] = useState("");
 
   const isStakeTab = activeTab === "stake";
@@ -175,10 +181,7 @@ function Stake() {
         title: isStakeTab ? "Staked successfully" : "Unstaked successfully",
       });
     }
-    if (
-      flow.step2Tx.error &&
-      flow.step2Tx.error !== prevStep2Error.current
-    ) {
+    if (flow.step2Tx.error && flow.step2Tx.error !== prevStep2Error.current) {
       console.error(
         isStakeTab ? "Stake failed:" : "Unstake failed:",
         flow.step2Tx.error,
@@ -201,13 +204,10 @@ function Stake() {
   ]);
 
   // ── Tab-switch handler ─────────────────────────────────────────────────
-  const onSelectTab = useCallback(
-    (next: string) => {
-      setActiveTab(next as "stake" | "unstake");
-      setAmountInput("");
-    },
-    [],
-  );
+  const onSelectTab = useCallback((next: string) => {
+    setActiveTab(next as StakeTab);
+    setAmountInput("");
+  }, []);
 
   // ── Render ────────────────────────────────────────────────────────────
   return (
@@ -250,9 +250,7 @@ function Stake() {
               token={isStakeTab ? "plusd" : "splusd"}
               tokenLabel={isStakeTab ? "PLUSD" : "sPLUSD"}
               balanceLabel={
-                flow.formattedInputBalance
-                  ? flow.formattedInputBalance
-                  : "—"
+                flow.formattedInputBalance ? flow.formattedInputBalance : "—"
               }
               placeholderValue="0"
               value={amountInput}
@@ -278,9 +276,7 @@ function Stake() {
               token={isStakeTab ? "splusd" : "plusd"}
               tokenLabel={isStakeTab ? "sPLUSD" : "PLUSD"}
               balanceLabel={
-                flow.formattedOutputBalance
-                  ? flow.formattedOutputBalance
-                  : "—"
+                flow.formattedOutputBalance ? flow.formattedOutputBalance : "—"
               }
               value={flow.previewOutputValue}
               style={{
@@ -321,7 +317,9 @@ function Stake() {
           </Card>
         ) : (
           <StepsCard
-            data-testid={isStakeTab ? "stake-steps-card" : "stake-unstake-steps"}
+            data-testid={
+              isStakeTab ? "stake-steps-card" : "stake-unstake-steps"
+            }
             steps={flow.steps}
           />
         )}
@@ -331,5 +329,8 @@ function Stake() {
 }
 
 export const Route = createFileRoute("/stake")({
+  validateSearch: (raw): { tab: StakeTab } => ({
+    tab: raw?.tab === "unstake" ? "unstake" : "stake",
+  }),
   component: Stake,
 });


### PR DESCRIPTION
## What

Three related improvements to the home dashboard's stake/earned cards.

### 1. Staked state on the desktop stake card
The "Staked PLUSD" balance layout already existed but only rendered on mobile — the desktop dashboard `StakeCard` never received the state props, so a staked user kept seeing the generic "Stake PLUSD" CTA. It now shows on desktop too (Figma node 1497:95217), gated to the `splusd` state so the empty/plusd marketing CTA is unchanged.

Card content now matches the Figma:
- sPLUSD coin icon + USD value appended to the sub-line (`{X} sPLUSD · $Y`)
- "Stake More" CTA label on two lines
- "Unstake" link moved to the bottom-left (Body Emphasized)

### 2. Stake page `?tab=` deep-link
- `/stake` gains a `?tab=stake|unstake` search param (`validateSearch`, defaults to `stake`). The page seeds its initial tab from the URL; in-page switching stays local state.
- The home card's "Unstake" link now deep-links `/stake?tab=unstake` via a new `onUnstake` handler.

### 3. Earned card shows total PnL in dollars
`home-earned-card` now shows the staked position's **total PnL in dollars** (`total_pnl` from `GET /v1/pnl`, signed e.g. `+$123.00`) instead of the APY percentage. Gated to a staked position so non-stakers keep "Nothing yet" and a fresh staker keeps "Tracked once you stake".

## Verification

- Frontend tests: stake + index + related suites pass; full suite 1110 pass.
- `tsc -b`, eslint, prettier clean on all changed files.
- Pre-existing unrelated failure (`PortfolioPlaceholderCard` chart-tooltip) confirmed failing on clean `main`, untouched here.