### PR TITLE
Fix: Stellar deposit input permanently disabled by stale in-flight record

### DIFF
--- a/packages/frontend/src/wallet/useDepositFlow.ts
+++ b/packages/frontend/src/wallet/useDepositFlow.ts
@@ -31,7 +31,7 @@
  *   of direction. On EVM, `trustlines` is always empty.
  */
 
-import { useCallback } from "react";
+import { useCallback, useEffect } from "react";
 import {
   useWalletView,
   // EVM
@@ -61,6 +61,8 @@ import {
   useStellarChangeTrustUsdc,
   readInflightDeposit,
   readInflightWithdrawal,
+  clearInflightDeposit,
+  clearInflightWithdrawal,
   useStellarNetworkFeeEstimate,
 } from "@/wallet";
 import {
@@ -511,14 +513,55 @@ export function useDepositFlow(
     stellarWithdrawRequestIdBigInt,
   );
 
+  // ── Reconcile stale in-flight records against on-chain claimed state ───────
+  // The in-flight localStorage record is written when `request_deposit` succeeds
+  // and is otherwise only cleared by a successful claim through this app/browser.
+  // If the request was claimed any other way (different device, the API-driven
+  // `Completed` reset, etc.), the record lingers and pins the form as "confirmed"
+  // forever — disabling the amount input with no escape hatch. When the on-chain
+  // request reads back as already claimed, drop the record so a fresh
+  // deposit/withdrawal can start. (A claimed request is terminal, so this never
+  // races with a genuinely in-flight one.)
+  const stellarDepositClaimedOnChain =
+    stellarDepositOnChainReq.request?.claimed === true;
+  const stellarWithdrawClaimedOnChain =
+    stellarWithdrawOnChainReq.request?.claimed === true;
+
+  const stellarDepositInflightActive =
+    stellarDepositInflight !== undefined && !stellarDepositClaimedOnChain;
+  const stellarWithdrawInflightActive =
+    stellarWithdrawInflight !== undefined && !stellarWithdrawClaimedOnChain;
+
+  // Housekeeping: physically remove the dead localStorage key. The UI already
+  // ignores it this render via `*InflightActive`, so correctness does not depend
+  // on this effect firing — it just stops the key from lingering.
+  useEffect(() => {
+    if (
+      stellarAddress &&
+      stellarDepositInflight !== undefined &&
+      stellarDepositClaimedOnChain
+    ) {
+      clearInflightDeposit(stellarAddress);
+    }
+  }, [stellarAddress, stellarDepositInflight, stellarDepositClaimedOnChain]);
+  useEffect(() => {
+    if (
+      stellarAddress &&
+      stellarWithdrawInflight !== undefined &&
+      stellarWithdrawClaimedOnChain
+    ) {
+      clearInflightWithdrawal(stellarAddress);
+    }
+  }, [stellarAddress, stellarWithdrawInflight, stellarWithdrawClaimedOnChain]);
+
   const stellarDepositRequestIsConfirmed =
     stellarDepositActiveRequest !== null ||
     stellarRequestDeposit.isSuccess ||
-    stellarDepositInflight !== undefined;
+    stellarDepositInflightActive;
   const stellarWithdrawRequestIsConfirmed =
     stellarWithdrawActiveRequest !== null ||
     stellarRequestWithdrawal.isSuccess ||
-    stellarWithdrawInflight !== undefined;
+    stellarWithdrawInflightActive;
 
   const stellarDepositIsPendingClaim =
     stellarDepositActiveRequest?.status === "PendingClaim" ||


### PR DESCRIPTION
## Problem

On `/deposit` (Stellar), some accounts that already hold USDC + PLUSD and have trustlines find the amount input **permanently disabled** — no way to start a new deposit.

Repro account: `GCAZ3UTYTGBNU2LWLLMJGWFH37CL4AXLF6JDUJQJFFHXMBVTGQRN4SIC` (futurenet).

## Root cause

The input is disabled when `!isConnected || !isReady || isAmountLocked`. The account is connected with a USDC balance, so the lock is `isAmountLocked`, which for Stellar is `stellarDepositRequestIsConfirmed`:

```
stellarDepositActiveRequest !== null
  || stellarRequestDeposit.isSuccess
  || stellarDepositInflight !== undefined   ← the culprit
```

`stellarDepositInflight` is a **localStorage** record (`pipeline.stellar.deposit.inflight.<G…>`) written when `request_deposit` succeeds and **only ever cleared by a successful claim through this app/browser** (`useStellarDepositManager.ts`). There was no reconciliation against on-chain state, so if the prior deposit was claimed any other way — different device, the API-driven `Completed` reset (which clears the input but not localStorage), or a futurenet contract redeploy — the record lingered and pinned the flow as confirmed forever. The page even reads the on-chain `claimed` flag but never used it to clear the record.

Since the account already holds PLUSD (i.e. it deposited+claimed before), a leftover record locks it out.

## Fix

Reconcile the in-flight record against on-chain claimed state in `useDepositFlow`:

- Derive `stellarDepositInflightActive` / `stellarWithdrawInflightActive` = `inflight !== undefined && !claimedOnChain`, and use those in `*RequestIsConfirmed`. The form unlocks the same render the on-chain read returns `claimed`.
- An effect clears the dead localStorage key for housekeeping (correctness does not depend on it firing).

A claimed request is terminal, so this never races with a genuinely in-flight one. Applied symmetrically to deposit and withdraw.

## Workaround (pre-fix)

`localStorage.removeItem("pipeline.stellar.deposit.inflight.<address>")` + reload.

## Testing

- `tsc -b`, `eslint`, `prettier` clean.
- Existing suites pass: `useStellarDepositManager`, `-deposit`, `useStakeFlow` (126 tests).
- No dedicated `useDepositFlow` hook test exists and a full one would require mocking ~25 wallet/API hooks; per the frontend flow (no testing phase) this fix relies on the verification above. The reconciliation is a small, isolated derivation.